### PR TITLE
fix: multi-segment full coverage misclassified as PartialOverlap

### DIFF
--- a/src/reassembly/segment.rs
+++ b/src/reassembly/segment.rs
@@ -180,6 +180,8 @@ impl FlowDirection {
             // Only report ConflictingOverlap when fully covered (no gap was inserted)
             return if !had_gap && has_conflict {
                 InsertResult::ConflictingOverlap
+            } else if !had_gap {
+                InsertResult::Duplicate
             } else if truncated {
                 InsertResult::Truncated
             } else {

--- a/src/reassembly/segment.rs
+++ b/src/reassembly/segment.rs
@@ -177,7 +177,7 @@ impl FlowDirection {
                 }
             }
 
-            // Only report ConflictingOverlap when fully covered (no gap was inserted)
+            // Union of existing segments covers the new segment entirely (no gaps to fill)
             return if !had_gap && has_conflict {
                 InsertResult::ConflictingOverlap
             } else if !had_gap {

--- a/tests/reassembly_segment_tests.rs
+++ b/tests/reassembly_segment_tests.rs
@@ -288,3 +288,33 @@ fn test_out_of_window_segment_rejected() {
     let result = dir.insert_segment(edge_seq as u32, b"edge", 10_485_760, 10_000, 1_048_576);
     assert_eq!(result, InsertResult::Inserted);
 }
+
+#[test]
+fn test_multi_segment_full_coverage_returns_duplicate() {
+    let mut dir = FlowDirection::new();
+    dir.set_isn(1000);
+
+    // Insert two adjacent segments: "AAA" at offset 1, "BBB" at offset 4
+    dir.insert_segment(1001, b"AAA", 10_485_760, 10_000, 10_485_760);
+    dir.insert_segment(1004, b"BBB", 10_485_760, 10_000, 10_485_760);
+
+    // Insert segment spanning both: "AAABBB" at offset 1
+    // Union of existing segments fully covers this — should be Duplicate
+    let result = dir.insert_segment(1001, b"AAABBB", 10_485_760, 10_000, 10_485_760);
+    assert_eq!(result, InsertResult::Duplicate);
+}
+
+#[test]
+fn test_multi_segment_full_coverage_conflicting_returns_conflict() {
+    let mut dir = FlowDirection::new();
+    dir.set_isn(1000);
+
+    // Insert two adjacent segments: "AAA" at offset 1, "BBB" at offset 4
+    dir.insert_segment(1001, b"AAA", 10_485_760, 10_000, 10_485_760);
+    dir.insert_segment(1004, b"BBB", 10_485_760, 10_000, 10_485_760);
+
+    // Insert segment spanning both with different data
+    // Union covers it but data conflicts — should be ConflictingOverlap
+    let result = dir.insert_segment(1001, b"XXXXXX", 10_485_760, 10_000, 10_485_760);
+    assert_eq!(result, InsertResult::ConflictingOverlap);
+}


### PR DESCRIPTION
## Summary

- Fix `insert_segment` returning `PartialOverlap` instead of `Duplicate` when a new segment is fully covered by the union of multiple existing segments (but not by any single segment)
- Add regression tests for both duplicate and conflicting multi-segment coverage cases
- Update misleading comment on the overlap return logic

Fixes #34

## Test plan

- [x] `test_multi_segment_full_coverage_returns_duplicate` — two adjacent segments fully cover new segment with matching data → returns `Duplicate`
- [x] `test_multi_segment_full_coverage_conflicting_returns_conflict` — two adjacent segments fully cover new segment with different data → returns `ConflictingOverlap`
- [x] All 19 segment tests pass
- [x] Full test suite (123 tests) passes
- [x] Code review agent: no issues found
- [x] Silent-failure-hunter: fix confirmed correct, pre-existing issues filed as #35 and #36