### PR TITLE
feat: add HTTP traffic analyzer with stream-level parsing (#1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -398,6 +398,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
 name = "iana-time-zone"
 version = "0.1.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1111,6 +1117,7 @@ dependencies = [
  "clap",
  "csv",
  "etherparse",
+ "httparse",
  "indicatif",
  "owo-colors",
  "pcap-file",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ description = "Fast PCAP forensics and network triage CLI tool"
 license = "MIT"
 
 [dependencies]
+httparse = "1"
 clap = { version = "4", features = ["derive"] }
 etherparse = "0.16"
 pcap-file = "2"

--- a/docs/superpowers/plans/2026-04-06-http-analyzer.md
+++ b/docs/superpowers/plans/2026-04-06-http-analyzer.md
@@ -1,0 +1,1207 @@
+# HTTP Analyzer Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add stream-level HTTP/1.x analysis using the TCP reassembly engine, with httparse for parsing and detection rules for forensics indicators.
+
+**Architecture:** `HttpAnalyzer` implements `StreamHandler` to receive reassembled TCP bytes, accumulates per-flow buffers, parses HTTP requests/responses with `httparse`, generates `Finding`s for suspicious patterns, and produces summary statistics. Auto-enables reassembly when `--http` is passed.
+
+**Tech Stack:** httparse 1.x (zero-alloc HTTP/1.x push parser), existing TCP reassembly engine, existing `Finding`/`AnalysisSummary` types.
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|---------------|
+| `Cargo.toml` | Modify | Add `httparse = "1"` dependency |
+| `src/analyzer/http.rs` | Create | HttpAnalyzer struct, StreamHandler impl, parsing, detection, summary |
+| `src/analyzer/mod.rs` | Modify | Register `pub mod http;` |
+| `src/main.rs` | Modify | Wire up --http flag, auto-reassembly, HttpAnalyzer as handler |
+| `tests/http_analyzer_tests.rs` | Create | Unit tests for parsing, detection, summary |
+| `tests/http_integration_tests.rs` | Create | Integration test with http-full.cap fixture |
+
+---
+
+### Task 1: HttpAnalyzer Skeleton + Dependency
+
+**Files:**
+- Modify: `Cargo.toml`
+- Create: `src/analyzer/http.rs`
+- Modify: `src/analyzer/mod.rs`
+- Create: `tests/http_analyzer_tests.rs`
+
+- [ ] **Step 1: Add httparse dependency**
+
+In `Cargo.toml`, add under `[dependencies]`:
+
+```toml
+httparse = "1"
+```
+
+- [ ] **Step 2: Write a test that constructs HttpAnalyzer**
+
+Create `tests/http_analyzer_tests.rs`:
+
+```rust
+use wirerust::analyzer::http::HttpAnalyzer;
+
+#[test]
+fn test_http_analyzer_construction() {
+    let analyzer = HttpAnalyzer::new();
+    assert_eq!(analyzer.transaction_count(), 0);
+}
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `cargo test --test http_analyzer_tests test_http_analyzer_construction`
+Expected: FAIL — module doesn't exist.
+
+- [ ] **Step 4: Create the HttpAnalyzer skeleton**
+
+Create `src/analyzer/http.rs`:
+
+```rust
+use std::collections::HashMap;
+
+use crate::analyzer::AnalysisSummary;
+use crate::findings::Finding;
+use crate::reassembly::flow::FlowKey;
+use crate::reassembly::handler::{CloseReason, Direction, StreamAnalyzer, StreamHandler};
+
+const MAX_HEADER_BUF: usize = 65_536;
+const MAX_HEADERS: usize = 96;
+const MAX_URIS: usize = 10_000;
+
+struct HttpFlowState {
+    request_buf: Vec<u8>,
+    response_buf: Vec<u8>,
+    pending_method: Option<String>,
+}
+
+impl HttpFlowState {
+    fn new() -> Self {
+        HttpFlowState {
+            request_buf: Vec::new(),
+            response_buf: Vec::new(),
+            pending_method: None,
+        }
+    }
+}
+
+pub struct HttpAnalyzer {
+    flows: HashMap<FlowKey, HttpFlowState>,
+    methods: HashMap<String, u64>,
+    status_codes: HashMap<u16, u64>,
+    hosts: HashMap<String, u64>,
+    user_agents: HashMap<String, u64>,
+    uris: Vec<String>,
+    transactions: u64,
+    all_findings: Vec<Finding>,
+}
+
+impl HttpAnalyzer {
+    pub fn new() -> Self {
+        HttpAnalyzer {
+            flows: HashMap::new(),
+            methods: HashMap::new(),
+            status_codes: HashMap::new(),
+            hosts: HashMap::new(),
+            user_agents: HashMap::new(),
+            uris: Vec::new(),
+            transactions: 0,
+            all_findings: Vec::new(),
+        }
+    }
+
+    pub fn transaction_count(&self) -> u64 {
+        self.transactions
+    }
+}
+
+impl StreamHandler for HttpAnalyzer {
+    fn on_data(&mut self, flow_key: &FlowKey, direction: Direction, data: &[u8], _offset: u64) {
+        {
+            let state = self.flows.entry(flow_key.clone()).or_insert_with(HttpFlowState::new);
+            match direction {
+                Direction::ClientToServer => {
+                    let remaining = MAX_HEADER_BUF.saturating_sub(state.request_buf.len());
+                    if remaining > 0 {
+                        state.request_buf.extend_from_slice(&data[..data.len().min(remaining)]);
+                    }
+                }
+                Direction::ServerToClient => {
+                    let remaining = MAX_HEADER_BUF.saturating_sub(state.response_buf.len());
+                    if remaining > 0 {
+                        state.response_buf.extend_from_slice(&data[..data.len().min(remaining)]);
+                    }
+                }
+            }
+        }
+        // Parsing will be added in Tasks 2 and 3
+    }
+
+    fn on_flow_close(&mut self, flow_key: &FlowKey, _reason: CloseReason) {
+        self.flows.remove(flow_key);
+    }
+}
+
+impl StreamAnalyzer for HttpAnalyzer {
+    fn name(&self) -> &'static str {
+        "HTTP"
+    }
+
+    fn summarize(&self) -> AnalysisSummary {
+        AnalysisSummary {
+            analyzer_name: self.name().to_string(),
+            packets_analyzed: self.transactions,
+            detail: HashMap::new(), // Populated in Task 5
+        }
+    }
+
+    fn findings(&self) -> Vec<Finding> {
+        self.all_findings.clone()
+    }
+}
+```
+
+- [ ] **Step 5: Register the module**
+
+In `src/analyzer/mod.rs`, add after the `pub mod dns;` line:
+
+```rust
+pub mod http;
+```
+
+- [ ] **Step 6: Run the test**
+
+Run: `cargo test --test http_analyzer_tests`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add Cargo.toml src/analyzer/http.rs src/analyzer/mod.rs tests/http_analyzer_tests.rs
+git commit -m "feat: add HttpAnalyzer skeleton with StreamHandler impl"
+```
+
+---
+
+### Task 2: HTTP Request Parsing
+
+**Files:**
+- Modify: `src/analyzer/http.rs`
+- Modify: `tests/http_analyzer_tests.rs`
+
+- [ ] **Step 1: Write test for parsing a simple GET request**
+
+Add to `tests/http_analyzer_tests.rs`:
+
+```rust
+use wirerust::reassembly::flow::FlowKey;
+use wirerust::reassembly::handler::{Direction, StreamHandler};
+use std::net::IpAddr;
+
+fn test_flow_key() -> FlowKey {
+    FlowKey::new(
+        "10.0.0.1".parse::<IpAddr>().unwrap(), 49153,
+        "10.0.0.2".parse::<IpAddr>().unwrap(), 80,
+    )
+}
+
+#[test]
+fn test_parse_get_request() {
+    let mut analyzer = HttpAnalyzer::new();
+    let fk = test_flow_key();
+
+    let request = b"GET /index.html HTTP/1.1\r\nHost: example.com\r\nUser-Agent: Mozilla/5.0\r\n\r\n";
+    analyzer.on_data(&fk, Direction::ClientToServer, request, 0);
+
+    assert_eq!(*analyzer.method_counts().get("GET").unwrap(), 1);
+    assert_eq!(*analyzer.host_counts().get("example.com").unwrap(), 1);
+    assert_eq!(*analyzer.user_agent_counts().get("Mozilla/5.0").unwrap(), 1);
+    assert_eq!(analyzer.uri_list(), &["/index.html"]);
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test --test http_analyzer_tests test_parse_get_request`
+Expected: FAIL — `method_counts` doesn't exist yet.
+
+- [ ] **Step 3: Write test for HTTP pipelining**
+
+Add to `tests/http_analyzer_tests.rs`:
+
+```rust
+#[test]
+fn test_parse_pipelined_requests() {
+    let mut analyzer = HttpAnalyzer::new();
+    let fk = test_flow_key();
+
+    let pipelined = b"GET /first HTTP/1.1\r\nHost: a.com\r\n\r\nPOST /second HTTP/1.1\r\nHost: b.com\r\nContent-Length: 0\r\n\r\n";
+    analyzer.on_data(&fk, Direction::ClientToServer, pipelined, 0);
+
+    assert_eq!(*analyzer.method_counts().get("GET").unwrap(), 1);
+    assert_eq!(*analyzer.method_counts().get("POST").unwrap(), 1);
+    assert_eq!(analyzer.uri_list().len(), 2);
+}
+```
+
+- [ ] **Step 4: Write test for partial request across two data chunks**
+
+Add to `tests/http_analyzer_tests.rs`:
+
+```rust
+#[test]
+fn test_parse_partial_request() {
+    let mut analyzer = HttpAnalyzer::new();
+    let fk = test_flow_key();
+
+    // Send request in two parts
+    analyzer.on_data(&fk, Direction::ClientToServer, b"GET /page HTTP/1.1\r\nHos", 0);
+    assert_eq!(analyzer.method_counts().get("GET"), None); // Not parsed yet
+
+    analyzer.on_data(&fk, Direction::ClientToServer, b"t: example.com\r\n\r\n", 23);
+    assert_eq!(*analyzer.method_counts().get("GET").unwrap(), 1);
+}
+```
+
+- [ ] **Step 5: Implement request parsing**
+
+In `src/analyzer/http.rs`, add a free function and accessor methods. Add at the top of the file:
+
+```rust
+use httparse;
+```
+
+Add this free function outside the impl blocks:
+
+```rust
+struct ParsedRequest {
+    bytes_consumed: usize,
+    method: String,
+    uri: String,
+    version: u8,
+    host: Option<String>,
+    user_agent: Option<String>,
+}
+
+fn parse_one_request(buf: &[u8]) -> Result<Option<ParsedRequest>, ()> {
+    let mut headers = [httparse::EMPTY_HEADER; MAX_HEADERS];
+    let mut req = httparse::Request::new(&mut headers);
+    match req.parse(buf) {
+        Ok(httparse::Status::Complete(n)) => Ok(Some(ParsedRequest {
+            bytes_consumed: n,
+            method: req.method.unwrap_or("").to_string(),
+            uri: req.path.unwrap_or("").to_string(),
+            version: req.version.unwrap_or(1),
+            host: find_header(req.headers, "host"),
+            user_agent: find_header(req.headers, "user-agent"),
+        })),
+        Ok(httparse::Status::Partial) => Ok(None),
+        Err(_) => Err(()),
+    }
+}
+
+fn find_header(headers: &[httparse::Header<'_>], name: &str) -> Option<String> {
+    headers
+        .iter()
+        .find(|h| h.name.eq_ignore_ascii_case(name))
+        .map(|h| String::from_utf8_lossy(h.value).to_string())
+}
+```
+
+Add accessor methods to the `impl HttpAnalyzer` block:
+
+```rust
+pub fn method_counts(&self) -> &HashMap<String, u64> {
+    &self.methods
+}
+
+pub fn host_counts(&self) -> &HashMap<String, u64> {
+    &self.hosts
+}
+
+pub fn user_agent_counts(&self) -> &HashMap<String, u64> {
+    &self.user_agents
+}
+
+pub fn uri_list(&self) -> &[String] {
+    &self.uris
+}
+
+pub fn status_code_counts(&self) -> &HashMap<u16, u64> {
+    &self.status_codes
+}
+```
+
+Add a private method to parse requests from the buffer:
+
+```rust
+fn try_parse_requests(&mut self, flow_key: &FlowKey) {
+    loop {
+        let result = self
+            .flows
+            .get(flow_key)
+            .filter(|s| !s.request_buf.is_empty())
+            .map(|s| parse_one_request(&s.request_buf));
+
+        match result {
+            Some(Ok(Some(parsed))) => {
+                *self.methods.entry(parsed.method.clone()).or_insert(0) += 1;
+                if let Some(ref h) = parsed.host {
+                    *self.hosts.entry(h.clone()).or_insert(0) += 1;
+                }
+                if let Some(ref ua) = parsed.user_agent {
+                    *self.user_agents.entry(ua.clone()).or_insert(0) += 1;
+                }
+                if self.uris.len() < MAX_URIS {
+                    self.uris.push(parsed.uri.clone());
+                }
+
+                if let Some(state) = self.flows.get_mut(flow_key) {
+                    state.pending_method = Some(parsed.method);
+                    state.request_buf.drain(..parsed.bytes_consumed);
+                }
+            }
+            Some(Ok(None)) => return, // Partial — wait for more data
+            Some(Err(())) => {
+                // Malformed — clear buffer
+                if let Some(state) = self.flows.get_mut(flow_key) {
+                    state.request_buf.clear();
+                }
+                return;
+            }
+            None => return, // No flow state or empty buffer
+        }
+    }
+}
+```
+
+Update the `on_data` callback to call parsing. Replace the `// Parsing will be added in Tasks 2 and 3` comment and the closing brace of the `ClientToServer` arm's outer block:
+
+After the buffer append block (after the closing `}`), add:
+
+```rust
+match direction {
+    Direction::ClientToServer => self.try_parse_requests(flow_key),
+    Direction::ServerToClient => {} // Task 3
+}
+```
+
+The full `on_data` method should now look like:
+
+```rust
+fn on_data(&mut self, flow_key: &FlowKey, direction: Direction, data: &[u8], _offset: u64) {
+    {
+        let state = self
+            .flows
+            .entry(flow_key.clone())
+            .or_insert_with(HttpFlowState::new);
+        match direction {
+            Direction::ClientToServer => {
+                let remaining = MAX_HEADER_BUF.saturating_sub(state.request_buf.len());
+                if remaining > 0 {
+                    state
+                        .request_buf
+                        .extend_from_slice(&data[..data.len().min(remaining)]);
+                }
+            }
+            Direction::ServerToClient => {
+                let remaining = MAX_HEADER_BUF.saturating_sub(state.response_buf.len());
+                if remaining > 0 {
+                    state
+                        .response_buf
+                        .extend_from_slice(&data[..data.len().min(remaining)]);
+                }
+            }
+        }
+    }
+    match direction {
+        Direction::ClientToServer => self.try_parse_requests(flow_key),
+        Direction::ServerToClient => {} // Task 3
+    }
+}
+```
+
+- [ ] **Step 6: Run all tests**
+
+Run: `cargo test --test http_analyzer_tests`
+Expected: All 4 tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/analyzer/http.rs tests/http_analyzer_tests.rs
+git commit -m "feat: parse HTTP/1.x requests from reassembled streams with httparse"
+```
+
+---
+
+### Task 3: HTTP Response Parsing
+
+**Files:**
+- Modify: `src/analyzer/http.rs`
+- Modify: `tests/http_analyzer_tests.rs`
+
+- [ ] **Step 1: Write test for response parsing**
+
+Add to `tests/http_analyzer_tests.rs`:
+
+```rust
+#[test]
+fn test_parse_response() {
+    let mut analyzer = HttpAnalyzer::new();
+    let fk = test_flow_key();
+
+    // Send a request first (to set pending_method)
+    let request = b"GET /index.html HTTP/1.1\r\nHost: example.com\r\n\r\n";
+    analyzer.on_data(&fk, Direction::ClientToServer, request, 0);
+
+    // Then a response
+    let response = b"HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nContent-Length: 5\r\n\r\nhello";
+    analyzer.on_data(&fk, Direction::ServerToClient, response, 0);
+
+    assert_eq!(*analyzer.status_code_counts().get(&200).unwrap(), 1);
+    assert_eq!(analyzer.transaction_count(), 1);
+}
+```
+
+- [ ] **Step 2: Write test for pipelined responses**
+
+Add to `tests/http_analyzer_tests.rs`:
+
+```rust
+#[test]
+fn test_parse_pipelined_responses() {
+    let mut analyzer = HttpAnalyzer::new();
+    let fk = test_flow_key();
+
+    // Two requests
+    let requests = b"GET /a HTTP/1.1\r\nHost: x.com\r\n\r\nGET /b HTTP/1.1\r\nHost: x.com\r\n\r\n";
+    analyzer.on_data(&fk, Direction::ClientToServer, requests, 0);
+
+    // Two responses
+    let responses = b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\nHTTP/1.1 404 Not Found\r\nContent-Length: 0\r\n\r\n";
+    analyzer.on_data(&fk, Direction::ServerToClient, responses, 0);
+
+    assert_eq!(*analyzer.status_code_counts().get(&200).unwrap(), 1);
+    assert_eq!(*analyzer.status_code_counts().get(&404).unwrap(), 1);
+    assert_eq!(analyzer.transaction_count(), 2);
+}
+```
+
+- [ ] **Step 3: Implement response parsing**
+
+In `src/analyzer/http.rs`, add a free function:
+
+```rust
+struct ParsedResponse {
+    bytes_consumed: usize,
+    status_code: u16,
+}
+
+fn parse_one_response(buf: &[u8]) -> Result<Option<ParsedResponse>, ()> {
+    let mut headers = [httparse::EMPTY_HEADER; MAX_HEADERS];
+    let mut resp = httparse::Response::new(&mut headers);
+    match resp.parse(buf) {
+        Ok(httparse::Status::Complete(n)) => Ok(Some(ParsedResponse {
+            bytes_consumed: n,
+            status_code: resp.code.unwrap_or(0),
+        })),
+        Ok(httparse::Status::Partial) => Ok(None),
+        Err(_) => Err(()),
+    }
+}
+```
+
+Add a private method for the response parsing loop:
+
+```rust
+fn try_parse_responses(&mut self, flow_key: &FlowKey) {
+    loop {
+        let result = self
+            .flows
+            .get(flow_key)
+            .filter(|s| !s.response_buf.is_empty())
+            .map(|s| parse_one_response(&s.response_buf));
+
+        match result {
+            Some(Ok(Some(parsed))) => {
+                *self.status_codes.entry(parsed.status_code).or_insert(0) += 1;
+                self.transactions += 1;
+
+                if let Some(state) = self.flows.get_mut(flow_key) {
+                    state.pending_method = None;
+                    state.response_buf.drain(..parsed.bytes_consumed);
+                }
+            }
+            Some(Ok(None)) => return,
+            Some(Err(())) => {
+                if let Some(state) = self.flows.get_mut(flow_key) {
+                    state.response_buf.clear();
+                }
+                return;
+            }
+            None => return,
+        }
+    }
+}
+```
+
+Update the `on_data` match for `ServerToClient`. Change:
+
+```rust
+Direction::ServerToClient => {} // Task 3
+```
+
+to:
+
+```rust
+Direction::ServerToClient => self.try_parse_responses(flow_key),
+```
+
+- [ ] **Step 4: Run all tests**
+
+Run: `cargo test --test http_analyzer_tests`
+Expected: All 6 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/analyzer/http.rs tests/http_analyzer_tests.rs
+git commit -m "feat: parse HTTP/1.x responses and track request-response transactions"
+```
+
+---
+
+### Task 4: Detection Rules
+
+**Files:**
+- Modify: `src/analyzer/http.rs`
+- Modify: `tests/http_analyzer_tests.rs`
+
+- [ ] **Step 1: Write detection tests**
+
+Add to `tests/http_analyzer_tests.rs`:
+
+```rust
+use wirerust::findings::{Confidence, ThreatCategory, Verdict};
+
+#[test]
+fn test_detect_path_traversal() {
+    let mut analyzer = HttpAnalyzer::new();
+    let fk = test_flow_key();
+
+    let request = b"GET /../../etc/passwd HTTP/1.1\r\nHost: target.com\r\n\r\n";
+    analyzer.on_data(&fk, Direction::ClientToServer, request, 0);
+
+    let findings = analyzer.findings();
+    assert_eq!(findings.len(), 1);
+    assert_eq!(findings[0].category, ThreatCategory::Reconnaissance);
+    assert_eq!(findings[0].verdict, Verdict::Likely);
+    assert_eq!(findings[0].confidence, Confidence::High);
+}
+
+#[test]
+fn test_detect_encoded_traversal() {
+    let mut analyzer = HttpAnalyzer::new();
+    let fk = test_flow_key();
+
+    let request = b"GET /..%2f..%2fetc/passwd HTTP/1.1\r\nHost: target.com\r\n\r\n";
+    analyzer.on_data(&fk, Direction::ClientToServer, request, 0);
+
+    let findings = analyzer.findings();
+    assert!(!findings.is_empty(), "Should detect encoded path traversal");
+}
+
+#[test]
+fn test_detect_webshell_path() {
+    let mut analyzer = HttpAnalyzer::new();
+    let fk = test_flow_key();
+
+    let request = b"GET /uploads/shell.php HTTP/1.1\r\nHost: target.com\r\n\r\n";
+    analyzer.on_data(&fk, Direction::ClientToServer, request, 0);
+
+    let findings = analyzer.findings();
+    assert_eq!(findings.len(), 1);
+    assert_eq!(findings[0].category, ThreatCategory::Execution);
+}
+
+#[test]
+fn test_detect_unusual_method() {
+    let mut analyzer = HttpAnalyzer::new();
+    let fk = test_flow_key();
+
+    let request = b"CONNECT proxy.example.com:443 HTTP/1.1\r\nHost: proxy.example.com\r\n\r\n";
+    analyzer.on_data(&fk, Direction::ClientToServer, request, 0);
+
+    let findings = analyzer.findings();
+    assert_eq!(findings.len(), 1);
+    assert_eq!(findings[0].category, ThreatCategory::Reconnaissance);
+}
+
+#[test]
+fn test_detect_missing_host_header() {
+    let mut analyzer = HttpAnalyzer::new();
+    let fk = test_flow_key();
+
+    // HTTP/1.1 without Host header
+    let request = b"GET /path HTTP/1.1\r\n\r\n";
+    analyzer.on_data(&fk, Direction::ClientToServer, request, 0);
+
+    let findings = analyzer.findings();
+    assert!(
+        findings.iter().any(|f| f.category == ThreatCategory::Anomaly),
+        "Should detect missing Host header"
+    );
+}
+
+#[test]
+fn test_no_findings_for_normal_request() {
+    let mut analyzer = HttpAnalyzer::new();
+    let fk = test_flow_key();
+
+    let request = b"GET /index.html HTTP/1.1\r\nHost: example.com\r\nUser-Agent: Mozilla/5.0\r\n\r\n";
+    analyzer.on_data(&fk, Direction::ClientToServer, request, 0);
+
+    assert!(analyzer.findings().is_empty(), "Normal request should produce no findings");
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test --test http_analyzer_tests test_detect`
+Expected: FAIL — findings are always empty.
+
+- [ ] **Step 3: Implement detection rules**
+
+In `src/analyzer/http.rs`, add the detection method to `impl HttpAnalyzer`:
+
+```rust
+fn check_request_detections(&mut self, parsed: &ParsedRequest, flow_key: &FlowKey) {
+    let uri_lower = parsed.uri.to_lowercase();
+
+    // Path traversal (including URL-encoded variants)
+    if uri_lower.contains("../")
+        || uri_lower.contains("..%2f")
+        || uri_lower.contains("..%252f")
+        || uri_lower.contains("....//")
+    {
+        self.all_findings.push(Finding {
+            category: ThreatCategory::Reconnaissance,
+            verdict: Verdict::Likely,
+            confidence: Confidence::High,
+            summary: format!("Path traversal in URI: {}", truncate_uri(&parsed.uri, 120)),
+            evidence: vec![format!("URI: {}", parsed.uri)],
+            mitre_technique: Some("T1083".to_string()),
+            source_ip: None,
+            timestamp: None,
+        });
+    }
+
+    // Web shell paths
+    let shell_patterns = ["/shell", "/cmd", "/c99", "/r57", "/webshell", "/backdoor"];
+    if shell_patterns.iter().any(|p| uri_lower.contains(p)) {
+        self.all_findings.push(Finding {
+            category: ThreatCategory::Execution,
+            verdict: Verdict::Likely,
+            confidence: Confidence::Medium,
+            summary: format!("Possible web shell access: {}", truncate_uri(&parsed.uri, 120)),
+            evidence: vec![format!("URI: {}", parsed.uri)],
+            mitre_technique: Some("T1505.003".to_string()),
+            source_ip: None,
+            timestamp: None,
+        });
+    }
+
+    // Admin panel paths
+    let admin_patterns = ["/wp-admin", "/admin", "/phpmyadmin", "/manager"];
+    if admin_patterns.iter().any(|p| uri_lower.contains(p)) {
+        self.all_findings.push(Finding {
+            category: ThreatCategory::Reconnaissance,
+            verdict: Verdict::Inconclusive,
+            confidence: Confidence::Low,
+            summary: format!("Admin panel access: {}", truncate_uri(&parsed.uri, 120)),
+            evidence: vec![format!("URI: {}", parsed.uri)],
+            mitre_technique: Some("T1046".to_string()),
+            source_ip: None,
+            timestamp: None,
+        });
+    }
+
+    // Unusual HTTP methods
+    let unusual_methods = ["CONNECT", "TRACE", "DELETE", "OPTIONS"];
+    if unusual_methods.contains(&parsed.method.as_str()) {
+        self.all_findings.push(Finding {
+            category: ThreatCategory::Reconnaissance,
+            verdict: Verdict::Inconclusive,
+            confidence: Confidence::Medium,
+            summary: format!("Unusual HTTP method: {}", parsed.method),
+            evidence: vec![format!("{} {}", parsed.method, parsed.uri)],
+            mitre_technique: None,
+            source_ip: None,
+            timestamp: None,
+        });
+    }
+
+    // Missing Host header (HTTP/1.1 requires it)
+    if parsed.version == 1 && parsed.host.is_none() {
+        self.all_findings.push(Finding {
+            category: ThreatCategory::Anomaly,
+            verdict: Verdict::Inconclusive,
+            confidence: Confidence::Medium,
+            summary: "HTTP/1.1 request without Host header".to_string(),
+            evidence: vec![format!("{} {}", parsed.method, parsed.uri)],
+            mitre_technique: None,
+            source_ip: None,
+            timestamp: None,
+        });
+    }
+
+    // Long URI (> 2048 chars)
+    if parsed.uri.len() > 2048 {
+        self.all_findings.push(Finding {
+            category: ThreatCategory::Execution,
+            verdict: Verdict::Likely,
+            confidence: Confidence::Medium,
+            summary: format!("Abnormally long URI ({} chars)", parsed.uri.len()),
+            evidence: vec![format!("URI prefix: {}", truncate_uri(&parsed.uri, 200))],
+            mitre_technique: None,
+            source_ip: None,
+            timestamp: None,
+        });
+    }
+
+    // Empty User-Agent
+    if parsed.user_agent.as_deref() == Some("") {
+        self.all_findings.push(Finding {
+            category: ThreatCategory::Anomaly,
+            verdict: Verdict::Inconclusive,
+            confidence: Confidence::Low,
+            summary: "Empty User-Agent header".to_string(),
+            evidence: vec![format!("{} {}", parsed.method, parsed.uri)],
+            mitre_technique: None,
+            source_ip: None,
+            timestamp: None,
+        });
+    }
+}
+```
+
+Add the helper function outside the impl blocks:
+
+```rust
+fn truncate_uri(uri: &str, max_len: usize) -> &str {
+    if uri.len() <= max_len {
+        uri
+    } else {
+        &uri[..max_len]
+    }
+}
+```
+
+Now integrate detection into `try_parse_requests`. In the `Some(Ok(Some(parsed)))` arm, after the URI is pushed to `self.uris` and before the flow state update, add:
+
+```rust
+self.check_request_detections(&parsed, flow_key);
+```
+
+But wait — `parsed` is moved when we access its fields above. We need to restructure. Change the `Some(Ok(Some(parsed)))` arm to pass `&parsed` to detection before consuming fields. The full arm becomes:
+
+```rust
+Some(Ok(Some(parsed))) => {
+    *self.methods.entry(parsed.method.clone()).or_insert(0) += 1;
+    if let Some(ref h) = parsed.host {
+        *self.hosts.entry(h.clone()).or_insert(0) += 1;
+    }
+    if let Some(ref ua) = parsed.user_agent {
+        *self.user_agents.entry(ua.clone()).or_insert(0) += 1;
+    }
+    if self.uris.len() < MAX_URIS {
+        self.uris.push(parsed.uri.clone());
+    }
+
+    self.check_request_detections(&parsed, flow_key);
+
+    if let Some(state) = self.flows.get_mut(flow_key) {
+        state.pending_method = Some(parsed.method);
+        state.request_buf.drain(..parsed.bytes_consumed);
+    }
+}
+```
+
+- [ ] **Step 4: Add Finding imports to test file**
+
+At the top of `tests/http_analyzer_tests.rs`, ensure these imports exist:
+
+```rust
+use wirerust::analyzer::http::HttpAnalyzer;
+use wirerust::findings::{Confidence, ThreatCategory, Verdict};
+use wirerust::reassembly::flow::FlowKey;
+use wirerust::reassembly::handler::{Direction, StreamHandler};
+use std::net::IpAddr;
+```
+
+- [ ] **Step 5: Run all tests**
+
+Run: `cargo test --test http_analyzer_tests`
+Expected: All 12 tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/analyzer/http.rs tests/http_analyzer_tests.rs
+git commit -m "feat: add HTTP forensics detection rules (traversal, webshell, methods, anomalies)"
+```
+
+---
+
+### Task 5: Summary Output
+
+**Files:**
+- Modify: `src/analyzer/http.rs`
+- Modify: `tests/http_analyzer_tests.rs`
+
+- [ ] **Step 1: Write test for summary output**
+
+Add to `tests/http_analyzer_tests.rs`:
+
+```rust
+use wirerust::reassembly::handler::{CloseReason, StreamAnalyzer};
+
+#[test]
+fn test_summarize_produces_complete_output() {
+    let mut analyzer = HttpAnalyzer::new();
+    let fk = test_flow_key();
+
+    let request = b"GET /page HTTP/1.1\r\nHost: example.com\r\nUser-Agent: TestBot\r\n\r\n";
+    analyzer.on_data(&fk, Direction::ClientToServer, request, 0);
+
+    let response = b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n";
+    analyzer.on_data(&fk, Direction::ServerToClient, response, 0);
+
+    let summary = analyzer.summarize();
+    assert_eq!(summary.analyzer_name, "HTTP");
+    assert_eq!(summary.packets_analyzed, 1); // 1 transaction
+
+    let detail = &summary.detail;
+    assert_eq!(detail["transactions"], 1);
+    assert_eq!(detail["methods"]["GET"], 1);
+    assert_eq!(detail["status_codes"]["200"], 1);
+    assert!(detail["top_hosts"].as_array().unwrap().contains(&serde_json::json!("example.com")));
+    assert!(detail["user_agents"]["TestBot"].as_u64().unwrap() == 1);
+}
+
+#[test]
+fn test_flow_close_cleans_up_state() {
+    let mut analyzer = HttpAnalyzer::new();
+    let fk = test_flow_key();
+
+    let request = b"GET / HTTP/1.1\r\nHost: x.com\r\n\r\n";
+    analyzer.on_data(&fk, Direction::ClientToServer, request, 0);
+    analyzer.on_flow_close(&fk, CloseReason::Fin);
+
+    // After close, new data on same flow starts fresh
+    analyzer.on_data(&fk, Direction::ClientToServer, b"GET /new HTTP/1.1\r\nHost: y.com\r\n\r\n", 0);
+    assert_eq!(*analyzer.method_counts().get("GET").unwrap(), 2);
+    assert_eq!(*analyzer.host_counts().get("y.com").unwrap(), 1);
+}
+```
+
+- [ ] **Step 2: Implement the full summarize method**
+
+In `src/analyzer/http.rs`, replace the `summarize` method in the `StreamAnalyzer` impl:
+
+```rust
+fn summarize(&self) -> AnalysisSummary {
+    let mut detail = HashMap::new();
+
+    detail.insert(
+        "transactions".to_string(),
+        serde_json::json!(self.transactions),
+    );
+    detail.insert("methods".to_string(), serde_json::json!(self.methods));
+    detail.insert(
+        "status_codes".to_string(),
+        serde_json::json!(
+            self.status_codes
+                .iter()
+                .map(|(k, v)| (k.to_string(), *v))
+                .collect::<HashMap<String, u64>>()
+        ),
+    );
+
+    // Top hosts (up to 20)
+    let mut top_hosts: Vec<_> = self.hosts.iter().collect();
+    top_hosts.sort_by(|a, b| b.1.cmp(a.1));
+    let top_hosts: Vec<&str> = top_hosts.iter().take(20).map(|(k, _)| k.as_str()).collect();
+    detail.insert("top_hosts".to_string(), serde_json::json!(top_hosts));
+
+    // Top URIs (up to 20)
+    let top_uris: Vec<&str> = self.uris.iter().take(20).map(|s| s.as_str()).collect();
+    detail.insert("top_uris".to_string(), serde_json::json!(top_uris));
+
+    detail.insert(
+        "user_agents".to_string(),
+        serde_json::json!(self.user_agents),
+    );
+
+    AnalysisSummary {
+        analyzer_name: self.name().to_string(),
+        packets_analyzed: self.transactions,
+        detail,
+    }
+}
+```
+
+- [ ] **Step 3: Run all tests**
+
+Run: `cargo test --test http_analyzer_tests`
+Expected: All 14 tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/analyzer/http.rs tests/http_analyzer_tests.rs
+git commit -m "feat: add HTTP analyzer summary with methods, status codes, hosts, user-agents"
+```
+
+---
+
+### Task 6: Wire Up main.rs + Integration Test
+
+**Files:**
+- Modify: `src/main.rs`
+- Create: `tests/http_integration_tests.rs`
+
+- [ ] **Step 1: Write integration test**
+
+Create `tests/http_integration_tests.rs`:
+
+```rust
+use std::io::Cursor;
+
+use wirerust::analyzer::http::HttpAnalyzer;
+use wirerust::decoder::decode_packet;
+use wirerust::reader::PcapSource;
+use wirerust::reassembly::handler::StreamAnalyzer;
+use wirerust::reassembly::{ReassemblyConfig, TcpReassembler};
+
+#[test]
+fn test_http_analysis_with_fixture() {
+    let source =
+        PcapSource::from_file(std::path::Path::new("tests/fixtures/http-full.cap")).unwrap();
+
+    let config = ReassemblyConfig::default();
+    let mut reassembler = TcpReassembler::new(config);
+    let mut http_analyzer = HttpAnalyzer::new();
+
+    for raw in &source.packets {
+        if let Ok(parsed) = decode_packet(&raw.data, source.datalink) {
+            reassembler.process_packet(&parsed, raw.timestamp_secs, &mut http_analyzer);
+        }
+    }
+    reassembler.finalize(&mut http_analyzer);
+
+    let summary = http_analyzer.summarize();
+    assert_eq!(summary.analyzer_name, "HTTP");
+
+    // http-full.cap should have at least some HTTP transactions
+    assert!(
+        http_analyzer.transaction_count() > 0,
+        "Expected HTTP transactions from http-full.cap, got 0"
+    );
+
+    // Should have at least one GET method
+    assert!(
+        http_analyzer.method_counts().contains_key("GET"),
+        "Expected GET requests in http-full.cap"
+    );
+}
+```
+
+- [ ] **Step 2: Run integration test to verify it passes**
+
+Run: `cargo test --test http_integration_tests`
+Expected: PASS (HttpAnalyzer receives stream data from reassembly engine).
+
+- [ ] **Step 3: Wire up main.rs**
+
+In `src/main.rs`, make these changes:
+
+**Add import** at the top (after the dns import):
+
+```rust
+use wirerust::analyzer::http::HttpAnalyzer;
+use wirerust::reassembly::handler::StreamAnalyzer;
+```
+
+**Update the `Commands::Analyze` match** to extract `http`:
+
+Change:
+
+```rust
+Commands::Analyze {
+    targets, dns, all, ..
+} => {
+    run_analyze(targets, *dns || *all, use_color, &cli)?;
+}
+```
+
+to:
+
+```rust
+Commands::Analyze {
+    targets, dns, http, all, ..
+} => {
+    run_analyze(targets, *dns || *all, *http || *all, use_color, &cli)?;
+}
+```
+
+**Update `run_analyze` signature** to accept `enable_http`:
+
+```rust
+fn run_analyze(
+    targets: &[std::path::PathBuf],
+    enable_dns: bool,
+    enable_http: bool,
+    use_color: bool,
+    cli: &Cli,
+) -> Result<()> {
+```
+
+**Update the reassembly decision** — change:
+
+```rust
+let needs_reassembly = cli.reassemble; // Will expand when HTTP/TLS analyzers added
+```
+
+to:
+
+```rust
+let needs_reassembly = cli.reassemble || enable_http;
+```
+
+**Replace NullHandler with conditional HttpAnalyzer** — replace:
+
+```rust
+struct NullHandler;
+impl StreamHandler for NullHandler {
+    fn on_data(&mut self, _: &FlowKey, _: Direction, _: &[u8], _: u64) {}
+    fn on_flow_close(&mut self, _: &FlowKey, _: CloseReason) {}
+}
+let mut stream_handler = NullHandler;
+```
+
+with:
+
+```rust
+struct NullHandler;
+impl StreamHandler for NullHandler {
+    fn on_data(&mut self, _: &FlowKey, _: Direction, _: &[u8], _: u64) {}
+    fn on_flow_close(&mut self, _: &FlowKey, _: CloseReason) {}
+}
+let mut null_handler = NullHandler;
+let mut http_analyzer = if enable_http && !skip_reassembly {
+    Some(HttpAnalyzer::new())
+} else {
+    None
+};
+```
+
+**Update process_packet call** — change:
+
+```rust
+if let Some(ref mut reasm) = reassembler {
+    reasm.process_packet(&parsed, raw.timestamp_secs, &mut stream_handler);
+}
+```
+
+to:
+
+```rust
+if let Some(ref mut reasm) = reassembler {
+    match http_analyzer {
+        Some(ref mut http) => {
+            reasm.process_packet(&parsed, raw.timestamp_secs, http);
+        }
+        None => {
+            reasm.process_packet(&parsed, raw.timestamp_secs, &mut null_handler);
+        }
+    }
+}
+```
+
+**Update finalize call** — change:
+
+```rust
+if let Some(ref mut reasm) = reassembler {
+    reasm.finalize(&mut stream_handler);
+    all_findings.extend(reasm.findings().to_vec());
+}
+```
+
+to:
+
+```rust
+if let Some(ref mut reasm) = reassembler {
+    match http_analyzer {
+        Some(ref mut http) => {
+            reasm.finalize(http);
+            all_findings.extend(http.findings());
+        }
+        None => {
+            reasm.finalize(&mut null_handler);
+        }
+    }
+    all_findings.extend(reasm.findings().to_vec());
+}
+```
+
+**Update analyzer_summaries** — change:
+
+```rust
+let analyzer_summaries = if enable_dns {
+    vec![dns_analyzer.summarize()]
+} else {
+    vec![]
+};
+```
+
+to:
+
+```rust
+let mut analyzer_summaries = Vec::new();
+if enable_dns {
+    analyzer_summaries.push(dns_analyzer.summarize());
+}
+if let Some(ref http) = http_analyzer {
+    analyzer_summaries.push(http.summarize());
+}
+```
+
+- [ ] **Step 4: Run full test suite**
+
+Run: `cargo test`
+Expected: All tests pass.
+
+Run: `cargo clippy -- -D warnings`
+Expected: Clean.
+
+Run: `cargo fmt --check`
+Expected: Clean (run `cargo fmt` if not).
+
+- [ ] **Step 5: Smoke test with fixture**
+
+Run: `cargo run -- analyze tests/fixtures/http-full.cap --http`
+Expected: Should show HTTP analyzer output with transactions, methods, status codes.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/main.rs tests/http_integration_tests.rs
+git commit -m "feat: wire up --http flag with auto-reassembly and HttpAnalyzer"
+```

--- a/docs/superpowers/specs/2026-04-06-http-analyzer-design.md
+++ b/docs/superpowers/specs/2026-04-06-http-analyzer-design.md
@@ -1,0 +1,154 @@
+# HTTP Traffic Analyzer Design
+
+**Issue:** #1 — Add HTTP traffic analyzer
+**Scope:** Stream-level HTTP/1.x analysis using the TCP reassembly engine with `httparse`.
+
+## Problem
+
+wirerust has no HTTP analysis capability. The `--http` flag exists in the CLI but does nothing. HTTP is the most common application protocol in forensics captures and the first thing analysts look for during incident response.
+
+## Approach
+
+Stream-level analysis via the `StreamAnalyzer` trait and TCP reassembly engine, not per-packet inspection. Industry standard tools (Wireshark, Zeek, Suricata) all use TCP stream reassembly for HTTP because headers frequently span multiple TCP segments (~30-40% of real-world requests).
+
+The `httparse` crate (v1.10.1) provides zero-allocation push parsing of HTTP/1.x requests and responses from raw bytes, with `Status::Partial`/`Status::Complete(n)` for incremental stream processing.
+
+## Architecture
+
+### HttpAnalyzer (`src/analyzer/http.rs`)
+
+Implements `StreamAnalyzer` (which extends `StreamHandler`). Receives reassembled TCP byte streams from the reassembly engine and parses HTTP/1.x transactions.
+
+**Stream callbacks:**
+- `on_data(flow_key, ClientToServer, data, offset)` — append to per-flow request buffer, parse requests
+- `on_data(flow_key, ServerToClient, data, offset)` — append to per-flow response buffer, parse responses
+- `on_flow_close(flow_key, reason)` — clean up per-flow state
+
+**Parsing uses `httparse`:**
+- `httparse::Request::new(&mut headers).parse(&buf)` for requests
+- `httparse::Response::new(&mut headers).parse(&buf)` for responses
+- After `Status::Complete(n)`, drain `n` bytes and parse again (handles HTTP pipelining)
+- `Status::Partial` means wait for more data
+- Pre-allocate 96-element header arrays (covers real-world HTTP; `Status::Partial` returned if exceeded)
+
+### Per-Flow State
+
+`HashMap<FlowKey, HttpFlowState>` where each flow tracks:
+- `request_buf: Vec<u8>` — accumulates client→server bytes until a complete request header is parsed
+- `response_buf: Vec<u8>` — accumulates server→client bytes
+- `pending_method: Option<String>` — last request method, to pair with response
+
+**Buffer cap:** 64KB per direction per flow. HTTP headers exceeding 64KB are themselves anomalous and are skipped rather than buffered indefinitely.
+
+### CLI Wiring
+
+Auto-enable reassembly when `--http` (or `--all`) is passed. In `run_analyze()`:
+
+```
+let needs_reassembly = cli.reassemble || enable_http;  // was: cli.reassemble only
+```
+
+`NullHandler` is replaced with `HttpAnalyzer` when HTTP analysis is enabled. After processing:
+- `http_analyzer.findings()` feeds into `all_findings`
+- `http_analyzer.summarize()` feeds into `analyzer_summaries`
+
+No new CLI flags needed — `--http` already exists in `Commands::Analyze`.
+
+If `--no-reassemble` is explicitly passed alongside `--http`, reassembly is skipped and HTTP analysis is silently disabled (reassembly is required for stream-level parsing).
+
+## Data Flow
+
+```
+Reassembly Engine
+  → on_data(flow_key, direction, data, offset)
+    → HttpAnalyzer
+      ├── direction == ClientToServer:
+      │   append to request_buf
+      │   loop: httparse::Request::parse(&request_buf)
+      │     Complete(n) → extract method, uri, version, headers
+      │                  → store pending_method for response pairing
+      │                  → check detection rules → generate findings
+      │                  → update summary counters
+      │                  → drain n bytes, continue loop
+      │     Partial → break, wait for more data
+      │
+      └── direction == ServerToClient:
+          append to response_buf
+          loop: httparse::Response::parse(&response_buf)
+            Complete(n) → extract status_code, reason, headers
+                        → pair with pending_method
+                        → update summary counters
+                        → drain n bytes, continue loop
+            Partial → break, wait for more data
+
+  → on_flow_close(flow_key, reason)
+    → remove flow state from HashMap
+```
+
+## Detection Rules
+
+Each produces a `Finding` with the listed severity. Conservative by design — forensics tools surface indicators, analysts decide.
+
+| Pattern | Category | Verdict | Confidence | Details |
+|---------|----------|---------|------------|---------|
+| Path traversal (`../`, `..%2f`, `..%252f`, `....//`) | Reconnaissance | Likely | High | URI decoded and checked |
+| Web shell paths (`/shell`, `/cmd`, `/c99`, `/r57`, `/webshell`, `/backdoor`) | Execution | Likely | Medium | Substring match on URI |
+| Admin panel paths (`/wp-admin`, `/admin`, `/phpmyadmin`, `/manager`) | Reconnaissance | Inconclusive | Low | Common scan targets |
+| Unusual methods (CONNECT, TRACE, DELETE, OPTIONS) | Reconnaissance | Inconclusive | Medium | Rarely seen in normal traffic |
+| Missing Host header (HTTP/1.1) | Anomaly | Inconclusive | Medium | Violates HTTP/1.1 spec, common in exploits |
+| Long URI (> 2048 chars) | Execution | Likely | Medium | Buffer overflow / fuzzing indicator |
+| Empty User-Agent | Anomaly | Inconclusive | Low | Scripts and tools often omit it |
+
+## Summary Output
+
+After all packets are processed, `HttpAnalyzer::summarize()` returns:
+
+```json
+{
+  "analyzer_name": "HTTP",
+  "packets_analyzed": 142,
+  "detail": {
+    "transactions": 42,
+    "methods": {"GET": 35, "POST": 7},
+    "status_codes": {"200": 30, "404": 5, "301": 4, "500": 3},
+    "top_hosts": ["example.com", "api.target.com"],
+    "top_uris": ["/index.html", "/api/v1/users", "/login"],
+    "user_agents": {"Mozilla/5.0...": 35, "curl/7.68": 7}
+  }
+}
+```
+
+Terminal reporter displays this in the existing `ANALYZER: HTTP` section format.
+
+## Dependencies
+
+Add to `Cargo.toml`:
+```toml
+httparse = "1"
+```
+
+## Testing
+
+**Unit tests (crafted byte streams):**
+1. Parse simple GET request → verify method, URI, Host, User-Agent
+2. Parse HTTP response → verify status code, reason
+3. Pipelining: two requests in one buffer → both parsed correctly
+4. Partial data: incomplete request → no crash, waits for more
+5. Buffer cap: 64KB+ headers → skipped gracefully
+6. Detection: URI with `../` → path traversal Finding generated
+7. Detection: CONNECT method → unusual method Finding generated
+8. Detection: missing Host header → Finding generated
+9. Summary counters: methods, status codes, hosts all tracked
+
+**Integration test:**
+- `http-full.cap` fixture — verify HttpAnalyzer produces transactions and summary with methods/status codes
+
+**Existing tests unaffected** — `NullHandler` path still works when `--http` is not passed.
+
+## Not In Scope
+
+- **HTTP/2 or HTTP/3** — different wire format, separate analyzer
+- **Response body parsing** — track Content-Length for size, don't parse body content
+- **File extraction/carving** — future feature (`--carve` flag like pcapper)
+- **TLS decryption** — requires keylog file, separate feature
+- **Chunked body decoding** — httparse detects Transfer-Encoding header; body decoding deferred

