### PR TITLE
fix: add SegmentLimitReached for observable segment count limit drops

### DIFF
--- a/src/reassembly/mod.rs
+++ b/src/reassembly/mod.rs
@@ -218,7 +218,8 @@ impl TcpReassembler {
                 before_insert,
                 flow_dir.buffered_bytes
             );
-            self.total_memory += flow_dir.buffered_bytes.saturating_sub(before_insert);
+            let bytes_added = flow_dir.buffered_bytes.saturating_sub(before_insert);
+            self.total_memory += bytes_added;
 
             match result {
                 InsertResult::Inserted => self.stats.segments_inserted += 1,
@@ -240,6 +241,11 @@ impl TcpReassembler {
                 }
                 InsertResult::SegmentLimitReached => {
                     self.stats.segments_segment_limit += 1;
+                    // Partial insertion: some gap bytes were inserted before the limit
+                    if bytes_added > 0 {
+                        self.stats.segments_overlaps += 1;
+                        self.stats.segments_inserted += 1;
+                    }
                 }
                 InsertResult::OutOfWindow => {
                     self.stats.segments_out_of_window += 1;

--- a/src/reassembly/mod.rs
+++ b/src/reassembly/mod.rs
@@ -60,6 +60,7 @@ pub struct ReassemblyStats {
     pub segments_duplicates: u64,
     pub segments_overlaps: u64,
     pub segments_out_of_window: u64,
+    pub segments_segment_limit: u64,
     pub bytes_reassembled: u64,
     pub evictions: u64,
 }
@@ -236,6 +237,9 @@ impl TcpReassembler {
                 }
                 InsertResult::DepthExceeded => {
                     // Already tracked in the direction
+                }
+                InsertResult::SegmentLimitReached => {
+                    self.stats.segments_segment_limit += 1;
                 }
                 InsertResult::OutOfWindow => {
                     self.stats.segments_out_of_window += 1;

--- a/src/reassembly/segment.rs
+++ b/src/reassembly/segment.rs
@@ -8,6 +8,7 @@ pub enum InsertResult {
     ConflictingOverlap,
     Truncated,
     DepthExceeded,
+    SegmentLimitReached,
     OutOfWindow,
 }
 
@@ -48,7 +49,7 @@ impl FlowDirection {
 
         // Enforce max segments per direction to prevent BTreeMap overhead explosion
         if self.segments.len() >= max_segments {
-            return InsertResult::DepthExceeded;
+            return InsertResult::SegmentLimitReached;
         }
 
         // Track small segments (cumulative, not consecutive)
@@ -152,9 +153,12 @@ impl FlowDirection {
 
             let had_gap = !gaps.is_empty();
 
+            let mut segments_exhausted = false;
+            let mut any_gap_inserted = false;
             for (gap_start, gap_end) in gaps {
                 // Enforce max_segments inside gap insertion loop
                 if self.segments.len() >= max_segments {
+                    segments_exhausted = true;
                     break;
                 }
                 let start_idx = (gap_start - new_start) as usize;
@@ -173,6 +177,7 @@ impl FlowDirection {
                             self.buffered_bytes -= old.len();
                         }
                         self.buffered_bytes += gap_len;
+                        any_gap_inserted = true;
                     }
                 }
             }
@@ -182,6 +187,8 @@ impl FlowDirection {
                 InsertResult::ConflictingOverlap
             } else if !had_gap {
                 InsertResult::Duplicate
+            } else if segments_exhausted && !any_gap_inserted {
+                InsertResult::SegmentLimitReached
             } else if truncated {
                 InsertResult::Truncated
             } else {

--- a/src/reassembly/segment.rs
+++ b/src/reassembly/segment.rs
@@ -154,7 +154,6 @@ impl FlowDirection {
             let had_gap = !gaps.is_empty();
 
             let mut segments_exhausted = false;
-            let mut any_gap_inserted = false;
             for (gap_start, gap_end) in gaps {
                 // Enforce max_segments inside gap insertion loop
                 if self.segments.len() >= max_segments {
@@ -177,7 +176,6 @@ impl FlowDirection {
                             self.buffered_bytes -= old.len();
                         }
                         self.buffered_bytes += gap_len;
-                        any_gap_inserted = true;
                     }
                 }
             }
@@ -187,7 +185,7 @@ impl FlowDirection {
                 InsertResult::ConflictingOverlap
             } else if !had_gap {
                 InsertResult::Duplicate
-            } else if segments_exhausted && !any_gap_inserted {
+            } else if segments_exhausted {
                 InsertResult::SegmentLimitReached
             } else if truncated {
                 InsertResult::Truncated

--- a/tests/reassembly_engine_tests.rs
+++ b/tests/reassembly_engine_tests.rs
@@ -940,7 +940,7 @@ fn test_max_segments_per_direction() {
     let stats_before = reassembler.stats().segments_inserted;
     assert_eq!(stats_before, 5);
 
-    // 6th segment — should be rejected (DepthExceeded: max_segments reached)
+    // 6th segment — should be rejected (SegmentLimitReached: max_segments reached)
     let rejected = make_tcp_packet(
         client, 12345, server, 80, 1012, b"y", false, false, false, false,
     );
@@ -951,6 +951,13 @@ fn test_max_segments_per_direction() {
         reassembler.stats().segments_inserted,
         stats_before,
         "6th segment should be rejected when max_segments_per_direction is reached"
+    );
+
+    // segments_segment_limit counter must be incremented
+    assert_eq!(
+        reassembler.stats().segments_segment_limit,
+        1,
+        "segment limit counter should track the rejection"
     );
 
     // Verify existing buffered segments survive rejection (non-destructive).

--- a/tests/reassembly_segment_tests.rs
+++ b/tests/reassembly_segment_tests.rs
@@ -369,15 +369,23 @@ fn test_segment_limit_gap_loop_partial_insertion() {
     dir.insert_segment(1010, b"BBB", 10_485_760, max_segments, 10_485_760);
     assert_eq!(dir.segments.len(), 2);
 
-    // Insert segment spanning offset 1-14 (overlaps both, has two gaps: 4-9 and 13-14)
-    // Only 1 segment slot available (limit=3, currently 2). First gap fills, second is dropped.
-    let result = dir.insert_segment(1001, b"AAABBBBBBBBBBCC", 10_485_760, max_segments, 10_485_760);
+    // Insert a 15-byte segment spanning offsets 1-15; it overlaps both existing
+    // segments and leaves two insertable gaps: [4,10) and [13,16).
+    // Only 1 segment slot available (limit=3, currently 2), so the first gap is
+    // inserted and the second gap is dropped when the segment limit is reached.
+    let result = dir.insert_segment(
+        1001,
+        b"AAABBBBBBBBBBCC",
+        10_485_760,
+        max_segments,
+        10_485_760,
+    );
     // Segment limit was hit (even though some data was inserted)
     assert_eq!(result, InsertResult::SegmentLimitReached);
     assert_eq!(dir.segments.len(), 3); // One gap inserted, hit limit before second
 
-    // Verify the first gap was filled (offset 4, data "BBBBBBB" for offsets 4-9 = 6 bytes)
+    // Verify the first gap was filled at offset 4 with 6 bytes covering [4,10)
     assert!(dir.segments.contains_key(&4));
-    // Second gap (offset 13) was NOT inserted
+    // Second gap (starting at offset 13) was NOT inserted
     assert!(!dir.segments.contains_key(&13));
 }

--- a/tests/reassembly_segment_tests.rs
+++ b/tests/reassembly_segment_tests.rs
@@ -318,3 +318,66 @@ fn test_multi_segment_full_coverage_conflicting_returns_conflict() {
     let result = dir.insert_segment(1001, b"XXXXXX", 10_485_760, 10_000, 10_485_760);
     assert_eq!(result, InsertResult::ConflictingOverlap);
 }
+
+#[test]
+fn test_segment_limit_non_overlap_path() {
+    let mut dir = FlowDirection::new();
+    dir.set_isn(1000);
+
+    let max_segments: usize = 3;
+
+    // Fill up to the segment limit
+    dir.insert_segment(1001, b"aaa", 10_485_760, max_segments, 10_485_760);
+    dir.insert_segment(1010, b"bbb", 10_485_760, max_segments, 10_485_760);
+    dir.insert_segment(1020, b"ccc", 10_485_760, max_segments, 10_485_760);
+    assert_eq!(dir.segments.len(), 3);
+
+    // Next non-overlapping insert should return SegmentLimitReached
+    let result = dir.insert_segment(1030, b"ddd", 10_485_760, max_segments, 10_485_760);
+    assert_eq!(result, InsertResult::SegmentLimitReached);
+    assert_eq!(dir.segments.len(), 3); // No new segment added
+}
+
+#[test]
+fn test_segment_limit_gap_loop_full_rejection() {
+    let mut dir = FlowDirection::new();
+    dir.set_isn(1000);
+
+    let max_segments: usize = 2;
+
+    // Insert two segments with a gap between them (offsets 1-3 and 10-12)
+    dir.insert_segment(1001, b"AAA", 10_485_760, max_segments, 10_485_760);
+    dir.insert_segment(1010, b"BBB", 10_485_760, max_segments, 10_485_760);
+    assert_eq!(dir.segments.len(), 2);
+
+    // Now insert a segment that overlaps the first and has a gap to fill (offset 1-6)
+    // Gap is at offset 4-6. But segments are at capacity (2), so the gap can't be inserted.
+    let result = dir.insert_segment(1001, b"AAAXXX", 10_485_760, max_segments, 10_485_760);
+    assert_eq!(result, InsertResult::SegmentLimitReached);
+    assert_eq!(dir.segments.len(), 2); // No new segment added
+}
+
+#[test]
+fn test_segment_limit_gap_loop_partial_insertion() {
+    let mut dir = FlowDirection::new();
+    dir.set_isn(1000);
+
+    let max_segments: usize = 3;
+
+    // Insert two segments: offset 1-3 and offset 10-12, leaving gaps at 4-9 and 13+
+    dir.insert_segment(1001, b"AAA", 10_485_760, max_segments, 10_485_760);
+    dir.insert_segment(1010, b"BBB", 10_485_760, max_segments, 10_485_760);
+    assert_eq!(dir.segments.len(), 2);
+
+    // Insert segment spanning offset 1-14 (overlaps both, has two gaps: 4-9 and 13-14)
+    // Only 1 segment slot available (limit=3, currently 2). First gap fills, second is dropped.
+    let result = dir.insert_segment(1001, b"AAABBBBBBBBBBCC", 10_485_760, max_segments, 10_485_760);
+    // Some data was inserted (first gap), so returns PartialOverlap
+    assert_eq!(result, InsertResult::PartialOverlap);
+    assert_eq!(dir.segments.len(), 3); // One gap inserted, hit limit before second
+
+    // Verify the first gap was filled (offset 4, data "BBBBBBB" for offsets 4-9 = 6 bytes)
+    assert!(dir.segments.contains_key(&4));
+    // Second gap (offset 13) was NOT inserted
+    assert!(!dir.segments.contains_key(&13));
+}

--- a/tests/reassembly_segment_tests.rs
+++ b/tests/reassembly_segment_tests.rs
@@ -372,8 +372,8 @@ fn test_segment_limit_gap_loop_partial_insertion() {
     // Insert segment spanning offset 1-14 (overlaps both, has two gaps: 4-9 and 13-14)
     // Only 1 segment slot available (limit=3, currently 2). First gap fills, second is dropped.
     let result = dir.insert_segment(1001, b"AAABBBBBBBBBBCC", 10_485_760, max_segments, 10_485_760);
-    // Some data was inserted (first gap), so returns PartialOverlap
-    assert_eq!(result, InsertResult::PartialOverlap);
+    // Segment limit was hit (even though some data was inserted)
+    assert_eq!(result, InsertResult::SegmentLimitReached);
     assert_eq!(dir.segments.len(), 3); // One gap inserted, hit limit before second
 
     // Verify the first gap was filled (offset 4, data "BBBBBBB" for offsets 4-9 = 6 bytes)


### PR DESCRIPTION
## Summary

- New `InsertResult::SegmentLimitReached` variant distinguishes segment-count-limit rejections from byte-depth-limit rejections
- Non-overlap path returns `SegmentLimitReached` instead of `DepthExceeded` when max_segments is reached
- Gap insertion loop returns `SegmentLimitReached` when limit is hit (both full rejection and partial insertion)
- Caller detects partial insertion via `bytes_added > 0` and increments both `segments_segment_limit` and `segments_inserted`
- New `segments_segment_limit: u64` counter in `ReassemblyStats`

Validated with Perplexity: Suricata and Snort enforce segment count and byte depth limits independently per direction. Best practice is distinct counters for each.

Fixes #35

## Test plan

- [x] `test_segment_limit_non_overlap_path` — fills segments to limit, next insert returns `SegmentLimitReached`
- [x] `test_segment_limit_gap_loop_full_rejection` — overlap with gaps, all gap insertions blocked → `SegmentLimitReached`
- [x] `test_segment_limit_gap_loop_partial_insertion` — overlap with two gaps, one fills before limit → `SegmentLimitReached` (caller counts as inserted + limit)
- [x] Updated `test_max_segments_per_direction` — verifies `segments_segment_limit` counter
- [x] All 126 tests pass
- [x] Code reviewer: no issues
- [x] Silent-failure-hunter: partial insertion observability fixed, pre-existing issues filed as #38