### PR TITLE
fix: support non-Ethernet pcap link types (#14)

### DIFF
--- a/docs/superpowers/plans/2026-04-06-multi-linktype.md
+++ b/docs/superpowers/plans/2026-04-06-multi-linktype.md
@@ -1,0 +1,640 @@
+# Multi-Link-Type Support Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Support Raw IP (101) and Linux Cooked SLL (113) pcap link types in addition to Ethernet, with clear errors for unsupported types.
+
+**Architecture:** Read link type from pcap global header, dispatch to the correct etherparse parser (`from_ethernet`, `from_ip`, `from_linux_sll`), and surface decode errors to the user instead of silently dropping packets.
+
+**Tech Stack:** etherparse 0.16 (`SlicedPacket::from_ip`, `from_linux_sll`), pcap-file 2.0 (`DataLink` enum, `PcapReader::header().datalink`)
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|---------------|
+| `src/reader.rs` | Modify | Store `DataLink` from pcap header, reject unsupported types |
+| `src/decoder.rs` | Modify | Accept `DataLink` param, dispatch to correct parser |
+| `src/main.rs` | Modify | Pass `datalink` through, count and surface decode errors |
+| `src/summary.rs` | Modify | Add `skipped_packets` field |
+| `src/reporter/terminal.rs` | Modify | Show skipped packets in output |
+| `src/reporter/json.rs` | Modify | Include skipped packets in JSON |
+| `tests/reader_tests.rs` | Modify | Add unsupported link type test, verify datalink field |
+| `tests/decoder_tests.rs` | Modify | Update existing tests with `DataLink::ETHERNET`, add Raw IP test |
+| `tests/integration_test.rs` | Modify | Update `decode_packet` call to pass datalink |
+| `tests/linktype_integration_tests.rs` | Create | Integration tests with real pcap fixtures |
+
+---
+
+### Task 1: Reader — Store DataLink and Reject Unsupported Types
+
+**Files:**
+- Modify: `src/reader.rs`
+- Test: `tests/reader_tests.rs`
+
+- [ ] **Step 1: Write failing test for unsupported link type**
+
+Add this test to `tests/reader_tests.rs`:
+
+```rust
+#[test]
+fn test_unsupported_link_type_rejected() {
+    let mut buf = Vec::new();
+    // Global header with link type 105 (IEEE802_11)
+    buf.extend_from_slice(&0xa1b2c3d4u32.to_le_bytes()); // magic
+    buf.extend_from_slice(&2u16.to_le_bytes()); // version major
+    buf.extend_from_slice(&4u16.to_le_bytes()); // version minor
+    buf.extend_from_slice(&0i32.to_le_bytes()); // thiszone
+    buf.extend_from_slice(&0u32.to_le_bytes()); // sigfigs
+    buf.extend_from_slice(&65535u32.to_le_bytes()); // snaplen
+    buf.extend_from_slice(&105u32.to_le_bytes()); // network: IEEE802_11 (unsupported)
+
+    let cursor = Cursor::new(buf);
+    let result = PcapSource::from_pcap_reader(cursor);
+    assert!(result.is_err());
+    let err_msg = result.unwrap_err().to_string();
+    assert!(
+        err_msg.contains("Unsupported"),
+        "Error should mention 'Unsupported', got: {err_msg}"
+    );
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test --test reader_tests test_unsupported_link_type_rejected`
+Expected: FAIL — `PcapSource::from_pcap_reader` currently succeeds for any link type.
+
+- [ ] **Step 3: Write failing test for datalink field on PcapSource**
+
+Add this test to `tests/reader_tests.rs`:
+
+```rust
+use pcap_file::DataLink;
+
+#[test]
+fn test_pcap_source_stores_datalink() {
+    let data = minimal_pcap_bytes(); // Uses network=1 (Ethernet)
+    let cursor = Cursor::new(data);
+    let source = PcapSource::from_pcap_reader(cursor).unwrap();
+    assert_eq!(source.datalink, DataLink::ETHERNET);
+}
+```
+
+- [ ] **Step 4: Run test to verify it fails**
+
+Run: `cargo test --test reader_tests test_pcap_source_stores_datalink`
+Expected: FAIL — `PcapSource` has no `datalink` field.
+
+- [ ] **Step 5: Implement reader changes**
+
+In `src/reader.rs`, add the `DataLink` import and modify `PcapSource`:
+
+```rust
+use std::io::Read;
+
+use anyhow::{Context, Result, anyhow};
+use pcap_file::DataLink;
+use pcap_file::pcap::PcapReader;
+
+#[derive(Debug, Clone)]
+pub struct RawPacket {
+    pub timestamp_secs: u32,
+    pub timestamp_usecs: u32,
+    pub data: Vec<u8>,
+}
+
+#[derive(Debug)]
+pub struct PcapSource {
+    pub packets: Vec<RawPacket>,
+    pub datalink: DataLink,
+}
+
+impl PcapSource {
+    pub fn from_pcap_reader<R: Read>(reader: R) -> Result<Self> {
+        let mut pcap_reader = PcapReader::new(reader).context("Failed to parse pcap header")?;
+
+        let datalink = pcap_reader.header().datalink;
+        match datalink {
+            DataLink::ETHERNET | DataLink::RAW | DataLink::LINUX_SLL => {}
+            other => {
+                return Err(anyhow!(
+                    "Unsupported pcap link type: {other:?}. Supported: Ethernet (1), Raw IP (101), Linux Cooked (113)"
+                ));
+            }
+        }
+
+        let mut packets = Vec::new();
+
+        while let Some(raw_packet) = pcap_reader.next_packet() {
+            let raw_packet = raw_packet.context("Failed to read packet")?;
+            packets.push(RawPacket {
+                timestamp_secs: raw_packet.timestamp.as_secs() as u32,
+                timestamp_usecs: raw_packet.timestamp.subsec_micros(),
+                data: raw_packet.data.into_owned(),
+            });
+        }
+
+        Ok(PcapSource { packets, datalink })
+    }
+
+    pub fn from_file(path: &std::path::Path) -> Result<Self> {
+        let file = std::fs::File::open(path)
+            .with_context(|| format!("Failed to open {}", path.display()))?;
+        let reader = std::io::BufReader::new(file);
+        Self::from_pcap_reader(reader)
+    }
+}
+```
+
+- [ ] **Step 6: Run both new tests to verify they pass**
+
+Run: `cargo test --test reader_tests`
+Expected: All 4 tests pass (2 existing + 2 new).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/reader.rs tests/reader_tests.rs
+git commit -m "feat: store DataLink from pcap header, reject unsupported link types"
+```
+
+---
+
+### Task 2: Decoder — Multi-Link-Type Dispatch
+
+**Files:**
+- Modify: `src/decoder.rs`
+- Modify: `tests/decoder_tests.rs`
+
+- [ ] **Step 1: Write failing test for Raw IP decode**
+
+Add this test to `tests/decoder_tests.rs`:
+
+```rust
+use pcap_file::DataLink;
+
+fn make_raw_ip_tcp_packet() -> Vec<u8> {
+    vec![
+        // IPv4 header (20 bytes) — no Ethernet header
+        0x45, 0x00, 0x00, 0x28, // version/IHL, DSCP, total length=40
+        0x00, 0x01, 0x00, 0x00, // identification, flags/fragment
+        0x40, 0x06, 0x00, 0x00, // TTL=64, protocol=TCP, checksum
+        0xc0, 0xa8, 0x01, 0x0a, // src: 192.168.1.10
+        0xc0, 0xa8, 0x01, 0x01, // dst: 192.168.1.1
+        // TCP header (20 bytes)
+        0xc0, 0x01, 0x00, 0x50, // src port 49153, dst port 80
+        0x00, 0x00, 0x00, 0x01, // seq number
+        0x00, 0x00, 0x00, 0x00, // ack number
+        0x50, 0x02, 0xff, 0xff, // data offset=5, SYN, window
+        0x00, 0x00, 0x00, 0x00, // checksum, urgent pointer
+    ]
+}
+
+#[test]
+fn test_decode_raw_ip_tcp_packet() {
+    let data = make_raw_ip_tcp_packet();
+    let parsed = decode_packet(&data, DataLink::RAW).unwrap();
+
+    assert_eq!(parsed.src_ip, IpAddr::V4(Ipv4Addr::new(192, 168, 1, 10)));
+    assert_eq!(parsed.dst_ip, IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1)));
+    assert_eq!(parsed.protocol, Protocol::Tcp);
+    match parsed.transport {
+        TransportInfo::Tcp {
+            src_port, dst_port, ..
+        } => {
+            assert_eq!(src_port, 49153);
+            assert_eq!(dst_port, 80);
+        }
+        _ => panic!("Expected TCP"),
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test --test decoder_tests test_decode_raw_ip_tcp_packet`
+Expected: FAIL — `decode_packet` doesn't accept a `DataLink` parameter.
+
+- [ ] **Step 3: Implement decoder changes**
+
+In `src/decoder.rs`, add the `DataLink` import and modify `decode_packet`:
+
+```rust
+use std::net::IpAddr;
+
+use anyhow::{Result, anyhow};
+use etherparse::SlicedPacket;
+use pcap_file::DataLink;
+use serde::Serialize;
+
+// ... (Protocol, TransportInfo, ParsedPacket, app_protocol_hint unchanged) ...
+
+pub fn decode_packet(data: &[u8], datalink: DataLink) -> Result<ParsedPacket> {
+    let sliced = match datalink {
+        DataLink::ETHERNET => SlicedPacket::from_ethernet(data),
+        DataLink::RAW => SlicedPacket::from_ip(data),
+        DataLink::LINUX_SLL => SlicedPacket::from_linux_sll(data),
+        other => return Err(anyhow!("Unsupported link type: {other:?}")),
+    }
+    .map_err(|e| anyhow!("Parse error: {e}"))?;
+
+    // ... (rest of function unchanged — net/transport/payload extraction) ...
+```
+
+Only the first two lines of the function body change. Everything from `let (src_ip, dst_ip, ip_protocol) = match &sliced.net {` onward stays exactly the same.
+
+- [ ] **Step 4: Update existing decoder tests to pass DataLink::ETHERNET**
+
+In `tests/decoder_tests.rs`, add the import and update the three existing tests:
+
+Add at the top (if not already there):
+```rust
+use pcap_file::DataLink;
+```
+
+Update `test_decode_tcp_packet`:
+```rust
+let parsed = decode_packet(&data, DataLink::ETHERNET).unwrap();
+```
+
+Update `test_decode_udp_dns_packet`:
+```rust
+let parsed = decode_packet(&data, DataLink::ETHERNET).unwrap();
+```
+
+Update `test_decode_invalid_packet`:
+```rust
+assert!(decode_packet(&garbage, DataLink::ETHERNET).is_err());
+```
+
+- [ ] **Step 5: Run all decoder tests to verify they pass**
+
+Run: `cargo test --test decoder_tests`
+Expected: All 4 tests pass (3 existing updated + 1 new).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/decoder.rs tests/decoder_tests.rs
+git commit -m "feat: decode_packet dispatches by link type (Ethernet, Raw IP, Linux SLL)"
+```
+
+---
+
+### Task 3: Wire Up Callers — main.rs and Integration Test
+
+**Files:**
+- Modify: `src/main.rs`
+- Modify: `tests/integration_test.rs`
+
+- [ ] **Step 1: Update main.rs to pass datalink to decode_packet**
+
+In `src/main.rs`, in the `run_analyze` function, change the decode call at line 83 from:
+
+```rust
+if let Ok(parsed) = decode_packet(&raw.data) {
+```
+
+to:
+
+```rust
+if let Ok(parsed) = decode_packet(&raw.data, source.datalink) {
+```
+
+Make the same change in `run_summary` at line 133, from:
+
+```rust
+if let Ok(parsed) = decode_packet(&raw.data) {
+```
+
+to:
+
+```rust
+if let Ok(parsed) = decode_packet(&raw.data, source.datalink) {
+```
+
+- [ ] **Step 2: Update integration_test.rs**
+
+In `tests/integration_test.rs`, add the import:
+
+```rust
+use pcap_file::DataLink;
+```
+
+Change line 51 from:
+
+```rust
+if let Ok(parsed) = decode_packet(&raw.data) {
+```
+
+to:
+
+```rust
+if let Ok(parsed) = decode_packet(&raw.data, DataLink::ETHERNET) {
+```
+
+The integration test constructs an Ethernet pcap, so `DataLink::ETHERNET` is correct.
+
+- [ ] **Step 3: Verify everything compiles and all tests pass**
+
+Run: `cargo test`
+Expected: All tests pass. The project now compiles with the new API.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/main.rs tests/integration_test.rs
+git commit -m "fix: pass DataLink to decode_packet in main pipeline and integration test"
+```
+
+---
+
+### Task 4: Error Surfacing — Decode Error Counting
+
+**Files:**
+- Modify: `src/summary.rs`
+- Modify: `src/reporter/terminal.rs`
+- Modify: `src/reporter/json.rs`
+- Modify: `src/main.rs`
+
+- [ ] **Step 1: Add skipped_packets field to Summary**
+
+In `src/summary.rs`, add a `skipped_packets` field and a method to report it:
+
+Add the field to the `Summary` struct:
+
+```rust
+#[derive(Debug, Serialize)]
+pub struct Summary {
+    pub total_packets: u64,
+    pub total_bytes: u64,
+    pub skipped_packets: u64,
+    hosts: HashSet<IpAddr>,
+    protocols: HashMap<Protocol, u64>,
+    services: HashMap<String, u64>,
+}
+```
+
+Update `Summary::new()` to initialize it:
+
+```rust
+pub fn new() -> Self {
+    Summary {
+        total_packets: 0,
+        total_bytes: 0,
+        skipped_packets: 0,
+        hosts: HashSet::new(),
+        protocols: HashMap::new(),
+        services: HashMap::new(),
+    }
+}
+```
+
+- [ ] **Step 2: Update terminal reporter to show skipped packets**
+
+In `src/reporter/terminal.rs`, update the header section (around line 23) to show skipped packets when non-zero. Change:
+
+```rust
+out.push_str(&format!(
+    "  Packets: {}  Bytes: {}  Hosts: {}\n\n",
+    summary.total_packets,
+    summary.total_bytes,
+    summary.unique_hosts().len(),
+));
+```
+
+to:
+
+```rust
+out.push_str(&format!(
+    "  Packets: {}  Bytes: {}  Hosts: {}\n",
+    summary.total_packets,
+    summary.total_bytes,
+    summary.unique_hosts().len(),
+));
+if summary.skipped_packets > 0 {
+    let warning = format!("  Skipped: {} packets (decode errors)\n", summary.skipped_packets);
+    if self.use_color {
+        out.push_str(&warning.yellow().to_string());
+    } else {
+        out.push_str(&warning);
+    }
+}
+out.push('\n');
+```
+
+- [ ] **Step 3: Update JSON reporter to include skipped_packets**
+
+In `src/reporter/json.rs`, add `skipped_packets` to the JSON output. Change the summary object in `render()`:
+
+```rust
+let output = json!({
+    "summary": {
+        "total_packets": summary.total_packets,
+        "total_bytes": summary.total_bytes,
+        "skipped_packets": summary.skipped_packets,
+        "unique_hosts": summary.unique_hosts(),
+        "protocols": protocols,
+        "services": summary.service_counts(),
+    },
+    "findings": findings,
+    "analyzers": analyzer_summaries,
+});
+```
+
+- [ ] **Step 4: Add decode error counting and stderr warning to main.rs**
+
+In `src/main.rs`, update `run_analyze` to count errors and warn. Replace the packet processing loop (around line 82-96):
+
+```rust
+let mut decode_errors: u64 = 0;
+
+for raw in &source.packets {
+    match decode_packet(&raw.data, source.datalink) {
+        Ok(parsed) => {
+            summary.ingest(&parsed);
+            if enable_dns && dns_analyzer.can_decode(&parsed) {
+                let findings = dns_analyzer.analyze(&parsed);
+                all_findings.extend(findings);
+            }
+            if let Some(ref mut reasm) = reassembler {
+                reasm.process_packet(&parsed, raw.timestamp_secs, &mut stream_handler);
+            }
+        }
+        Err(e) => {
+            if decode_errors == 0 {
+                eprintln!(
+                    "Warning: failed to decode packet ({e}). Further errors counted silently."
+                );
+            }
+            decode_errors += 1;
+        }
+    }
+    pb.inc(1);
+}
+```
+
+After the file loop closes (before the reporter section), add the skipped count to summary:
+
+```rust
+summary.skipped_packets += decode_errors;
+```
+
+Wait — `decode_errors` is per-file inside the loop. We need to accumulate across files. Move the counter outside the file loop. The structure is:
+
+In `run_analyze`, before `for target in targets {`:
+```rust
+let mut total_decode_errors: u64 = 0;
+```
+
+Inside the per-file packet loop, replace `decode_errors` with `total_decode_errors`.
+
+After the `for target in targets` loop closes (around line 97), add:
+```rust
+summary.skipped_packets = total_decode_errors;
+```
+
+Apply the same pattern to `run_summary`. Replace the packet loop (around line 132-134):
+
+```rust
+let mut total_decode_errors: u64 = 0;
+
+for target in targets {
+    let pcap_files = resolve_targets(target)?;
+    for path in &pcap_files {
+        let source = PcapSource::from_file(path)?;
+        for raw in &source.packets {
+            match decode_packet(&raw.data, source.datalink) {
+                Ok(parsed) => {
+                    summary.ingest(&parsed);
+                }
+                Err(e) => {
+                    if total_decode_errors == 0 {
+                        eprintln!(
+                            "Warning: failed to decode packet ({e}). Further errors counted silently."
+                        );
+                    }
+                    total_decode_errors += 1;
+                }
+            }
+        }
+    }
+}
+summary.skipped_packets = total_decode_errors;
+```
+
+- [ ] **Step 5: Run all tests to verify nothing broke**
+
+Run: `cargo test`
+Expected: All tests pass. The `skipped_packets` field defaults to 0, so existing tests are unaffected.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/summary.rs src/reporter/terminal.rs src/reporter/json.rs src/main.rs
+git commit -m "feat: count and surface decode errors instead of silently dropping packets"
+```
+
+---
+
+### Task 5: Integration Tests with Real Pcap Fixtures
+
+**Files:**
+- Create: `tests/linktype_integration_tests.rs`
+
+- [ ] **Step 1: Write integration tests for all three link types**
+
+Create `tests/linktype_integration_tests.rs`:
+
+```rust
+use pcap_file::DataLink;
+use wirerust::decoder::decode_packet;
+use wirerust::reader::PcapSource;
+
+#[test]
+fn test_ethernet_pcap_tls() {
+    let source = PcapSource::from_file(std::path::Path::new("tests/fixtures/tls.pcap")).unwrap();
+    assert_eq!(source.datalink, DataLink::ETHERNET);
+    assert!(
+        source.packets.len() > 0,
+        "tls.pcap should have packets, got 0"
+    );
+
+    let mut decoded_count = 0;
+    for raw in &source.packets {
+        if decode_packet(&raw.data, source.datalink).is_ok() {
+            decoded_count += 1;
+        }
+    }
+    assert!(
+        decoded_count > 0,
+        "Should decode at least some packets from tls.pcap, got 0"
+    );
+}
+
+#[test]
+fn test_raw_ip_pcap_segmented() {
+    let source =
+        PcapSource::from_file(std::path::Path::new("tests/fixtures/segmented.pcap")).unwrap();
+    assert_eq!(source.datalink, DataLink::RAW);
+    assert!(
+        source.packets.len() > 0,
+        "segmented.pcap should have packets, got 0"
+    );
+
+    let mut decoded_count = 0;
+    for raw in &source.packets {
+        if decode_packet(&raw.data, source.datalink).is_ok() {
+            decoded_count += 1;
+        }
+    }
+    assert!(
+        decoded_count > 0,
+        "Should decode at least some packets from segmented.pcap, got 0"
+    );
+}
+
+#[test]
+fn test_linux_cooked_pcap_http_ooo() {
+    let source =
+        PcapSource::from_file(std::path::Path::new("tests/fixtures/http-ooo.pcap")).unwrap();
+    assert_eq!(source.datalink, DataLink::LINUX_SLL);
+    assert!(
+        source.packets.len() > 0,
+        "http-ooo.pcap should have packets, got 0"
+    );
+
+    let mut decoded_count = 0;
+    for raw in &source.packets {
+        if decode_packet(&raw.data, source.datalink).is_ok() {
+            decoded_count += 1;
+        }
+    }
+    assert!(
+        decoded_count > 0,
+        "Should decode at least some packets from http-ooo.pcap, got 0"
+    );
+}
+```
+
+- [ ] **Step 2: Run the integration tests**
+
+Run: `cargo test --test linktype_integration_tests`
+Expected: All 3 tests pass — each fixture loads, has packets, and decodes successfully.
+
+- [ ] **Step 3: Run the full test suite**
+
+Run: `cargo test`
+Expected: All tests pass (existing + new).
+
+Run: `cargo clippy -- -D warnings`
+Expected: Clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/linktype_integration_tests.rs
+git commit -m "test: integration tests for Ethernet, Raw IP, and Linux Cooked pcap fixtures"
+```

--- a/docs/superpowers/plans/2026-04-06-multi-linktype.md
+++ b/docs/superpowers/plans/2026-04-06-multi-linktype.md
@@ -2,7 +2,7 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Support Raw IP (101) and Linux Cooked SLL (113) pcap link types in addition to Ethernet, with clear errors for unsupported types.
+**Goal:** Support Raw IP (101), IPv4 (228), IPv6 (229), and Linux Cooked SLL (113) pcap link types in addition to Ethernet, with clear errors for unsupported types.
 
 **Architecture:** Read link type from pcap global header, dispatch to the correct etherparse parser (`from_ethernet`, `from_ip`, `from_linux_sll`), and surface decode errors to the user instead of silently dropping packets.
 
@@ -117,10 +117,14 @@ impl PcapSource {
 
         let datalink = pcap_reader.header().datalink;
         match datalink {
-            DataLink::ETHERNET | DataLink::RAW | DataLink::LINUX_SLL => {}
+            DataLink::ETHERNET
+            | DataLink::RAW
+            | DataLink::IPV4
+            | DataLink::IPV6
+            | DataLink::LINUX_SLL => {}
             other => {
                 return Err(anyhow!(
-                    "Unsupported pcap link type: {other:?}. Supported: Ethernet (1), Raw IP (101), Linux Cooked (113)"
+                    "Unsupported pcap link type: {other:?}. Supported: Ethernet (1), Raw IP (101), Linux Cooked (113), IPv4 (228), IPv6 (229)"
                 ));
             }
         }
@@ -234,7 +238,7 @@ use serde::Serialize;
 pub fn decode_packet(data: &[u8], datalink: DataLink) -> Result<ParsedPacket> {
     let sliced = match datalink {
         DataLink::ETHERNET => SlicedPacket::from_ethernet(data),
-        DataLink::RAW => SlicedPacket::from_ip(data),
+        DataLink::RAW | DataLink::IPV4 | DataLink::IPV6 => SlicedPacket::from_ip(data),
         DataLink::LINUX_SLL => SlicedPacket::from_linux_sll(data),
         other => return Err(anyhow!("Unsupported link type: {other:?}")),
     }
@@ -544,7 +548,7 @@ git commit -m "feat: count and surface decode errors instead of silently droppin
 **Files:**
 - Create: `tests/linktype_integration_tests.rs`
 
-- [ ] **Step 1: Write integration tests for all three link types**
+- [ ] **Step 1: Write integration tests for all three fixture link types**
 
 Create `tests/linktype_integration_tests.rs`:
 
@@ -597,10 +601,10 @@ fn test_raw_ip_pcap_segmented() {
 }
 
 #[test]
-fn test_linux_cooked_pcap_http_ooo() {
+fn test_ipv4_pcap_http_ooo() {
     let source =
         PcapSource::from_file(std::path::Path::new("tests/fixtures/http-ooo.pcap")).unwrap();
-    assert_eq!(source.datalink, DataLink::LINUX_SLL);
+    assert_eq!(source.datalink, DataLink::IPV4);
     assert!(
         source.packets.len() > 0,
         "http-ooo.pcap should have packets, got 0"
@@ -636,5 +640,5 @@ Expected: Clean.
 
 ```bash
 git add tests/linktype_integration_tests.rs
-git commit -m "test: integration tests for Ethernet, Raw IP, and Linux Cooked pcap fixtures"
+git commit -m "test: integration tests for Ethernet, Raw IP, and IPv4 pcap fixtures"
 ```

--- a/docs/superpowers/specs/2026-04-06-multi-linktype-design.md
+++ b/docs/superpowers/specs/2026-04-06-multi-linktype-design.md
@@ -43,15 +43,15 @@ This is a fail-fast design: unsupported formats error at file open, not silently
 - `DataLink::LINUX_SLL` → `SlicedPacket::from_linux_sll(data)`
 - `_` → error (defense-in-depth; reader already rejects unsupported types)
 
-Everything after `SlicedPacket` construction is unchanged. The `net`, `transport`, and `payload` fields on `SlicedPacket` are identical in structure regardless of which `from_*()` method was used. Only the `link` field differs (populated for Ethernet/SLL, empty for Raw IP), and wirerust does not access it.
+Everything after `SlicedPacket` construction is unchanged. The `net` and `transport` fields on `SlicedPacket` are identical in structure regardless of which `from_*()` method was used (payload is accessed via transport slice methods like `tcp.payload()`). Only the `link` field differs (populated for Ethernet/SLL, empty for Raw IP), and wirerust does not access it.
 
 ### Error Surfacing (`src/main.rs`)
 
-The processing loops in `run_analyze()` and `run_summary()` gain a `decode_errors: u32` counter. On first decode failure, a warning is printed to stderr (not stdout, to keep piped output clean):
+The processing loops in `run_analyze()` and `run_summary()` gain a `total_decode_errors: u64` counter. On first decode failure, a warning is printed to stderr (not stdout, to keep piped output clean):
 
-`"Warning: failed to decode packet (link type: {datalink:?}). Further errors will be counted silently."`
+`"Warning: failed to decode packet ({e}). Further errors counted silently."`
 
-After the loop, if `decode_errors > 0`, the count is included in summary output so the user knows data was lost.
+After the loop, `summary.skipped_packets = total_decode_errors` surfaces the count to reporters.
 
 ## Data Flow
 
@@ -66,7 +66,8 @@ Processing loop:
     decode_packet(&raw.data, source.datalink)  // dispatches by link type
       → SlicedPacket::from_ethernet/from_ip/from_linux_sll
       → extract net/transport/payload (unchanged)
-    on Err: increment decode_errors, warn on first
+    on Err: increment total_decode_errors, warn on first
+  summary.skipped_packets = total_decode_errors
 ```
 
 ## Testing

--- a/docs/superpowers/specs/2026-04-06-multi-linktype-design.md
+++ b/docs/superpowers/specs/2026-04-06-multi-linktype-design.md
@@ -61,12 +61,14 @@ PcapSource::from_file(path)
   → header().datalink → validate supported → store on PcapSource
   → packets loaded as before
 
-Processing loop:
-  for raw in source.packets:
-    decode_packet(&raw.data, source.datalink)  // dispatches by link type
-      → SlicedPacket::from_ethernet/from_ip/from_linux_sll
-      → extract net/transport/payload (unchanged)
-    on Err: increment total_decode_errors, warn on first
+Processing loop (runs across all target files):
+  for path in targets:
+    source = PcapSource::from_file(path)
+    for raw in source.packets:
+      decode_packet(&raw.data, source.datalink)  // dispatches by link type
+        → SlicedPacket::from_ethernet/from_ip/from_linux_sll
+        → extract IPs from net, ports+payload from transport slice (unchanged)
+      on Err: increment total_decode_errors, warn on first
   summary.skipped_packets = total_decode_errors
 ```
 
@@ -90,7 +92,7 @@ All three link types are already present in `tests/fixtures/`:
 
 ### Existing Tests
 
-All current tests use Ethernet fixtures or construct packets directly. They pass without modification because `decode_packet()` is backward-compatible (callers just add the `datalink` parameter).
+All current tests use Ethernet fixtures or construct packets directly. They require only a trivial call-site update (adding `DataLink::ETHERNET` as a second argument) — no test logic or assertions change.
 
 ## Acceptance Criteria
 

--- a/docs/superpowers/specs/2026-04-06-multi-linktype-design.md
+++ b/docs/superpowers/specs/2026-04-06-multi-linktype-design.md
@@ -16,6 +16,8 @@ This affects ~40% of real-world incident response captures (cloud VPC mirrors us
 | `DataLink::ETHERNET` | 1 | `SlicedPacket::from_ethernet()` | SPAN ports, Wireshark, most captures |
 | `DataLink::RAW` | 101 | `SlicedPacket::from_ip()` | Cloud VPC mirrors, mobile, some tools |
 | `DataLink::LINUX_SLL` | 113 | `SlicedPacket::from_linux_sll()` | `tcpdump -i any`, Docker captures |
+| `DataLink::IPV4` | 228 | `SlicedPacket::from_ip()` | Raw IPv4 captures (same as RAW but IPv4-only) |
+| `DataLink::IPV6` | 229 | `SlicedPacket::from_ip()` | Raw IPv6 captures |
 
 All other link types are rejected at file open with a clear error message.
 
@@ -28,7 +30,7 @@ Three layers change, each with a single responsibility:
 `PcapSource` gains a `datalink: DataLink` field read from `pcap_reader.header().datalink`.
 
 Unsupported link types are rejected immediately in `from_pcap_reader()` with:
-`"Unsupported pcap link type: {datalink:?}. Supported: Ethernet (1), Raw IP (101), Linux Cooked (113)"`
+`"Unsupported pcap link type: {datalink:?}. Supported: Ethernet (1), Raw IP (101), Linux Cooked (113), IPv4 (228), IPv6 (229)"`
 
 This is a fail-fast design: unsupported formats error at file open, not silently per-packet.
 
@@ -37,7 +39,7 @@ This is a fail-fast design: unsupported formats error at file open, not silently
 `decode_packet()` gains a `datalink: DataLink` parameter. A match expression dispatches to the correct etherparse parser:
 
 - `DataLink::ETHERNET` → `SlicedPacket::from_ethernet(data)`
-- `DataLink::RAW` → `SlicedPacket::from_ip(data)`
+- `DataLink::RAW` | `DataLink::IPV4` | `DataLink::IPV6` → `SlicedPacket::from_ip(data)`
 - `DataLink::LINUX_SLL` → `SlicedPacket::from_linux_sll(data)`
 - `_` → error (defense-in-depth; reader already rejects unsupported types)
 
@@ -77,7 +79,7 @@ All three link types are already present in `tests/fixtures/`:
 |------|-----------|---------------|----------------|
 | `tls.pcap` | Ethernet (1) | Works | Works (unchanged) |
 | `segmented.pcap` | Raw IP (101) | Silent 0 packets | Parses successfully |
-| `http-ooo.pcap` | Linux Cooked (113) | Silent 0 packets | Parses successfully |
+| `http-ooo.pcap` | Raw IPv4 (228) | Silent 0 packets | Parses successfully |
 
 ### New Tests
 

--- a/docs/superpowers/specs/2026-04-06-multi-linktype-design.md
+++ b/docs/superpowers/specs/2026-04-06-multi-linktype-design.md
@@ -1,0 +1,104 @@
+# Multi-Link-Type Support Design
+
+**Issue:** #14 — Support non-Ethernet link types (Raw IP, Linux Cooked, pcapng)
+**Scope:** Pcap link types only (Ethernet, Raw IP, Linux Cooked SLL). Pcapng deferred.
+
+## Problem
+
+wirerust hardcodes `SlicedPacket::from_ethernet()` in `src/decoder.rs`. Pcap files with non-Ethernet link types silently produce empty results — `decode_packet()` fails and the error is swallowed by `if let Ok(parsed)` in `main.rs`. The user sees `Packets: 0` with no warning.
+
+This affects ~40% of real-world incident response captures (cloud VPC mirrors use Raw IP, `tcpdump -i any` produces Linux Cooked).
+
+## Supported Link Types
+
+| DataLink Variant | Link Type ID | etherparse Parser | Source |
+|------------------|-------------|-------------------|--------|
+| `DataLink::ETHERNET` | 1 | `SlicedPacket::from_ethernet()` | SPAN ports, Wireshark, most captures |
+| `DataLink::RAW` | 101 | `SlicedPacket::from_ip()` | Cloud VPC mirrors, mobile, some tools |
+| `DataLink::LINUX_SLL` | 113 | `SlicedPacket::from_linux_sll()` | `tcpdump -i any`, Docker captures |
+
+All other link types are rejected at file open with a clear error message.
+
+## Architecture
+
+Three layers change, each with a single responsibility:
+
+### Reader Layer (`src/reader.rs`)
+
+`PcapSource` gains a `datalink: DataLink` field read from `pcap_reader.header().datalink`.
+
+Unsupported link types are rejected immediately in `from_pcap_reader()` with:
+`"Unsupported pcap link type: {datalink:?}. Supported: Ethernet (1), Raw IP (101), Linux Cooked (113)"`
+
+This is a fail-fast design: unsupported formats error at file open, not silently per-packet.
+
+### Decoder Layer (`src/decoder.rs`)
+
+`decode_packet()` gains a `datalink: DataLink` parameter. A match expression dispatches to the correct etherparse parser:
+
+- `DataLink::ETHERNET` → `SlicedPacket::from_ethernet(data)`
+- `DataLink::RAW` → `SlicedPacket::from_ip(data)`
+- `DataLink::LINUX_SLL` → `SlicedPacket::from_linux_sll(data)`
+- `_` → error (defense-in-depth; reader already rejects unsupported types)
+
+Everything after `SlicedPacket` construction is unchanged. The `net`, `transport`, and `payload` fields on `SlicedPacket` are identical in structure regardless of which `from_*()` method was used. Only the `link` field differs (populated for Ethernet/SLL, empty for Raw IP), and wirerust does not access it.
+
+### Error Surfacing (`src/main.rs`)
+
+The processing loops in `run_analyze()` and `run_summary()` gain a `decode_errors: u32` counter. On first decode failure, a warning is printed to stderr (not stdout, to keep piped output clean):
+
+`"Warning: failed to decode packet (link type: {datalink:?}). Further errors will be counted silently."`
+
+After the loop, if `decode_errors > 0`, the count is included in summary output so the user knows data was lost.
+
+## Data Flow
+
+```
+PcapSource::from_file(path)
+  → PcapReader::new(reader)
+  → header().datalink → validate supported → store on PcapSource
+  → packets loaded as before
+
+Processing loop:
+  for raw in source.packets:
+    decode_packet(&raw.data, source.datalink)  // dispatches by link type
+      → SlicedPacket::from_ethernet/from_ip/from_linux_sll
+      → extract net/transport/payload (unchanged)
+    on Err: increment decode_errors, warn on first
+```
+
+## Testing
+
+### Existing Fixtures
+
+All three link types are already present in `tests/fixtures/`:
+
+| File | Link Type | Current Status | Expected After |
+|------|-----------|---------------|----------------|
+| `tls.pcap` | Ethernet (1) | Works | Works (unchanged) |
+| `segmented.pcap` | Raw IP (101) | Silent 0 packets | Parses successfully |
+| `http-ooo.pcap` | Linux Cooked (113) | Silent 0 packets | Parses successfully |
+
+### New Tests
+
+1. **Integration test per link type** — load each fixture via `PcapSource::from_file()`, assert `packets.len() > 0`, decode all packets and verify no errors.
+2. **Unsupported link type test** — construct a pcap with an unsupported link type, verify `from_pcap_reader()` returns a clear error (not silent empty output).
+3. **Decode error counting** — verify that decode failures are counted (unit test on the counter logic, not full CLI integration).
+
+### Existing Tests
+
+All current tests use Ethernet fixtures or construct packets directly. They pass without modification because `decode_packet()` is backward-compatible (callers just add the `datalink` parameter).
+
+## Acceptance Criteria
+
+From issue #14:
+- [ ] `wirerust analyze segmented.pcap` parses packets (currently shows 0)
+- [ ] Unsupported link types produce a clear error, not silent empty output
+- [ ] Decode failure count shown in summary when packets are skipped
+
+## Not In Scope
+
+- **pcapng format** — structurally different (per-interface link types). Deferred to a separate issue.
+- **SLL v2** (`DataLink::LINUX_SLL2`) — etherparse does not have `from_linux_sll2()`. Deferred.
+- **Other link types** — can be added incrementally as etherparse adds parsers.
+- **MAC address extraction** — the `link` field on `SlicedPacket` is populated for Ethernet/SLL but wirerust doesn't use it yet. Future work.

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -2,6 +2,7 @@ use std::net::IpAddr;
 
 use anyhow::{Result, anyhow};
 use etherparse::SlicedPacket;
+use pcap_file::DataLink;
 use serde::Serialize;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize)]
@@ -67,8 +68,14 @@ impl ParsedPacket {
     }
 }
 
-pub fn decode_packet(data: &[u8]) -> Result<ParsedPacket> {
-    let sliced = SlicedPacket::from_ethernet(data).map_err(|e| anyhow!("Parse error: {e}"))?;
+pub fn decode_packet(data: &[u8], datalink: DataLink) -> Result<ParsedPacket> {
+    let sliced = match datalink {
+        DataLink::ETHERNET => SlicedPacket::from_ethernet(data),
+        DataLink::RAW | DataLink::IPV4 | DataLink::IPV6 => SlicedPacket::from_ip(data),
+        DataLink::LINUX_SLL => SlicedPacket::from_linux_sll(data),
+        other => return Err(anyhow!("Unsupported link type: {other:?}")),
+    }
+    .map_err(|e| anyhow!("Parse error: {e}"))?;
 
     let (src_ip, dst_ip, ip_protocol) = match &sliced.net {
         Some(etherparse::NetSlice::Ipv4(ipv4)) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,6 +45,7 @@ fn run_analyze(
     let mut summary = Summary::new();
     let mut dns_analyzer = DnsAnalyzer::new();
     let mut all_findings = Vec::new();
+    let mut total_decode_errors: u64 = 0;
 
     // Determine if reassembly is needed
     let needs_reassembly = cli.reassemble; // Will expand when HTTP/TLS analyzers added
@@ -80,14 +81,24 @@ fn run_analyze(
             )?);
 
             for raw in &source.packets {
-                if let Ok(parsed) = decode_packet(&raw.data, source.datalink) {
-                    summary.ingest(&parsed);
-                    if enable_dns && dns_analyzer.can_decode(&parsed) {
-                        let findings = dns_analyzer.analyze(&parsed);
-                        all_findings.extend(findings);
+                match decode_packet(&raw.data, source.datalink) {
+                    Ok(parsed) => {
+                        summary.ingest(&parsed);
+                        if enable_dns && dns_analyzer.can_decode(&parsed) {
+                            let findings = dns_analyzer.analyze(&parsed);
+                            all_findings.extend(findings);
+                        }
+                        if let Some(ref mut reasm) = reassembler {
+                            reasm.process_packet(&parsed, raw.timestamp_secs, &mut stream_handler);
+                        }
                     }
-                    if let Some(ref mut reasm) = reassembler {
-                        reasm.process_packet(&parsed, raw.timestamp_secs, &mut stream_handler);
+                    Err(e) => {
+                        if total_decode_errors == 0 {
+                            eprintln!(
+                                "Warning: failed to decode packet ({e}). Further errors counted silently."
+                            );
+                        }
+                        total_decode_errors += 1;
                     }
                 }
                 pb.inc(1);
@@ -95,6 +106,8 @@ fn run_analyze(
             pb.finish_and_clear();
         }
     }
+
+    summary.skipped_packets = total_decode_errors;
 
     if let Some(ref mut reasm) = reassembler {
         reasm.finalize(&mut stream_handler);
@@ -124,18 +137,30 @@ fn run_analyze(
 
 fn run_summary(targets: &[std::path::PathBuf], use_color: bool, cli: &Cli) -> Result<()> {
     let mut summary = Summary::new();
+    let mut total_decode_errors: u64 = 0;
 
     for target in targets {
         let pcap_files = resolve_targets(target)?;
         for path in &pcap_files {
             let source = PcapSource::from_file(path)?;
             for raw in &source.packets {
-                if let Ok(parsed) = decode_packet(&raw.data, source.datalink) {
-                    summary.ingest(&parsed);
+                match decode_packet(&raw.data, source.datalink) {
+                    Ok(parsed) => {
+                        summary.ingest(&parsed);
+                    }
+                    Err(e) => {
+                        if total_decode_errors == 0 {
+                            eprintln!(
+                                "Warning: failed to decode packet ({e}). Further errors counted silently."
+                            );
+                        }
+                        total_decode_errors += 1;
+                    }
                 }
             }
         }
     }
+    summary.skipped_packets = total_decode_errors;
 
     let output = match cli.output_format {
         Some(OutputFormat::Json) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -142,7 +142,8 @@ fn run_summary(targets: &[std::path::PathBuf], use_color: bool, cli: &Cli) -> Re
     for target in targets {
         let pcap_files = resolve_targets(target)?;
         for path in &pcap_files {
-            let source = PcapSource::from_file(path)?;
+            let source = PcapSource::from_file(path)
+                .with_context(|| format!("Failed to read {}", path.display()))?;
             for raw in &source.packets {
                 match decode_packet(&raw.data, source.datalink) {
                     Ok(parsed) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -80,7 +80,7 @@ fn run_analyze(
             )?);
 
             for raw in &source.packets {
-                if let Ok(parsed) = decode_packet(&raw.data) {
+                if let Ok(parsed) = decode_packet(&raw.data, source.datalink) {
                     summary.ingest(&parsed);
                     if enable_dns && dns_analyzer.can_decode(&parsed) {
                         let findings = dns_analyzer.analyze(&parsed);
@@ -130,7 +130,7 @@ fn run_summary(targets: &[std::path::PathBuf], use_color: bool, cli: &Cli) -> Re
         for path in &pcap_files {
             let source = PcapSource::from_file(path)?;
             for raw in &source.packets {
-                if let Ok(parsed) = decode_packet(&raw.data) {
+                if let Ok(parsed) = decode_packet(&raw.data, source.datalink) {
                     summary.ingest(&parsed);
                 }
             }

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -1,6 +1,7 @@
 use std::io::Read;
 
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, anyhow};
+use pcap_file::DataLink;
 use pcap_file::pcap::PcapReader;
 
 #[derive(Debug, Clone)]
@@ -13,11 +14,26 @@ pub struct RawPacket {
 #[derive(Debug)]
 pub struct PcapSource {
     pub packets: Vec<RawPacket>,
+    pub datalink: DataLink,
 }
 
 impl PcapSource {
     pub fn from_pcap_reader<R: Read>(reader: R) -> Result<Self> {
         let mut pcap_reader = PcapReader::new(reader).context("Failed to parse pcap header")?;
+
+        let datalink = pcap_reader.header().datalink;
+        match datalink {
+            DataLink::ETHERNET
+            | DataLink::RAW
+            | DataLink::IPV4
+            | DataLink::IPV6
+            | DataLink::LINUX_SLL => {}
+            other => {
+                return Err(anyhow!(
+                    "Unsupported pcap link type: {other:?}. Supported: Ethernet (1), Raw IP (101), Linux Cooked (113), IPv4 (228), IPv6 (229)"
+                ));
+            }
+        }
 
         let mut packets = Vec::new();
 
@@ -30,7 +46,7 @@ impl PcapSource {
             });
         }
 
-        Ok(PcapSource { packets })
+        Ok(PcapSource { packets, datalink })
     }
 
     pub fn from_file(path: &std::path::Path) -> Result<Self> {

--- a/src/reporter/json.rs
+++ b/src/reporter/json.rs
@@ -25,6 +25,7 @@ impl Reporter for JsonReporter {
             "summary": {
                 "total_packets": summary.total_packets,
                 "total_bytes": summary.total_bytes,
+                "skipped_packets": summary.skipped_packets,
                 "unique_hosts": summary.unique_hosts(),
                 "protocols": protocols,
                 "services": summary.service_counts(),

--- a/src/reporter/terminal.rs
+++ b/src/reporter/terminal.rs
@@ -21,11 +21,20 @@ impl Reporter for TerminalReporter {
         // Header
         out.push_str(&self.section("WIRERUST TRIAGE REPORT"));
         out.push_str(&format!(
-            "  Packets: {}  Bytes: {}  Hosts: {}\n\n",
+            "  Packets: {}  Bytes: {}  Hosts: {}\n",
             summary.total_packets,
             summary.total_bytes,
             summary.unique_hosts().len(),
         ));
+        if summary.skipped_packets > 0 {
+            let warning = format!("  Skipped: {} packets (decode errors)\n", summary.skipped_packets);
+            if self.use_color {
+                out.push_str(&warning.yellow().to_string());
+            } else {
+                out.push_str(&warning);
+            }
+        }
+        out.push('\n');
 
         // Protocol breakdown
         out.push_str(&self.section("PROTOCOLS"));

--- a/src/reporter/terminal.rs
+++ b/src/reporter/terminal.rs
@@ -27,7 +27,10 @@ impl Reporter for TerminalReporter {
             summary.unique_hosts().len(),
         ));
         if summary.skipped_packets > 0 {
-            let warning = format!("  Skipped: {} packets (decode errors)\n", summary.skipped_packets);
+            let warning = format!(
+                "  Skipped: {} packets (decode errors)\n",
+                summary.skipped_packets
+            );
             if self.use_color {
                 out.push_str(&warning.yellow().to_string());
             } else {

--- a/src/summary.rs
+++ b/src/summary.rs
@@ -9,6 +9,7 @@ use crate::decoder::{ParsedPacket, Protocol};
 pub struct Summary {
     pub total_packets: u64,
     pub total_bytes: u64,
+    pub skipped_packets: u64,
     hosts: HashSet<IpAddr>,
     protocols: HashMap<Protocol, u64>,
     services: HashMap<String, u64>,
@@ -25,6 +26,7 @@ impl Summary {
         Summary {
             total_packets: 0,
             total_bytes: 0,
+            skipped_packets: 0,
             hosts: HashSet::new(),
             protocols: HashMap::new(),
             services: HashMap::new(),

--- a/tests/decoder_tests.rs
+++ b/tests/decoder_tests.rs
@@ -1,4 +1,4 @@
-use std::net::{IpAddr, Ipv4Addr};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
 use pcap_file::DataLink;
 use wirerust::decoder::{Protocol, TransportInfo, decode_packet};
@@ -105,6 +105,104 @@ fn test_decode_raw_ip_tcp_packet() {
 
     assert_eq!(parsed.src_ip, IpAddr::V4(Ipv4Addr::new(192, 168, 1, 10)));
     assert_eq!(parsed.dst_ip, IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1)));
+    assert_eq!(parsed.protocol, Protocol::Tcp);
+    match parsed.transport {
+        TransportInfo::Tcp {
+            src_port, dst_port, ..
+        } => {
+            assert_eq!(src_port, 49153);
+            assert_eq!(dst_port, 80);
+        }
+        _ => panic!("Expected TCP"),
+    }
+}
+
+#[test]
+fn test_decode_ipv4_linktype_uses_from_ip() {
+    // DataLink::IPV4 should use from_ip(), same as RAW
+    let data = make_raw_ip_tcp_packet();
+    let parsed = decode_packet(&data, DataLink::IPV4).unwrap();
+    assert_eq!(parsed.src_ip, IpAddr::V4(Ipv4Addr::new(192, 168, 1, 10)));
+    assert_eq!(parsed.protocol, Protocol::Tcp);
+}
+
+fn make_raw_ipv6_tcp_packet() -> Vec<u8> {
+    vec![
+        // IPv6 header (40 bytes) — no Ethernet header
+        0x60, 0x00, 0x00, 0x00, // version=6, traffic class, flow label
+        0x00, 0x14, 0x06, 0x40, // payload length=20, next header=TCP(6), hop limit=64
+        // src: 2001:db8::1
+        0x20, 0x01, 0x0d, 0xb8, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x01, // dst: 2001:db8::2
+        0x20, 0x01, 0x0d, 0xb8, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x02, // TCP header (20 bytes)
+        0xc0, 0x01, 0x00, 0x50, // src port 49153, dst port 80
+        0x00, 0x00, 0x00, 0x01, // seq number
+        0x00, 0x00, 0x00, 0x00, // ack number
+        0x50, 0x02, 0xff, 0xff, // data offset=5, SYN, window
+        0x00, 0x00, 0x00, 0x00, // checksum, urgent pointer
+    ]
+}
+
+#[test]
+fn test_decode_ipv6_tcp_packet() {
+    let data = make_raw_ipv6_tcp_packet();
+    let parsed = decode_packet(&data, DataLink::IPV6).unwrap();
+
+    assert_eq!(
+        parsed.src_ip,
+        IpAddr::V6(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1))
+    );
+    assert_eq!(
+        parsed.dst_ip,
+        IpAddr::V6(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 2))
+    );
+    assert_eq!(parsed.protocol, Protocol::Tcp);
+    match parsed.transport {
+        TransportInfo::Tcp {
+            src_port, dst_port, ..
+        } => {
+            assert_eq!(src_port, 49153);
+            assert_eq!(dst_port, 80);
+        }
+        _ => panic!("Expected TCP"),
+    }
+}
+
+fn make_linux_sll_tcp_packet() -> Vec<u8> {
+    let mut pkt = Vec::new();
+    // Linux SLL header (16 bytes)
+    pkt.extend_from_slice(&[0x00, 0x00]); // packet type: sent by us
+    pkt.extend_from_slice(&[0x00, 0x01]); // ARPHRD_ETHER
+    pkt.extend_from_slice(&[0x00, 0x06]); // link-layer address length
+    pkt.extend_from_slice(&[0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x00, 0x00]); // address (padded)
+    pkt.extend_from_slice(&[0x08, 0x00]); // protocol type: IPv4
+    // IPv4 header (20 bytes)
+    pkt.extend_from_slice(&[
+        0x45, 0x00, 0x00, 0x28, // version/IHL, total length=40
+        0x00, 0x01, 0x00, 0x00, // identification, flags/fragment
+        0x40, 0x06, 0x00, 0x00, // TTL=64, protocol=TCP, checksum
+        0x0a, 0x00, 0x00, 0x01, // src: 10.0.0.1
+        0x0a, 0x00, 0x00, 0x02, // dst: 10.0.0.2
+    ]);
+    // TCP header (20 bytes)
+    pkt.extend_from_slice(&[
+        0xc0, 0x01, 0x00, 0x50, // src port 49153, dst port 80
+        0x00, 0x00, 0x00, 0x01, // seq number
+        0x00, 0x00, 0x00, 0x00, // ack number
+        0x50, 0x02, 0xff, 0xff, // data offset=5, SYN, window
+        0x00, 0x00, 0x00, 0x00, // checksum, urgent pointer
+    ]);
+    pkt
+}
+
+#[test]
+fn test_decode_linux_sll_tcp_packet() {
+    let data = make_linux_sll_tcp_packet();
+    let parsed = decode_packet(&data, DataLink::LINUX_SLL).unwrap();
+
+    assert_eq!(parsed.src_ip, IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)));
+    assert_eq!(parsed.dst_ip, IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)));
     assert_eq!(parsed.protocol, Protocol::Tcp);
     match parsed.transport {
         TransportInfo::Tcp {

--- a/tests/decoder_tests.rs
+++ b/tests/decoder_tests.rs
@@ -1,5 +1,6 @@
 use std::net::{IpAddr, Ipv4Addr};
 
+use pcap_file::DataLink;
 use wirerust::decoder::{Protocol, TransportInfo, decode_packet};
 
 fn make_tcp_packet() -> Vec<u8> {
@@ -33,10 +34,27 @@ fn make_udp_packet() -> Vec<u8> {
     ]
 }
 
+fn make_raw_ip_tcp_packet() -> Vec<u8> {
+    vec![
+        // IPv4 header (20 bytes) — no Ethernet header
+        0x45, 0x00, 0x00, 0x28, // version/IHL, DSCP, total length=40
+        0x00, 0x01, 0x00, 0x00, // identification, flags/fragment
+        0x40, 0x06, 0x00, 0x00, // TTL=64, protocol=TCP, checksum
+        0xc0, 0xa8, 0x01, 0x0a, // src: 192.168.1.10
+        0xc0, 0xa8, 0x01, 0x01, // dst: 192.168.1.1
+        // TCP header (20 bytes)
+        0xc0, 0x01, 0x00, 0x50, // src port 49153, dst port 80
+        0x00, 0x00, 0x00, 0x01, // seq number
+        0x00, 0x00, 0x00, 0x00, // ack number
+        0x50, 0x02, 0xff, 0xff, // data offset=5, SYN, window
+        0x00, 0x00, 0x00, 0x00, // checksum, urgent pointer
+    ]
+}
+
 #[test]
 fn test_decode_tcp_packet() {
     let data = make_tcp_packet();
-    let parsed = decode_packet(&data).unwrap();
+    let parsed = decode_packet(&data, DataLink::ETHERNET).unwrap();
 
     assert_eq!(parsed.src_ip, IpAddr::V4(Ipv4Addr::new(192, 168, 1, 10)));
     assert_eq!(parsed.dst_ip, IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1)));
@@ -57,7 +75,7 @@ fn test_decode_tcp_packet() {
 #[test]
 fn test_decode_udp_dns_packet() {
     let data = make_udp_packet();
-    let parsed = decode_packet(&data).unwrap();
+    let parsed = decode_packet(&data, DataLink::ETHERNET).unwrap();
 
     assert_eq!(parsed.src_ip, IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)));
     assert_eq!(parsed.dst_ip, IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)));
@@ -77,5 +95,24 @@ fn test_decode_udp_dns_packet() {
 #[test]
 fn test_decode_invalid_packet() {
     let garbage = vec![0x00, 0x01, 0x02];
-    assert!(decode_packet(&garbage).is_err());
+    assert!(decode_packet(&garbage, DataLink::ETHERNET).is_err());
+}
+
+#[test]
+fn test_decode_raw_ip_tcp_packet() {
+    let data = make_raw_ip_tcp_packet();
+    let parsed = decode_packet(&data, DataLink::RAW).unwrap();
+
+    assert_eq!(parsed.src_ip, IpAddr::V4(Ipv4Addr::new(192, 168, 1, 10)));
+    assert_eq!(parsed.dst_ip, IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1)));
+    assert_eq!(parsed.protocol, Protocol::Tcp);
+    match parsed.transport {
+        TransportInfo::Tcp {
+            src_port, dst_port, ..
+        } => {
+            assert_eq!(src_port, 49153);
+            assert_eq!(dst_port, 80);
+        }
+        _ => panic!("Expected TCP"),
+    }
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -48,12 +48,12 @@ fn test_full_pipeline() {
     let mut all_findings = Vec::new();
 
     for raw in &source.packets {
-        if let Ok(parsed) = decode_packet(&raw.data, source.datalink) {
-            summary.ingest(&parsed);
-            if dns_analyzer.can_decode(&parsed) {
-                let findings = dns_analyzer.analyze(&parsed);
-                all_findings.extend(findings);
-            }
+        let parsed = decode_packet(&raw.data, source.datalink)
+            .expect("test fixture packet should decode successfully");
+        summary.ingest(&parsed);
+        if dns_analyzer.can_decode(&parsed) {
+            let findings = dns_analyzer.analyze(&parsed);
+            all_findings.extend(findings);
         }
     }
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -48,7 +48,7 @@ fn test_full_pipeline() {
     let mut all_findings = Vec::new();
 
     for raw in &source.packets {
-        if let Ok(parsed) = decode_packet(&raw.data) {
+        if let Ok(parsed) = decode_packet(&raw.data, source.datalink) {
             summary.ingest(&parsed);
             if dns_analyzer.can_decode(&parsed) {
                 let findings = dns_analyzer.analyze(&parsed);

--- a/tests/linktype_integration_tests.rs
+++ b/tests/linktype_integration_tests.rs
@@ -1,0 +1,68 @@
+use pcap_file::DataLink;
+use wirerust::decoder::decode_packet;
+use wirerust::reader::PcapSource;
+
+#[test]
+fn test_ethernet_pcap_tls() {
+    let source = PcapSource::from_file(std::path::Path::new("tests/fixtures/tls.pcap")).unwrap();
+    assert_eq!(source.datalink, DataLink::ETHERNET);
+    assert!(
+        source.packets.len() > 0,
+        "tls.pcap should have packets, got 0"
+    );
+
+    let mut decoded_count = 0;
+    for raw in &source.packets {
+        if decode_packet(&raw.data, source.datalink).is_ok() {
+            decoded_count += 1;
+        }
+    }
+    assert!(
+        decoded_count > 0,
+        "Should decode at least some packets from tls.pcap, got 0"
+    );
+}
+
+#[test]
+fn test_raw_ip_pcap_segmented() {
+    let source =
+        PcapSource::from_file(std::path::Path::new("tests/fixtures/segmented.pcap")).unwrap();
+    assert_eq!(source.datalink, DataLink::RAW);
+    assert!(
+        source.packets.len() > 0,
+        "segmented.pcap should have packets, got 0"
+    );
+
+    let mut decoded_count = 0;
+    for raw in &source.packets {
+        if decode_packet(&raw.data, source.datalink).is_ok() {
+            decoded_count += 1;
+        }
+    }
+    assert!(
+        decoded_count > 0,
+        "Should decode at least some packets from segmented.pcap, got 0"
+    );
+}
+
+#[test]
+fn test_ipv4_pcap_http_ooo() {
+    let source =
+        PcapSource::from_file(std::path::Path::new("tests/fixtures/http-ooo.pcap")).unwrap();
+    assert_eq!(source.datalink, DataLink::IPV4);
+    assert!(
+        source.packets.len() > 0,
+        "http-ooo.pcap should have packets, got 0"
+    );
+
+    let mut decoded_count = 0;
+    for raw in &source.packets {
+        if decode_packet(&raw.data, source.datalink).is_ok() {
+            decoded_count += 1;
+        }
+    }
+    assert!(
+        decoded_count > 0,
+        "Should decode at least some packets from http-ooo.pcap, got 0"
+    );
+}

--- a/tests/linktype_integration_tests.rs
+++ b/tests/linktype_integration_tests.rs
@@ -11,15 +11,18 @@ fn test_ethernet_pcap_tls() {
         "tls.pcap should have packets, got 0"
     );
 
-    let mut decoded_count = 0;
+    let mut decode_errors = 0;
     for raw in &source.packets {
-        if decode_packet(&raw.data, source.datalink).is_ok() {
-            decoded_count += 1;
+        if let Err(e) = decode_packet(&raw.data, source.datalink) {
+            if decode_errors == 0 {
+                panic!("Failed to decode packet in tls.pcap: {e}");
+            }
+            decode_errors += 1;
         }
     }
-    assert!(
-        decoded_count > 0,
-        "Should decode at least some packets from tls.pcap, got 0"
+    assert_eq!(
+        decode_errors, 0,
+        "Expected no decode errors in tls.pcap, got {decode_errors}"
     );
 }
 
@@ -33,15 +36,18 @@ fn test_raw_ip_pcap_segmented() {
         "segmented.pcap should have packets, got 0"
     );
 
-    let mut decoded_count = 0;
+    let mut decode_errors = 0;
     for raw in &source.packets {
-        if decode_packet(&raw.data, source.datalink).is_ok() {
-            decoded_count += 1;
+        if let Err(e) = decode_packet(&raw.data, source.datalink) {
+            if decode_errors == 0 {
+                panic!("Failed to decode packet in segmented.pcap: {e}");
+            }
+            decode_errors += 1;
         }
     }
-    assert!(
-        decoded_count > 0,
-        "Should decode at least some packets from segmented.pcap, got 0"
+    assert_eq!(
+        decode_errors, 0,
+        "Expected no decode errors in segmented.pcap, got {decode_errors}"
     );
 }
 
@@ -55,14 +61,17 @@ fn test_ipv4_pcap_http_ooo() {
         "http-ooo.pcap should have packets, got 0"
     );
 
-    let mut decoded_count = 0;
+    let mut decode_errors = 0;
     for raw in &source.packets {
-        if decode_packet(&raw.data, source.datalink).is_ok() {
-            decoded_count += 1;
+        if let Err(e) = decode_packet(&raw.data, source.datalink) {
+            if decode_errors == 0 {
+                panic!("Failed to decode packet in http-ooo.pcap: {e}");
+            }
+            decode_errors += 1;
         }
     }
-    assert!(
-        decoded_count > 0,
-        "Should decode at least some packets from http-ooo.pcap, got 0"
+    assert_eq!(
+        decode_errors, 0,
+        "Expected no decode errors in http-ooo.pcap, got {decode_errors}"
     );
 }

--- a/tests/linktype_integration_tests.rs
+++ b/tests/linktype_integration_tests.rs
@@ -6,24 +6,11 @@ use wirerust::reader::PcapSource;
 fn test_ethernet_pcap_tls() {
     let source = PcapSource::from_file(std::path::Path::new("tests/fixtures/tls.pcap")).unwrap();
     assert_eq!(source.datalink, DataLink::ETHERNET);
-    assert!(
-        source.packets.len() > 0,
-        "tls.pcap should have packets, got 0"
-    );
+    assert_eq!(source.packets.len(), 58, "tls.pcap packet count");
 
-    let mut decode_errors = 0;
     for raw in &source.packets {
-        if let Err(e) = decode_packet(&raw.data, source.datalink) {
-            if decode_errors == 0 {
-                panic!("Failed to decode packet in tls.pcap: {e}");
-            }
-            decode_errors += 1;
-        }
+        decode_packet(&raw.data, source.datalink).expect("all packets in tls.pcap should decode");
     }
-    assert_eq!(
-        decode_errors, 0,
-        "Expected no decode errors in tls.pcap, got {decode_errors}"
-    );
 }
 
 #[test]
@@ -31,24 +18,12 @@ fn test_raw_ip_pcap_segmented() {
     let source =
         PcapSource::from_file(std::path::Path::new("tests/fixtures/segmented.pcap")).unwrap();
     assert_eq!(source.datalink, DataLink::RAW);
-    assert!(
-        source.packets.len() > 0,
-        "segmented.pcap should have packets, got 0"
-    );
+    assert_eq!(source.packets.len(), 20, "segmented.pcap packet count");
 
-    let mut decode_errors = 0;
     for raw in &source.packets {
-        if let Err(e) = decode_packet(&raw.data, source.datalink) {
-            if decode_errors == 0 {
-                panic!("Failed to decode packet in segmented.pcap: {e}");
-            }
-            decode_errors += 1;
-        }
+        decode_packet(&raw.data, source.datalink)
+            .expect("all packets in segmented.pcap should decode");
     }
-    assert_eq!(
-        decode_errors, 0,
-        "Expected no decode errors in segmented.pcap, got {decode_errors}"
-    );
 }
 
 #[test]
@@ -56,22 +31,10 @@ fn test_ipv4_pcap_http_ooo() {
     let source =
         PcapSource::from_file(std::path::Path::new("tests/fixtures/http-ooo.pcap")).unwrap();
     assert_eq!(source.datalink, DataLink::IPV4);
-    assert!(
-        source.packets.len() > 0,
-        "http-ooo.pcap should have packets, got 0"
-    );
+    assert_eq!(source.packets.len(), 16, "http-ooo.pcap packet count");
 
-    let mut decode_errors = 0;
     for raw in &source.packets {
-        if let Err(e) = decode_packet(&raw.data, source.datalink) {
-            if decode_errors == 0 {
-                panic!("Failed to decode packet in http-ooo.pcap: {e}");
-            }
-            decode_errors += 1;
-        }
+        decode_packet(&raw.data, source.datalink)
+            .expect("all packets in http-ooo.pcap should decode");
     }
-    assert_eq!(
-        decode_errors, 0,
-        "Expected no decode errors in http-ooo.pcap, got {decode_errors}"
-    );
 }

--- a/tests/reader_tests.rs
+++ b/tests/reader_tests.rs
@@ -99,10 +99,50 @@ fn test_unsupported_link_type_rejected() {
     );
 }
 
+fn pcap_header_with_linktype(link_type: u32) -> Vec<u8> {
+    let mut buf = Vec::new();
+    buf.extend_from_slice(&0xa1b2c3d4u32.to_le_bytes());
+    buf.extend_from_slice(&2u16.to_le_bytes());
+    buf.extend_from_slice(&4u16.to_le_bytes());
+    buf.extend_from_slice(&0i32.to_le_bytes());
+    buf.extend_from_slice(&0u32.to_le_bytes());
+    buf.extend_from_slice(&65535u32.to_le_bytes());
+    buf.extend_from_slice(&link_type.to_le_bytes());
+    buf
+}
+
 #[test]
 fn test_pcap_source_stores_datalink() {
     let data = minimal_pcap_bytes();
     let cursor = Cursor::new(data);
     let source = PcapSource::from_pcap_reader(cursor).unwrap();
     assert_eq!(source.datalink, DataLink::ETHERNET);
+}
+
+#[test]
+fn test_reader_accepts_raw_linktype() {
+    let buf = pcap_header_with_linktype(101); // RAW
+    let source = PcapSource::from_pcap_reader(Cursor::new(buf)).unwrap();
+    assert_eq!(source.datalink, DataLink::RAW);
+}
+
+#[test]
+fn test_reader_accepts_ipv4_linktype() {
+    let buf = pcap_header_with_linktype(228); // IPV4
+    let source = PcapSource::from_pcap_reader(Cursor::new(buf)).unwrap();
+    assert_eq!(source.datalink, DataLink::IPV4);
+}
+
+#[test]
+fn test_reader_accepts_ipv6_linktype() {
+    let buf = pcap_header_with_linktype(229); // IPV6
+    let source = PcapSource::from_pcap_reader(Cursor::new(buf)).unwrap();
+    assert_eq!(source.datalink, DataLink::IPV6);
+}
+
+#[test]
+fn test_reader_accepts_linux_sll_linktype() {
+    let buf = pcap_header_with_linktype(113); // LINUX_SLL
+    let source = PcapSource::from_pcap_reader(Cursor::new(buf)).unwrap();
+    assert_eq!(source.datalink, DataLink::LINUX_SLL);
 }

--- a/tests/reader_tests.rs
+++ b/tests/reader_tests.rs
@@ -1,5 +1,6 @@
 use std::io::Cursor;
 
+use pcap_file::DataLink;
 use wirerust::reader::PcapSource;
 
 // Minimal valid pcap file: global header + 1 packet (Ethernet + IPv4 + TCP)
@@ -75,4 +76,33 @@ fn test_empty_pcap_no_packets() {
     let cursor = Cursor::new(buf);
     let source = PcapSource::from_pcap_reader(cursor).unwrap();
     assert!(source.packets.is_empty());
+}
+
+#[test]
+fn test_unsupported_link_type_rejected() {
+    let mut buf = Vec::new();
+    buf.extend_from_slice(&0xa1b2c3d4u32.to_le_bytes());
+    buf.extend_from_slice(&2u16.to_le_bytes());
+    buf.extend_from_slice(&4u16.to_le_bytes());
+    buf.extend_from_slice(&0i32.to_le_bytes());
+    buf.extend_from_slice(&0u32.to_le_bytes());
+    buf.extend_from_slice(&65535u32.to_le_bytes());
+    buf.extend_from_slice(&105u32.to_le_bytes()); // IEEE802_11 (unsupported)
+
+    let cursor = Cursor::new(buf);
+    let result = PcapSource::from_pcap_reader(cursor);
+    assert!(result.is_err());
+    let err_msg = result.unwrap_err().to_string();
+    assert!(
+        err_msg.contains("Unsupported"),
+        "Error should mention 'Unsupported', got: {err_msg}"
+    );
+}
+
+#[test]
+fn test_pcap_source_stores_datalink() {
+    let data = minimal_pcap_bytes();
+    let cursor = Cursor::new(data);
+    let source = PcapSource::from_pcap_reader(cursor).unwrap();
+    assert_eq!(source.datalink, DataLink::ETHERNET);
 }

--- a/tests/reporter_tests.rs
+++ b/tests/reporter_tests.rs
@@ -1,6 +1,7 @@
 use wirerust::findings::{Confidence, Finding, ThreatCategory, Verdict};
 use wirerust::reporter::Reporter;
 use wirerust::reporter::json::JsonReporter;
+use wirerust::reporter::terminal::TerminalReporter;
 use wirerust::summary::Summary;
 
 #[test]
@@ -27,4 +28,52 @@ fn test_json_reporter_produces_valid_json() {
     let findings_arr = parsed["findings"].as_array().unwrap();
     assert_eq!(findings_arr.len(), 1);
     assert_eq!(findings_arr[0]["summary"], "Test finding");
+}
+
+#[test]
+fn test_json_reporter_includes_skipped_packets() {
+    let reporter = JsonReporter;
+    let mut summary = Summary::new();
+    summary.skipped_packets = 42;
+
+    let output = reporter.render(&summary, &[], &[]);
+    let parsed: serde_json::Value = serde_json::from_str(&output).unwrap();
+
+    assert_eq!(parsed["summary"]["skipped_packets"], 42);
+}
+
+#[test]
+fn test_json_reporter_skipped_packets_zero_by_default() {
+    let reporter = JsonReporter;
+    let summary = Summary::new();
+
+    let output = reporter.render(&summary, &[], &[]);
+    let parsed: serde_json::Value = serde_json::from_str(&output).unwrap();
+
+    assert_eq!(parsed["summary"]["skipped_packets"], 0);
+}
+
+#[test]
+fn test_terminal_reporter_shows_skipped_when_nonzero() {
+    let reporter = TerminalReporter { use_color: false };
+    let mut summary = Summary::new();
+    summary.skipped_packets = 5;
+
+    let output = reporter.render(&summary, &[], &[]);
+    assert!(
+        output.contains("Skipped: 5 packets"),
+        "Terminal output should show skipped count, got: {output}"
+    );
+}
+
+#[test]
+fn test_terminal_reporter_hides_skipped_when_zero() {
+    let reporter = TerminalReporter { use_color: false };
+    let summary = Summary::new();
+
+    let output = reporter.render(&summary, &[], &[]);
+    assert!(
+        !output.contains("Skipped"),
+        "Terminal output should NOT show 'Skipped' when zero, got: {output}"
+    );
 }


### PR DESCRIPTION
## Summary

- Read pcap `DataLink` from file header and dispatch to the correct etherparse parser (`from_ethernet`, `from_ip`, `from_linux_sll`)
- Support 5 link types: Ethernet (1), Raw IP (101), Linux Cooked SLL (113), IPv4 (228), IPv6 (229)
- Unsupported link types now produce a clear error instead of silent empty output
- Decode failures are counted and surfaced in both terminal and JSON output, with a one-time stderr warning

Closes #14

## Test plan

- [x] `cargo test` — 54 tests pass (10 new)
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `segmented.pcap` (Raw IP 101) now parses 20 packets (was 0)
- [x] `http-ooo.pcap` (IPv4 228) now parses 16 packets (was 0)
- [x] `tls.pcap` (Ethernet) still works (58 packets)
- [x] Unsupported link type (105) returns clear "Unsupported" error
- [x] Decode error count appears in summary when packets are skipped