--- a/src/analyzer/http.rs
+++ b/src/analyzer/http.rs
@@ -1,5 +1,7 @@
 use std::collections::HashMap;
 
+use serde_json;
+
 use crate::analyzer::AnalysisSummary;
 use crate::findings::{Confidence, Finding, ThreatCategory, Verdict};
 use crate::reassembly::flow::FlowKey;
@@ -356,10 +358,40 @@ impl StreamAnalyzer for HttpAnalyzer {
     }
 
     fn summarize(&self) -> AnalysisSummary {
+        let mut detail = HashMap::new();
+
+        detail.insert(
+            "transactions".to_string(),
+            serde_json::json!(self.transactions),
+        );
+        detail.insert("methods".to_string(), serde_json::json!(self.methods));
+        detail.insert(
+            "status_codes".to_string(),
+            serde_json::json!(
+                self.status_codes
+                    .iter()
+                    .map(|(k, v)| (k.to_string(), *v))
+                    .collect::<HashMap<String, u64>>()
+            ),
+        );
+
+        let mut top_hosts: Vec<_> = self.hosts.iter().collect();
+        top_hosts.sort_by(|a, b| b.1.cmp(a.1));
+        let top_hosts: Vec<&str> = top_hosts.iter().take(20).map(|(k, _)| k.as_str()).collect();
+        detail.insert("top_hosts".to_string(), serde_json::json!(top_hosts));
+
+        let top_uris: Vec<&str> = self.uris.iter().take(20).map(|s| s.as_str()).collect();
+        detail.insert("top_uris".to_string(), serde_json::json!(top_uris));
+
+        detail.insert(
+            "user_agents".to_string(),
+            serde_json::json!(self.user_agents),
+        );
+
         AnalysisSummary {
             analyzer_name: self.name().to_string(),
             packets_analyzed: self.transactions,
-            detail: HashMap::new(), // Populated in Task 5
+            detail,
         }
     }
 

--- a/src/analyzer/http.rs
+++ b/src/analyzer/http.rs
@@ -58,7 +58,7 @@ fn find_header(headers: &[httparse::Header<'_>], name: &str) -> Option<String> {
     headers
         .iter()
         .find(|h| h.name.eq_ignore_ascii_case(name))
-        .map(|h| String::from_utf8_lossy(h.value).to_string())
+        .map(|h| String::from_utf8_lossy(h.value).trim().to_string())
 }
 
 struct HttpFlowState {
@@ -404,8 +404,8 @@ impl StreamAnalyzer for HttpAnalyzer {
         let top_hosts: Vec<&str> = top_hosts.iter().take(20).map(|(k, _)| k.as_str()).collect();
         detail.insert("top_hosts".to_string(), serde_json::json!(top_hosts));
 
-        let top_uris: Vec<&str> = self.uris.iter().take(20).map(|s| s.as_str()).collect();
-        detail.insert("top_uris".to_string(), serde_json::json!(top_uris));
+        let recent_uris: Vec<&str> = self.uris.iter().take(20).map(|s| s.as_str()).collect();
+        detail.insert("recent_uris".to_string(), serde_json::json!(recent_uris));
 
         detail.insert(
             "user_agents".to_string(),

--- a/src/analyzer/http.rs
+++ b/src/analyzer/http.rs
@@ -35,6 +35,24 @@ fn parse_one_request(buf: &[u8]) -> Result<Option<ParsedRequest>, ()> {
     }
 }
 
+struct ParsedResponse {
+    bytes_consumed: usize,
+    status_code: u16,
+}
+
+fn parse_one_response(buf: &[u8]) -> Result<Option<ParsedResponse>, ()> {
+    let mut headers = [httparse::EMPTY_HEADER; MAX_HEADERS];
+    let mut resp = httparse::Response::new(&mut headers);
+    match resp.parse(buf) {
+        Ok(httparse::Status::Complete(n)) => Ok(Some(ParsedResponse {
+            bytes_consumed: n,
+            status_code: resp.code.unwrap_or(0),
+        })),
+        Ok(httparse::Status::Partial) => Ok(None),
+        Err(_) => Err(()),
+    }
+}
+
 fn find_header(headers: &[httparse::Header<'_>], name: &str) -> Option<String> {
     headers
         .iter()
@@ -144,6 +162,36 @@ impl HttpAnalyzer {
             }
         }
     }
+
+    fn try_parse_responses(&mut self, flow_key: &FlowKey) {
+        loop {
+            let result = self
+                .flows
+                .get(flow_key)
+                .filter(|s| !s.response_buf.is_empty())
+                .map(|s| parse_one_response(&s.response_buf));
+
+            match result {
+                Some(Ok(Some(parsed))) => {
+                    *self.status_codes.entry(parsed.status_code).or_insert(0) += 1;
+                    self.transactions += 1;
+
+                    if let Some(state) = self.flows.get_mut(flow_key) {
+                        state.pending_method = None;
+                        state.response_buf.drain(..parsed.bytes_consumed);
+                    }
+                }
+                Some(Ok(None)) => return,
+                Some(Err(())) => {
+                    if let Some(state) = self.flows.get_mut(flow_key) {
+                        state.response_buf.clear();
+                    }
+                    return;
+                }
+                None => return,
+            }
+        }
+    }
 }
 
 impl StreamHandler for HttpAnalyzer {
@@ -174,7 +222,7 @@ impl StreamHandler for HttpAnalyzer {
         }
         match direction {
             Direction::ClientToServer => self.try_parse_requests(flow_key),
-            Direction::ServerToClient => {} // Task 3
+            Direction::ServerToClient => self.try_parse_responses(flow_key),
         }
     }
 

--- a/src/analyzer/http.rs
+++ b/src/analyzer/http.rs
@@ -97,6 +97,12 @@ pub struct HttpAnalyzer {
     all_findings: Vec<Finding>,
 }
 
+impl Default for HttpAnalyzer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl HttpAnalyzer {
     pub fn new() -> Self {
         HttpAnalyzer {
@@ -163,7 +169,10 @@ impl HttpAnalyzer {
                 category: ThreatCategory::Execution,
                 verdict: Verdict::Likely,
                 confidence: Confidence::Medium,
-                summary: format!("Possible web shell access: {}", truncate_uri(&parsed.uri, 120)),
+                summary: format!(
+                    "Possible web shell access: {}",
+                    truncate_uri(&parsed.uri, 120)
+                ),
                 evidence: vec![format!("URI: {}", parsed.uri)],
                 mitre_technique: Some("T1505.003".to_string()),
                 source_ip: None,

--- a/src/analyzer/http.rs
+++ b/src/analyzer/http.rs
@@ -1,0 +1,108 @@
+use std::collections::HashMap;
+
+use crate::analyzer::AnalysisSummary;
+use crate::findings::Finding;
+use crate::reassembly::flow::FlowKey;
+use crate::reassembly::handler::{CloseReason, Direction, StreamAnalyzer, StreamHandler};
+
+const MAX_HEADER_BUF: usize = 65_536;
+const MAX_HEADERS: usize = 96;
+const MAX_URIS: usize = 10_000;
+
+struct HttpFlowState {
+    request_buf: Vec<u8>,
+    response_buf: Vec<u8>,
+    pending_method: Option<String>,
+}
+
+impl HttpFlowState {
+    fn new() -> Self {
+        HttpFlowState {
+            request_buf: Vec::new(),
+            response_buf: Vec::new(),
+            pending_method: None,
+        }
+    }
+}
+
+pub struct HttpAnalyzer {
+    flows: HashMap<FlowKey, HttpFlowState>,
+    methods: HashMap<String, u64>,
+    status_codes: HashMap<u16, u64>,
+    hosts: HashMap<String, u64>,
+    user_agents: HashMap<String, u64>,
+    uris: Vec<String>,
+    transactions: u64,
+    all_findings: Vec<Finding>,
+}
+
+impl HttpAnalyzer {
+    pub fn new() -> Self {
+        HttpAnalyzer {
+            flows: HashMap::new(),
+            methods: HashMap::new(),
+            status_codes: HashMap::new(),
+            hosts: HashMap::new(),
+            user_agents: HashMap::new(),
+            uris: Vec::new(),
+            transactions: 0,
+            all_findings: Vec::new(),
+        }
+    }
+
+    pub fn transaction_count(&self) -> u64 {
+        self.transactions
+    }
+}
+
+impl StreamHandler for HttpAnalyzer {
+    fn on_data(&mut self, flow_key: &FlowKey, direction: Direction, data: &[u8], _offset: u64) {
+        {
+            let state = self
+                .flows
+                .entry(flow_key.clone())
+                .or_insert_with(HttpFlowState::new);
+            match direction {
+                Direction::ClientToServer => {
+                    let remaining = MAX_HEADER_BUF.saturating_sub(state.request_buf.len());
+                    if remaining > 0 {
+                        state
+                            .request_buf
+                            .extend_from_slice(&data[..data.len().min(remaining)]);
+                    }
+                }
+                Direction::ServerToClient => {
+                    let remaining = MAX_HEADER_BUF.saturating_sub(state.response_buf.len());
+                    if remaining > 0 {
+                        state
+                            .response_buf
+                            .extend_from_slice(&data[..data.len().min(remaining)]);
+                    }
+                }
+            }
+        }
+        // Parsing will be added in Tasks 2 and 3
+    }
+
+    fn on_flow_close(&mut self, flow_key: &FlowKey, _reason: CloseReason) {
+        self.flows.remove(flow_key);
+    }
+}
+
+impl StreamAnalyzer for HttpAnalyzer {
+    fn name(&self) -> &'static str {
+        "HTTP"
+    }
+
+    fn summarize(&self) -> AnalysisSummary {
+        AnalysisSummary {
+            analyzer_name: self.name().to_string(),
+            packets_analyzed: self.transactions,
+            detail: HashMap::new(), // Populated in Task 5
+        }
+    }
+
+    fn findings(&self) -> Vec<Finding> {
+        self.all_findings.clone()
+    }
+}

--- a/src/analyzer/http.rs
+++ b/src/analyzer/http.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use crate::analyzer::AnalysisSummary;
-use crate::findings::Finding;
+use crate::findings::{Confidence, Finding, ThreatCategory, Verdict};
 use crate::reassembly::flow::FlowKey;
 use crate::reassembly::handler::{CloseReason, Direction, StreamAnalyzer, StreamHandler};
 
@@ -76,6 +76,14 @@ impl HttpFlowState {
     }
 }
 
+fn truncate_uri(uri: &str, max_len: usize) -> &str {
+    if uri.len() <= max_len {
+        uri
+    } else {
+        &uri[..max_len]
+    }
+}
+
 pub struct HttpAnalyzer {
     flows: HashMap<FlowKey, HttpFlowState>,
     methods: HashMap<String, u64>,
@@ -125,6 +133,115 @@ impl HttpAnalyzer {
         &self.status_codes
     }
 
+    fn check_request_detections(&mut self, parsed: &ParsedRequest, _flow_key: &FlowKey) {
+        let uri_lower = parsed.uri.to_lowercase();
+
+        // 1. Path traversal (including URL-encoded variants)
+        if uri_lower.contains("../")
+            || uri_lower.contains("..%2f")
+            || uri_lower.contains("..%252f")
+            || uri_lower.contains("....//")
+        {
+            self.all_findings.push(Finding {
+                category: ThreatCategory::Reconnaissance,
+                verdict: Verdict::Likely,
+                confidence: Confidence::High,
+                summary: format!("Path traversal in URI: {}", truncate_uri(&parsed.uri, 120)),
+                evidence: vec![format!("URI: {}", parsed.uri)],
+                mitre_technique: Some("T1083".to_string()),
+                source_ip: None,
+                timestamp: None,
+            });
+        }
+
+        // 2. Web shell paths
+        let shell_patterns = ["/shell", "/cmd", "/c99", "/r57", "/webshell", "/backdoor"];
+        if shell_patterns.iter().any(|p| uri_lower.contains(p)) {
+            self.all_findings.push(Finding {
+                category: ThreatCategory::Execution,
+                verdict: Verdict::Likely,
+                confidence: Confidence::Medium,
+                summary: format!("Possible web shell access: {}", truncate_uri(&parsed.uri, 120)),
+                evidence: vec![format!("URI: {}", parsed.uri)],
+                mitre_technique: Some("T1505.003".to_string()),
+                source_ip: None,
+                timestamp: None,
+            });
+        }
+
+        // 3. Admin panel paths
+        let admin_patterns = ["/wp-admin", "/admin", "/phpmyadmin", "/manager"];
+        if admin_patterns.iter().any(|p| uri_lower.contains(p)) {
+            self.all_findings.push(Finding {
+                category: ThreatCategory::Reconnaissance,
+                verdict: Verdict::Inconclusive,
+                confidence: Confidence::Low,
+                summary: format!("Admin panel access: {}", truncate_uri(&parsed.uri, 120)),
+                evidence: vec![format!("URI: {}", parsed.uri)],
+                mitre_technique: Some("T1046".to_string()),
+                source_ip: None,
+                timestamp: None,
+            });
+        }
+
+        // 4. Unusual HTTP methods
+        let unusual_methods = ["CONNECT", "TRACE", "DELETE", "OPTIONS"];
+        if unusual_methods.contains(&parsed.method.as_str()) {
+            self.all_findings.push(Finding {
+                category: ThreatCategory::Reconnaissance,
+                verdict: Verdict::Inconclusive,
+                confidence: Confidence::Medium,
+                summary: format!("Unusual HTTP method: {}", parsed.method),
+                evidence: vec![format!("{} {}", parsed.method, parsed.uri)],
+                mitre_technique: None,
+                source_ip: None,
+                timestamp: None,
+            });
+        }
+
+        // 5. Missing Host header (HTTP/1.1 requires it)
+        if parsed.version == 1 && parsed.host.is_none() {
+            self.all_findings.push(Finding {
+                category: ThreatCategory::Anomaly,
+                verdict: Verdict::Inconclusive,
+                confidence: Confidence::Medium,
+                summary: "HTTP/1.1 request without Host header".to_string(),
+                evidence: vec![format!("{} {}", parsed.method, parsed.uri)],
+                mitre_technique: None,
+                source_ip: None,
+                timestamp: None,
+            });
+        }
+
+        // 6. Long URI (> 2048 chars)
+        if parsed.uri.len() > 2048 {
+            self.all_findings.push(Finding {
+                category: ThreatCategory::Execution,
+                verdict: Verdict::Likely,
+                confidence: Confidence::Medium,
+                summary: format!("Abnormally long URI ({} chars)", parsed.uri.len()),
+                evidence: vec![format!("URI prefix: {}", truncate_uri(&parsed.uri, 200))],
+                mitre_technique: None,
+                source_ip: None,
+                timestamp: None,
+            });
+        }
+
+        // 7. Empty User-Agent
+        if parsed.user_agent.as_deref() == Some("") {
+            self.all_findings.push(Finding {
+                category: ThreatCategory::Anomaly,
+                verdict: Verdict::Inconclusive,
+                confidence: Confidence::Low,
+                summary: "Empty User-Agent header".to_string(),
+                evidence: vec![format!("{} {}", parsed.method, parsed.uri)],
+                mitre_technique: None,
+                source_ip: None,
+                timestamp: None,
+            });
+        }
+    }
+
     fn try_parse_requests(&mut self, flow_key: &FlowKey) {
         loop {
             let result = self
@@ -145,6 +262,8 @@ impl HttpAnalyzer {
                     if self.uris.len() < MAX_URIS {
                         self.uris.push(parsed.uri.clone());
                     }
+
+                    self.check_request_detections(&parsed, flow_key);
 
                     if let Some(state) = self.flows.get_mut(flow_key) {
                         state.pending_method = Some(parsed.method);

--- a/src/analyzer/http.rs
+++ b/src/analyzer/http.rs
@@ -1,7 +1,5 @@
 use std::collections::HashMap;
 
-use serde_json;
-
 use crate::analyzer::AnalysisSummary;
 use crate::findings::{Confidence, Finding, ThreatCategory, Verdict};
 use crate::reassembly::flow::FlowKey;
@@ -10,6 +8,7 @@ use crate::reassembly::handler::{CloseReason, Direction, StreamAnalyzer, StreamH
 const MAX_HEADER_BUF: usize = 65_536;
 const MAX_HEADERS: usize = 96;
 const MAX_URIS: usize = 10_000;
+const MAX_MAP_ENTRIES: usize = 50_000;
 
 struct ParsedRequest {
     bytes_consumed: usize,
@@ -65,7 +64,6 @@ fn find_header(headers: &[httparse::Header<'_>], name: &str) -> Option<String> {
 struct HttpFlowState {
     request_buf: Vec<u8>,
     response_buf: Vec<u8>,
-    pending_method: Option<String>,
 }
 
 impl HttpFlowState {
@@ -73,7 +71,6 @@ impl HttpFlowState {
         HttpFlowState {
             request_buf: Vec::new(),
             response_buf: Vec::new(),
-            pending_method: None,
         }
     }
 }
@@ -82,7 +79,7 @@ fn truncate_uri(uri: &str, max_len: usize) -> &str {
     if uri.len() <= max_len {
         uri
     } else {
-        &uri[..max_len]
+        &uri[..uri.floor_char_boundary(max_len)]
     }
 }
 
@@ -162,8 +159,19 @@ impl HttpAnalyzer {
             });
         }
 
-        // 2. Web shell paths
-        let shell_patterns = ["/shell", "/cmd", "/c99", "/r57", "/webshell", "/backdoor"];
+        // 2. Web shell paths (specific file extensions to reduce false positives)
+        let shell_patterns = [
+            "/shell.php",
+            "/shell.asp",
+            "/shell.jsp",
+            "/cmd.php",
+            "/cmd.asp",
+            "/cmd.jsp",
+            "/c99.php",
+            "/r57.php",
+            "/webshell",
+            "/backdoor",
+        ];
         if shell_patterns.iter().any(|p| uri_lower.contains(p)) {
             self.all_findings.push(Finding {
                 category: ThreatCategory::Execution,
@@ -263,11 +271,20 @@ impl HttpAnalyzer {
 
             match result {
                 Some(Ok(Some(parsed))) => {
-                    *self.methods.entry(parsed.method.clone()).or_insert(0) += 1;
-                    if let Some(ref h) = parsed.host {
+                    if self.methods.len() < MAX_MAP_ENTRIES
+                        || self.methods.contains_key(&parsed.method)
+                    {
+                        *self.methods.entry(parsed.method.clone()).or_insert(0) += 1;
+                    }
+                    if let Some(ref h) = parsed.host
+                        && (self.hosts.len() < MAX_MAP_ENTRIES || self.hosts.contains_key(h))
+                    {
                         *self.hosts.entry(h.clone()).or_insert(0) += 1;
                     }
-                    if let Some(ref ua) = parsed.user_agent {
+                    if let Some(ref ua) = parsed.user_agent
+                        && (self.user_agents.len() < MAX_MAP_ENTRIES
+                            || self.user_agents.contains_key(ua))
+                    {
                         *self.user_agents.entry(ua.clone()).or_insert(0) += 1;
                     }
                     if self.uris.len() < MAX_URIS {
@@ -277,7 +294,6 @@ impl HttpAnalyzer {
                     self.check_request_detections(&parsed, flow_key);
 
                     if let Some(state) = self.flows.get_mut(flow_key) {
-                        state.pending_method = Some(parsed.method);
                         state.request_buf.drain(..parsed.bytes_consumed);
                     }
                 }
@@ -307,7 +323,6 @@ impl HttpAnalyzer {
                     self.transactions += 1;
 
                     if let Some(state) = self.flows.get_mut(flow_key) {
-                        state.pending_method = None;
                         state.response_buf.drain(..parsed.bytes_consumed);
                     }
                 }

--- a/src/analyzer/http.rs
+++ b/src/analyzer/http.rs
@@ -9,6 +9,39 @@ const MAX_HEADER_BUF: usize = 65_536;
 const MAX_HEADERS: usize = 96;
 const MAX_URIS: usize = 10_000;
 
+struct ParsedRequest {
+    bytes_consumed: usize,
+    method: String,
+    uri: String,
+    version: u8,
+    host: Option<String>,
+    user_agent: Option<String>,
+}
+
+fn parse_one_request(buf: &[u8]) -> Result<Option<ParsedRequest>, ()> {
+    let mut headers = [httparse::EMPTY_HEADER; MAX_HEADERS];
+    let mut req = httparse::Request::new(&mut headers);
+    match req.parse(buf) {
+        Ok(httparse::Status::Complete(n)) => Ok(Some(ParsedRequest {
+            bytes_consumed: n,
+            method: req.method.unwrap_or("").to_string(),
+            uri: req.path.unwrap_or("").to_string(),
+            version: req.version.unwrap_or(1),
+            host: find_header(req.headers, "host"),
+            user_agent: find_header(req.headers, "user-agent"),
+        })),
+        Ok(httparse::Status::Partial) => Ok(None),
+        Err(_) => Err(()),
+    }
+}
+
+fn find_header(headers: &[httparse::Header<'_>], name: &str) -> Option<String> {
+    headers
+        .iter()
+        .find(|h| h.name.eq_ignore_ascii_case(name))
+        .map(|h| String::from_utf8_lossy(h.value).to_string())
+}
+
 struct HttpFlowState {
     request_buf: Vec<u8>,
     response_buf: Vec<u8>,
@@ -53,6 +86,64 @@ impl HttpAnalyzer {
     pub fn transaction_count(&self) -> u64 {
         self.transactions
     }
+
+    pub fn method_counts(&self) -> &HashMap<String, u64> {
+        &self.methods
+    }
+
+    pub fn host_counts(&self) -> &HashMap<String, u64> {
+        &self.hosts
+    }
+
+    pub fn user_agent_counts(&self) -> &HashMap<String, u64> {
+        &self.user_agents
+    }
+
+    pub fn uri_list(&self) -> &[String] {
+        &self.uris
+    }
+
+    pub fn status_code_counts(&self) -> &HashMap<u16, u64> {
+        &self.status_codes
+    }
+
+    fn try_parse_requests(&mut self, flow_key: &FlowKey) {
+        loop {
+            let result = self
+                .flows
+                .get(flow_key)
+                .filter(|s| !s.request_buf.is_empty())
+                .map(|s| parse_one_request(&s.request_buf));
+
+            match result {
+                Some(Ok(Some(parsed))) => {
+                    *self.methods.entry(parsed.method.clone()).or_insert(0) += 1;
+                    if let Some(ref h) = parsed.host {
+                        *self.hosts.entry(h.clone()).or_insert(0) += 1;
+                    }
+                    if let Some(ref ua) = parsed.user_agent {
+                        *self.user_agents.entry(ua.clone()).or_insert(0) += 1;
+                    }
+                    if self.uris.len() < MAX_URIS {
+                        self.uris.push(parsed.uri.clone());
+                    }
+
+                    if let Some(state) = self.flows.get_mut(flow_key) {
+                        state.pending_method = Some(parsed.method);
+                        state.request_buf.drain(..parsed.bytes_consumed);
+                    }
+                }
+                Some(Ok(None)) => return, // Partial — wait for more data
+                Some(Err(())) => {
+                    if let Some(state) = self.flows.get_mut(flow_key) {
+                        state.request_buf.clear();
+                    }
+                    return;
+                }
+                None => return,
+            }
+        }
+    }
 }
 
 impl StreamHandler for HttpAnalyzer {
@@ -81,7 +172,10 @@ impl StreamHandler for HttpAnalyzer {
                 }
             }
         }
-        // Parsing will be added in Tasks 2 and 3
+        match direction {
+            Direction::ClientToServer => self.try_parse_requests(flow_key),
+            Direction::ServerToClient => {} // Task 3
+        }
     }
 
     fn on_flow_close(&mut self, flow_key: &FlowKey, _reason: CloseReason) {

--- a/src/analyzer/mod.rs
+++ b/src/analyzer/mod.rs
@@ -1,4 +1,5 @@
 pub mod dns;
+pub mod http;
 
 use std::collections::HashMap;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,10 +6,12 @@ use indicatif::{ProgressBar, ProgressStyle};
 
 use wirerust::analyzer::ProtocolAnalyzer;
 use wirerust::analyzer::dns::DnsAnalyzer;
+use wirerust::analyzer::http::HttpAnalyzer;
 use wirerust::cli::{Cli, Commands, OutputFormat};
 use wirerust::decoder::decode_packet;
 use wirerust::reader::PcapSource;
 use wirerust::reassembly::flow::FlowKey;
+use wirerust::reassembly::handler::StreamAnalyzer;
 use wirerust::reassembly::handler::{CloseReason, Direction, StreamHandler};
 use wirerust::reassembly::{ReassemblyConfig, TcpReassembler};
 use wirerust::reporter::Reporter;
@@ -24,9 +26,13 @@ fn main() -> Result<()> {
 
     match &cli.command {
         Commands::Analyze {
-            targets, dns, all, ..
+            targets,
+            dns,
+            http,
+            all,
+            ..
         } => {
-            run_analyze(targets, *dns || *all, use_color, &cli)?;
+            run_analyze(targets, *dns || *all, *http || *all, use_color, &cli)?;
         }
         Commands::Summary { targets, .. } => {
             run_summary(targets, use_color, &cli)?;
@@ -39,6 +45,7 @@ fn main() -> Result<()> {
 fn run_analyze(
     targets: &[std::path::PathBuf],
     enable_dns: bool,
+    enable_http: bool,
     use_color: bool,
     cli: &Cli,
 ) -> Result<()> {
@@ -48,7 +55,7 @@ fn run_analyze(
     let mut total_decode_errors: u64 = 0;
 
     // Determine if reassembly is needed
-    let needs_reassembly = cli.reassemble; // Will expand when HTTP/TLS analyzers added
+    let needs_reassembly = cli.reassemble || enable_http;
     let skip_reassembly = cli.no_reassemble;
 
     let mut reassembler = if needs_reassembly && !skip_reassembly {
@@ -67,7 +74,12 @@ fn run_analyze(
         fn on_data(&mut self, _: &FlowKey, _: Direction, _: &[u8], _: u64) {}
         fn on_flow_close(&mut self, _: &FlowKey, _: CloseReason) {}
     }
-    let mut stream_handler = NullHandler;
+    let mut null_handler = NullHandler;
+    let mut http_analyzer = if enable_http && !skip_reassembly {
+        Some(HttpAnalyzer::new())
+    } else {
+        None
+    };
 
     for target in targets {
         let pcap_files = resolve_targets(target)?;
@@ -89,7 +101,18 @@ fn run_analyze(
                             all_findings.extend(findings);
                         }
                         if let Some(ref mut reasm) = reassembler {
-                            reasm.process_packet(&parsed, raw.timestamp_secs, &mut stream_handler);
+                            match http_analyzer {
+                                Some(ref mut http) => {
+                                    reasm.process_packet(&parsed, raw.timestamp_secs, http);
+                                }
+                                None => {
+                                    reasm.process_packet(
+                                        &parsed,
+                                        raw.timestamp_secs,
+                                        &mut null_handler,
+                                    );
+                                }
+                            }
                         }
                     }
                     Err(e) => {
@@ -110,15 +133,25 @@ fn run_analyze(
     summary.skipped_packets = total_decode_errors;
 
     if let Some(ref mut reasm) = reassembler {
-        reasm.finalize(&mut stream_handler);
+        match http_analyzer {
+            Some(ref mut http) => {
+                reasm.finalize(http);
+                all_findings.extend(http.findings());
+            }
+            None => {
+                reasm.finalize(&mut null_handler);
+            }
+        }
         all_findings.extend(reasm.findings().to_vec());
     }
 
-    let analyzer_summaries = if enable_dns {
-        vec![dns_analyzer.summarize()]
-    } else {
-        vec![]
-    };
+    let mut analyzer_summaries = Vec::new();
+    if enable_dns {
+        analyzer_summaries.push(dns_analyzer.summarize());
+    }
+    if let Some(ref http) = http_analyzer {
+        analyzer_summaries.push(http.summarize());
+    }
 
     let output = match cli.output_format {
         Some(OutputFormat::Json) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,6 +58,12 @@ fn run_analyze(
     let needs_reassembly = cli.reassemble || enable_http;
     let skip_reassembly = cli.no_reassemble;
 
+    if enable_http && skip_reassembly {
+        eprintln!(
+            "Warning: --http requires TCP reassembly, but --no-reassemble is set. HTTP analysis will be skipped."
+        );
+    }
+
     let mut reassembler = if needs_reassembly && !skip_reassembly {
         let config = ReassemblyConfig {
             max_depth: cli.reassembly_depth * 1_048_576,

--- a/tests/http_analyzer_tests.rs
+++ b/tests/http_analyzer_tests.rs
@@ -1,7 +1,7 @@
 use wirerust::analyzer::http::HttpAnalyzer;
 use wirerust::findings::{Confidence, ThreatCategory, Verdict};
 use wirerust::reassembly::flow::FlowKey;
-use wirerust::reassembly::handler::{Direction, StreamAnalyzer, StreamHandler};
+use wirerust::reassembly::handler::{CloseReason, Direction, StreamAnalyzer, StreamHandler};
 use std::net::IpAddr;
 
 fn test_flow_key() -> FlowKey {
@@ -153,4 +153,41 @@ fn test_no_findings_for_normal_request() {
     let request = b"GET /index.html HTTP/1.1\r\nHost: example.com\r\nUser-Agent: Mozilla/5.0\r\n\r\n";
     analyzer.on_data(&fk, Direction::ClientToServer, request, 0);
     assert!(analyzer.findings().is_empty(), "Normal request should produce no findings");
+}
+
+#[test]
+fn test_summarize_produces_complete_output() {
+    let mut analyzer = HttpAnalyzer::new();
+    let fk = test_flow_key();
+
+    let request = b"GET /page HTTP/1.1\r\nHost: example.com\r\nUser-Agent: TestBot\r\n\r\n";
+    analyzer.on_data(&fk, Direction::ClientToServer, request, 0);
+
+    let response = b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n";
+    analyzer.on_data(&fk, Direction::ServerToClient, response, 0);
+
+    let summary = analyzer.summarize();
+    assert_eq!(summary.analyzer_name, "HTTP");
+    assert_eq!(summary.packets_analyzed, 1);
+
+    let detail = &summary.detail;
+    assert_eq!(detail["transactions"], 1);
+    assert_eq!(detail["methods"]["GET"], 1);
+    assert_eq!(detail["status_codes"]["200"], 1);
+    assert!(detail["top_hosts"].as_array().unwrap().contains(&serde_json::json!("example.com")));
+    assert_eq!(detail["user_agents"]["TestBot"], 1);
+}
+
+#[test]
+fn test_flow_close_cleans_up_state() {
+    let mut analyzer = HttpAnalyzer::new();
+    let fk = test_flow_key();
+
+    let request = b"GET / HTTP/1.1\r\nHost: x.com\r\n\r\n";
+    analyzer.on_data(&fk, Direction::ClientToServer, request, 0);
+    analyzer.on_flow_close(&fk, CloseReason::Fin);
+
+    analyzer.on_data(&fk, Direction::ClientToServer, b"GET /new HTTP/1.1\r\nHost: y.com\r\n\r\n", 0);
+    assert_eq!(*analyzer.method_counts().get("GET").unwrap(), 2);
+    assert_eq!(*analyzer.host_counts().get("y.com").unwrap(), 1);
 }

--- a/tests/http_analyzer_tests.rs
+++ b/tests/http_analyzer_tests.rs
@@ -1,0 +1,7 @@
+use wirerust::analyzer::http::HttpAnalyzer;
+
+#[test]
+fn test_http_analyzer_construction() {
+    let analyzer = HttpAnalyzer::new();
+    assert_eq!(analyzer.transaction_count(), 0);
+}

--- a/tests/http_analyzer_tests.rs
+++ b/tests/http_analyzer_tests.rs
@@ -131,7 +131,7 @@ fn test_detect_encoded_traversal() {
 fn test_detect_webshell_path() {
     let mut analyzer = HttpAnalyzer::new();
     let fk = test_flow_key();
-    let request = b"GET /uploads/shell.php HTTP/1.1\r\nHost: target.com\r\n\r\n";
+    let request = b"GET /uploads/c99.php HTTP/1.1\r\nHost: target.com\r\n\r\n";
     analyzer.on_data(&fk, Direction::ClientToServer, request, 0);
     let findings = analyzer.findings();
     assert_eq!(findings.len(), 1);

--- a/tests/http_analyzer_tests.rs
+++ b/tests/http_analyzer_tests.rs
@@ -1,13 +1,15 @@
+use std::net::IpAddr;
 use wirerust::analyzer::http::HttpAnalyzer;
 use wirerust::findings::{Confidence, ThreatCategory, Verdict};
 use wirerust::reassembly::flow::FlowKey;
 use wirerust::reassembly::handler::{CloseReason, Direction, StreamAnalyzer, StreamHandler};
-use std::net::IpAddr;
 
 fn test_flow_key() -> FlowKey {
     FlowKey::new(
-        "10.0.0.1".parse::<IpAddr>().unwrap(), 49153,
-        "10.0.0.2".parse::<IpAddr>().unwrap(), 80,
+        "10.0.0.1".parse::<IpAddr>().unwrap(),
+        49153,
+        "10.0.0.2".parse::<IpAddr>().unwrap(),
+        80,
     )
 }
 
@@ -22,7 +24,8 @@ fn test_parse_get_request() {
     let mut analyzer = HttpAnalyzer::new();
     let fk = test_flow_key();
 
-    let request = b"GET /index.html HTTP/1.1\r\nHost: example.com\r\nUser-Agent: Mozilla/5.0\r\n\r\n";
+    let request =
+        b"GET /index.html HTTP/1.1\r\nHost: example.com\r\nUser-Agent: Mozilla/5.0\r\n\r\n";
     analyzer.on_data(&fk, Direction::ClientToServer, request, 0);
 
     assert_eq!(*analyzer.method_counts().get("GET").unwrap(), 1);
@@ -49,10 +52,20 @@ fn test_parse_partial_request() {
     let mut analyzer = HttpAnalyzer::new();
     let fk = test_flow_key();
 
-    analyzer.on_data(&fk, Direction::ClientToServer, b"GET /page HTTP/1.1\r\nHos", 0);
+    analyzer.on_data(
+        &fk,
+        Direction::ClientToServer,
+        b"GET /page HTTP/1.1\r\nHos",
+        0,
+    );
     assert_eq!(analyzer.method_counts().get("GET"), None);
 
-    analyzer.on_data(&fk, Direction::ClientToServer, b"t: example.com\r\n\r\n", 23);
+    analyzer.on_data(
+        &fk,
+        Direction::ClientToServer,
+        b"t: example.com\r\n\r\n",
+        23,
+    );
     assert_eq!(*analyzer.method_counts().get("GET").unwrap(), 1);
 }
 
@@ -108,7 +121,10 @@ fn test_detect_encoded_traversal() {
     let fk = test_flow_key();
     let request = b"GET /..%2f..%2fetc/passwd HTTP/1.1\r\nHost: target.com\r\n\r\n";
     analyzer.on_data(&fk, Direction::ClientToServer, request, 0);
-    assert!(!analyzer.findings().is_empty(), "Should detect encoded path traversal");
+    assert!(
+        !analyzer.findings().is_empty(),
+        "Should detect encoded path traversal"
+    );
 }
 
 #[test]
@@ -141,7 +157,9 @@ fn test_detect_missing_host_header() {
     analyzer.on_data(&fk, Direction::ClientToServer, request, 0);
     let findings = analyzer.findings();
     assert!(
-        findings.iter().any(|f| f.category == ThreatCategory::Anomaly),
+        findings
+            .iter()
+            .any(|f| f.category == ThreatCategory::Anomaly),
         "Should detect missing Host header"
     );
 }
@@ -150,9 +168,13 @@ fn test_detect_missing_host_header() {
 fn test_no_findings_for_normal_request() {
     let mut analyzer = HttpAnalyzer::new();
     let fk = test_flow_key();
-    let request = b"GET /index.html HTTP/1.1\r\nHost: example.com\r\nUser-Agent: Mozilla/5.0\r\n\r\n";
+    let request =
+        b"GET /index.html HTTP/1.1\r\nHost: example.com\r\nUser-Agent: Mozilla/5.0\r\n\r\n";
     analyzer.on_data(&fk, Direction::ClientToServer, request, 0);
-    assert!(analyzer.findings().is_empty(), "Normal request should produce no findings");
+    assert!(
+        analyzer.findings().is_empty(),
+        "Normal request should produce no findings"
+    );
 }
 
 #[test]
@@ -174,7 +196,12 @@ fn test_summarize_produces_complete_output() {
     assert_eq!(detail["transactions"], 1);
     assert_eq!(detail["methods"]["GET"], 1);
     assert_eq!(detail["status_codes"]["200"], 1);
-    assert!(detail["top_hosts"].as_array().unwrap().contains(&serde_json::json!("example.com")));
+    assert!(
+        detail["top_hosts"]
+            .as_array()
+            .unwrap()
+            .contains(&serde_json::json!("example.com"))
+    );
     assert_eq!(detail["user_agents"]["TestBot"], 1);
 }
 
@@ -187,7 +214,12 @@ fn test_flow_close_cleans_up_state() {
     analyzer.on_data(&fk, Direction::ClientToServer, request, 0);
     analyzer.on_flow_close(&fk, CloseReason::Fin);
 
-    analyzer.on_data(&fk, Direction::ClientToServer, b"GET /new HTTP/1.1\r\nHost: y.com\r\n\r\n", 0);
+    analyzer.on_data(
+        &fk,
+        Direction::ClientToServer,
+        b"GET /new HTTP/1.1\r\nHost: y.com\r\n\r\n",
+        0,
+    );
     assert_eq!(*analyzer.method_counts().get("GET").unwrap(), 2);
     assert_eq!(*analyzer.host_counts().get("y.com").unwrap(), 1);
 }

--- a/tests/http_analyzer_tests.rs
+++ b/tests/http_analyzer_tests.rs
@@ -54,3 +54,36 @@ fn test_parse_partial_request() {
     analyzer.on_data(&fk, Direction::ClientToServer, b"t: example.com\r\n\r\n", 23);
     assert_eq!(*analyzer.method_counts().get("GET").unwrap(), 1);
 }
+
+#[test]
+fn test_parse_response() {
+    let mut analyzer = HttpAnalyzer::new();
+    let fk = test_flow_key();
+
+    // Send request first
+    let request = b"GET /index.html HTTP/1.1\r\nHost: example.com\r\n\r\n";
+    analyzer.on_data(&fk, Direction::ClientToServer, request, 0);
+
+    // Then response
+    let response = b"HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nContent-Length: 5\r\n\r\nhello";
+    analyzer.on_data(&fk, Direction::ServerToClient, response, 0);
+
+    assert_eq!(*analyzer.status_code_counts().get(&200).unwrap(), 1);
+    assert_eq!(analyzer.transaction_count(), 1);
+}
+
+#[test]
+fn test_parse_pipelined_responses() {
+    let mut analyzer = HttpAnalyzer::new();
+    let fk = test_flow_key();
+
+    let requests = b"GET /a HTTP/1.1\r\nHost: x.com\r\n\r\nGET /b HTTP/1.1\r\nHost: x.com\r\n\r\n";
+    analyzer.on_data(&fk, Direction::ClientToServer, requests, 0);
+
+    let responses = b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\nHTTP/1.1 404 Not Found\r\nContent-Length: 0\r\n\r\n";
+    analyzer.on_data(&fk, Direction::ServerToClient, responses, 0);
+
+    assert_eq!(*analyzer.status_code_counts().get(&200).unwrap(), 1);
+    assert_eq!(*analyzer.status_code_counts().get(&404).unwrap(), 1);
+    assert_eq!(analyzer.transaction_count(), 2);
+}

--- a/tests/http_analyzer_tests.rs
+++ b/tests/http_analyzer_tests.rs
@@ -1,6 +1,7 @@
 use wirerust::analyzer::http::HttpAnalyzer;
+use wirerust::findings::{Confidence, ThreatCategory, Verdict};
 use wirerust::reassembly::flow::FlowKey;
-use wirerust::reassembly::handler::{Direction, StreamHandler};
+use wirerust::reassembly::handler::{Direction, StreamAnalyzer, StreamHandler};
 use std::net::IpAddr;
 
 fn test_flow_key() -> FlowKey {
@@ -86,4 +87,70 @@ fn test_parse_pipelined_responses() {
     assert_eq!(*analyzer.status_code_counts().get(&200).unwrap(), 1);
     assert_eq!(*analyzer.status_code_counts().get(&404).unwrap(), 1);
     assert_eq!(analyzer.transaction_count(), 2);
+}
+
+#[test]
+fn test_detect_path_traversal() {
+    let mut analyzer = HttpAnalyzer::new();
+    let fk = test_flow_key();
+    let request = b"GET /../../etc/passwd HTTP/1.1\r\nHost: target.com\r\n\r\n";
+    analyzer.on_data(&fk, Direction::ClientToServer, request, 0);
+    let findings = analyzer.findings();
+    assert_eq!(findings.len(), 1);
+    assert_eq!(findings[0].category, ThreatCategory::Reconnaissance);
+    assert_eq!(findings[0].verdict, Verdict::Likely);
+    assert_eq!(findings[0].confidence, Confidence::High);
+}
+
+#[test]
+fn test_detect_encoded_traversal() {
+    let mut analyzer = HttpAnalyzer::new();
+    let fk = test_flow_key();
+    let request = b"GET /..%2f..%2fetc/passwd HTTP/1.1\r\nHost: target.com\r\n\r\n";
+    analyzer.on_data(&fk, Direction::ClientToServer, request, 0);
+    assert!(!analyzer.findings().is_empty(), "Should detect encoded path traversal");
+}
+
+#[test]
+fn test_detect_webshell_path() {
+    let mut analyzer = HttpAnalyzer::new();
+    let fk = test_flow_key();
+    let request = b"GET /uploads/shell.php HTTP/1.1\r\nHost: target.com\r\n\r\n";
+    analyzer.on_data(&fk, Direction::ClientToServer, request, 0);
+    let findings = analyzer.findings();
+    assert_eq!(findings.len(), 1);
+    assert_eq!(findings[0].category, ThreatCategory::Execution);
+}
+
+#[test]
+fn test_detect_unusual_method() {
+    let mut analyzer = HttpAnalyzer::new();
+    let fk = test_flow_key();
+    let request = b"CONNECT proxy.example.com:443 HTTP/1.1\r\nHost: proxy.example.com\r\n\r\n";
+    analyzer.on_data(&fk, Direction::ClientToServer, request, 0);
+    let findings = analyzer.findings();
+    assert_eq!(findings.len(), 1);
+    assert_eq!(findings[0].category, ThreatCategory::Reconnaissance);
+}
+
+#[test]
+fn test_detect_missing_host_header() {
+    let mut analyzer = HttpAnalyzer::new();
+    let fk = test_flow_key();
+    let request = b"GET /path HTTP/1.1\r\n\r\n";
+    analyzer.on_data(&fk, Direction::ClientToServer, request, 0);
+    let findings = analyzer.findings();
+    assert!(
+        findings.iter().any(|f| f.category == ThreatCategory::Anomaly),
+        "Should detect missing Host header"
+    );
+}
+
+#[test]
+fn test_no_findings_for_normal_request() {
+    let mut analyzer = HttpAnalyzer::new();
+    let fk = test_flow_key();
+    let request = b"GET /index.html HTTP/1.1\r\nHost: example.com\r\nUser-Agent: Mozilla/5.0\r\n\r\n";
+    analyzer.on_data(&fk, Direction::ClientToServer, request, 0);
+    assert!(analyzer.findings().is_empty(), "Normal request should produce no findings");
 }

--- a/tests/http_analyzer_tests.rs
+++ b/tests/http_analyzer_tests.rs
@@ -1,7 +1,56 @@
 use wirerust::analyzer::http::HttpAnalyzer;
+use wirerust::reassembly::flow::FlowKey;
+use wirerust::reassembly::handler::{Direction, StreamHandler};
+use std::net::IpAddr;
+
+fn test_flow_key() -> FlowKey {
+    FlowKey::new(
+        "10.0.0.1".parse::<IpAddr>().unwrap(), 49153,
+        "10.0.0.2".parse::<IpAddr>().unwrap(), 80,
+    )
+}
 
 #[test]
 fn test_http_analyzer_construction() {
     let analyzer = HttpAnalyzer::new();
     assert_eq!(analyzer.transaction_count(), 0);
+}
+
+#[test]
+fn test_parse_get_request() {
+    let mut analyzer = HttpAnalyzer::new();
+    let fk = test_flow_key();
+
+    let request = b"GET /index.html HTTP/1.1\r\nHost: example.com\r\nUser-Agent: Mozilla/5.0\r\n\r\n";
+    analyzer.on_data(&fk, Direction::ClientToServer, request, 0);
+
+    assert_eq!(*analyzer.method_counts().get("GET").unwrap(), 1);
+    assert_eq!(*analyzer.host_counts().get("example.com").unwrap(), 1);
+    assert_eq!(*analyzer.user_agent_counts().get("Mozilla/5.0").unwrap(), 1);
+    assert_eq!(analyzer.uri_list(), &["/index.html"]);
+}
+
+#[test]
+fn test_parse_pipelined_requests() {
+    let mut analyzer = HttpAnalyzer::new();
+    let fk = test_flow_key();
+
+    let pipelined = b"GET /first HTTP/1.1\r\nHost: a.com\r\n\r\nPOST /second HTTP/1.1\r\nHost: b.com\r\nContent-Length: 0\r\n\r\n";
+    analyzer.on_data(&fk, Direction::ClientToServer, pipelined, 0);
+
+    assert_eq!(*analyzer.method_counts().get("GET").unwrap(), 1);
+    assert_eq!(*analyzer.method_counts().get("POST").unwrap(), 1);
+    assert_eq!(analyzer.uri_list().len(), 2);
+}
+
+#[test]
+fn test_parse_partial_request() {
+    let mut analyzer = HttpAnalyzer::new();
+    let fk = test_flow_key();
+
+    analyzer.on_data(&fk, Direction::ClientToServer, b"GET /page HTTP/1.1\r\nHos", 0);
+    assert_eq!(analyzer.method_counts().get("GET"), None);
+
+    analyzer.on_data(&fk, Direction::ClientToServer, b"t: example.com\r\n\r\n", 23);
+    assert_eq!(*analyzer.method_counts().get("GET").unwrap(), 1);
 }

--- a/tests/http_integration_tests.rs
+++ b/tests/http_integration_tests.rs
@@ -1,0 +1,35 @@
+use wirerust::analyzer::http::HttpAnalyzer;
+use wirerust::decoder::decode_packet;
+use wirerust::reader::PcapSource;
+use wirerust::reassembly::handler::StreamAnalyzer;
+use wirerust::reassembly::{ReassemblyConfig, TcpReassembler};
+
+#[test]
+fn test_http_analysis_with_fixture() {
+    let source =
+        PcapSource::from_file(std::path::Path::new("tests/fixtures/http-full.cap")).unwrap();
+
+    let config = ReassemblyConfig::default();
+    let mut reassembler = TcpReassembler::new(config);
+    let mut http_analyzer = HttpAnalyzer::new();
+
+    for raw in &source.packets {
+        if let Ok(parsed) = decode_packet(&raw.data, source.datalink) {
+            reassembler.process_packet(&parsed, raw.timestamp_secs, &mut http_analyzer);
+        }
+    }
+    reassembler.finalize(&mut http_analyzer);
+
+    let summary = http_analyzer.summarize();
+    assert_eq!(summary.analyzer_name, "HTTP");
+
+    assert!(
+        http_analyzer.transaction_count() > 0,
+        "Expected HTTP transactions from http-full.cap, got 0"
+    );
+
+    assert!(
+        http_analyzer.method_counts().contains_key("GET"),
+        "Expected GET requests in http-full.cap"
+    );
+}


### PR DESCRIPTION
## Summary

- Stream-level HTTP/1.x analysis using `httparse` and the TCP reassembly engine
- Parses requests (method, URI, Host, User-Agent) and responses (status code) from reassembled byte streams
- 7 forensics detection rules: path traversal, web shells, admin panels, unusual methods, missing Host, long URIs, empty User-Agent
- Summary output: methods, status codes, top hosts, top URIs, user agents
- Auto-enables reassembly when `--http` is passed; warns if `--no-reassemble` conflicts

Closes #1

## Test plan

- [x] `cargo test` — 76 tests pass (15 new HTTP tests + 1 integration)
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo run -- analyze tests/fixtures/http-full.cap --http` — 2 transactions, GET method, 200 status codes
- [x] Detection: path traversal (`../`) generates finding
- [x] Detection: web shell (`c99.php`) generates finding
- [x] Detection: CONNECT method generates finding
- [x] Detection: missing Host header generates finding
- [x] Pipelining: 2 requests in one buffer both parsed
- [x] Partial reassembly: split request across chunks works
- [x] Flow close cleanup: state properly removed

## Follow-up issues created

- #17 — Add HTTP parse error counter and surface in summary
- #18 — Poison non-HTTP flows to avoid repeated parse-fail cycles
- #19 — Update HTTP analyzer spec to match implementation
- #20 — Add missing HTTP analyzer test coverage