### PR TITLE
feat: surface reassembly stats in reporter output

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -148,6 +148,9 @@ fn run_analyze(
     }
 
     let mut analyzer_summaries = Vec::new();
+    if let Some(ref reasm) = reassembler {
+        analyzer_summaries.push(reasm.summarize());
+    }
     if enable_dns {
         analyzer_summaries.push(dns_analyzer.summarize());
     }

--- a/src/reassembly/mod.rs
+++ b/src/reassembly/mod.rs
@@ -4,6 +4,7 @@ pub mod segment;
 
 use std::collections::HashMap;
 
+use crate::analyzer::AnalysisSummary;
 use crate::decoder::{ParsedPacket, Protocol, TransportInfo};
 use crate::findings::{Confidence, Finding, ThreatCategory, Verdict};
 use crate::reassembly::flow::{FlowKey, FlowState, TcpFlow};
@@ -343,10 +344,31 @@ impl TcpReassembler {
     }
 
     /// Close all remaining flows (called at end of capture).
+    /// Generates summary-level findings for notable reassembly events.
     pub fn finalize(&mut self, handler: &mut dyn StreamHandler) {
         let all_keys: Vec<FlowKey> = self.flows.keys().cloned().collect();
         for key in all_keys {
             self.close_flow(&key, CloseReason::Timeout, handler);
+        }
+
+        // Generate summary-level finding for segment limit hits
+        if self.stats.segments_segment_limit > 0 && self.findings.len() < MAX_FINDINGS {
+            self.findings.push(Finding {
+                category: ThreatCategory::Anomaly,
+                verdict: Verdict::Inconclusive,
+                confidence: Confidence::Medium,
+                summary: format!(
+                    "{} segments dropped due to per-flow segment count limit",
+                    self.stats.segments_segment_limit
+                ),
+                evidence: vec![
+                    "Segment count limit prevents BTreeMap overhead explosion".into(),
+                    "May indicate segmentation-based evasion attempt".into(),
+                ],
+                mitre_technique: None,
+                source_ip: None,
+                timestamp: None,
+            });
         }
     }
 
@@ -363,6 +385,34 @@ impl TcpReassembler {
     /// Return the current total memory used by all flow buffers.
     pub fn total_memory(&self) -> usize {
         self.total_memory
+    }
+
+    /// Produce an AnalysisSummary for the reassembly engine stats.
+    pub fn summarize(&self) -> AnalysisSummary {
+        let mut detail = HashMap::new();
+        let s = &self.stats;
+        detail.insert("flows_total".into(), s.flows_total.into());
+        detail.insert("flows_partial".into(), s.flows_partial.into());
+        detail.insert("flows_completed".into(), (s.flows_fin + s.flows_rst).into());
+        detail.insert("flows_expired".into(), s.flows_expired.into());
+        detail.insert("evictions".into(), s.evictions.into());
+        detail.insert("segments_inserted".into(), s.segments_inserted.into());
+        detail.insert("segments_duplicates".into(), s.segments_duplicates.into());
+        detail.insert("segments_overlaps".into(), s.segments_overlaps.into());
+        detail.insert(
+            "segments_out_of_window".into(),
+            s.segments_out_of_window.into(),
+        );
+        detail.insert(
+            "segments_segment_limit".into(),
+            s.segments_segment_limit.into(),
+        );
+        detail.insert("bytes_reassembled".into(), s.bytes_reassembled.into());
+        AnalysisSummary {
+            analyzer_name: "TCP Reassembly".into(),
+            packets_analyzed: s.packets_tcp,
+            detail,
+        }
     }
 
     // --- Private helpers ---

--- a/src/reassembly/mod.rs
+++ b/src/reassembly/mod.rs
@@ -410,6 +410,8 @@ impl TcpReassembler {
         );
         detail.insert("flows_total".into(), s.flows_total.into());
         detail.insert("flows_partial".into(), s.flows_partial.into());
+        detail.insert("flows_fin".into(), s.flows_fin.into());
+        detail.insert("flows_rst".into(), s.flows_rst.into());
         detail.insert("flows_completed".into(), (s.flows_fin + s.flows_rst).into());
         detail.insert("flows_expired".into(), s.flows_expired.into());
         detail.insert("evictions".into(), s.evictions.into());

--- a/src/reassembly/mod.rs
+++ b/src/reassembly/mod.rs
@@ -73,6 +73,7 @@ pub struct TcpReassembler {
     stats: ReassemblyStats,
     findings: Vec<Finding>,
     total_memory: usize,
+    finalized: bool,
 }
 
 impl TcpReassembler {
@@ -94,6 +95,7 @@ impl TcpReassembler {
             stats: ReassemblyStats::default(),
             findings: Vec::new(),
             total_memory: 0,
+            finalized: false,
         }
     }
 
@@ -345,21 +347,31 @@ impl TcpReassembler {
 
     /// Close all remaining flows (called at end of capture).
     /// Generates summary-level findings for notable reassembly events.
+    /// Must only be called once; subsequent calls are no-ops.
     pub fn finalize(&mut self, handler: &mut dyn StreamHandler) {
+        if self.finalized {
+            return;
+        }
+        self.finalized = true;
+
         let all_keys: Vec<FlowKey> = self.flows.keys().cloned().collect();
         for key in all_keys {
             self.close_flow(&key, CloseReason::Timeout, handler);
         }
 
-        // Generate summary-level finding for segment limit hits
-        if self.stats.segments_segment_limit > 0 && self.findings.len() < MAX_FINDINGS {
+        // Generate summary-level finding for segment limit hits.
+        // Pushed unconditionally (at most 1 finding) to avoid being silently
+        // dropped when per-flow findings have filled the MAX_FINDINGS cap.
+        let count = self.stats.segments_segment_limit;
+        if count > 0 {
             self.findings.push(Finding {
                 category: ThreatCategory::Anomaly,
                 verdict: Verdict::Inconclusive,
                 confidence: Confidence::Medium,
                 summary: format!(
-                    "{} segments dropped due to per-flow segment count limit",
-                    self.stats.segments_segment_limit
+                    "{} segment{} dropped due to per-flow segment count limit",
+                    count,
+                    if count == 1 { "" } else { "s" }
                 ),
                 evidence: vec![
                     "Segment count limit prevents BTreeMap overhead explosion".into(),
@@ -391,6 +403,11 @@ impl TcpReassembler {
     pub fn summarize(&self) -> AnalysisSummary {
         let mut detail = HashMap::new();
         let s = &self.stats;
+        detail.insert("packets_processed".into(), s.packets_processed.into());
+        detail.insert(
+            "packets_skipped_non_tcp".into(),
+            s.packets_skipped_non_tcp.into(),
+        );
         detail.insert("flows_total".into(), s.flows_total.into());
         detail.insert("flows_partial".into(), s.flows_partial.into());
         detail.insert("flows_completed".into(), (s.flows_fin + s.flows_rst).into());

--- a/tests/reassembly_engine_tests.rs
+++ b/tests/reassembly_engine_tests.rs
@@ -1186,7 +1186,7 @@ fn test_finalize_generates_segment_limit_finding() {
         .iter()
         .find(|f| f.summary.contains("segment count limit"))
         .expect("should find segment-limit summary finding");
-    assert!(limit_finding.summary.contains("1 segments dropped"));
+    assert!(limit_finding.summary.contains("1 segment dropped"));
 }
 
 #[test]

--- a/tests/reassembly_engine_tests.rs
+++ b/tests/reassembly_engine_tests.rs
@@ -1078,3 +1078,155 @@ fn test_out_of_window_segment_rejected_by_engine() {
     assert_eq!(reassembler.stats().segments_inserted, 2);
     assert_eq!(reassembler.stats().segments_out_of_window, 1); // unchanged
 }
+
+#[test]
+fn test_summarize_returns_reassembly_stats() {
+    let config = ReassemblyConfig::default();
+    let mut reassembler = TcpReassembler::new(config);
+    let mut handler = RecordingHandler::new();
+
+    let client = [10, 0, 0, 1];
+    let server = [10, 0, 0, 2];
+
+    let syn = make_tcp_packet(
+        client,
+        12345,
+        server,
+        80,
+        1000,
+        &[],
+        true,
+        false,
+        false,
+        false,
+    );
+    reassembler.process_packet(&syn, 1, &mut handler);
+
+    let data = make_tcp_packet(
+        client, 12345, server, 80, 1001, b"hello", false, false, false, false,
+    );
+    reassembler.process_packet(&data, 2, &mut handler);
+
+    reassembler.finalize(&mut handler);
+
+    let summary = reassembler.summarize();
+    assert_eq!(summary.analyzer_name, "TCP Reassembly");
+    assert!(summary.packets_analyzed > 0);
+    assert_eq!(
+        summary.detail.get("flows_total"),
+        Some(&serde_json::Value::from(1u64))
+    );
+    assert_eq!(
+        summary.detail.get("segments_inserted"),
+        Some(&serde_json::Value::from(1u64))
+    );
+    assert_eq!(
+        summary.detail.get("bytes_reassembled"),
+        Some(&serde_json::Value::from(5u64))
+    );
+}
+
+#[test]
+fn test_finalize_generates_segment_limit_finding() {
+    let config = ReassemblyConfig {
+        max_segments_per_direction: 2,
+        ..ReassemblyConfig::default()
+    };
+    let mut reassembler = TcpReassembler::new(config);
+    let mut handler = RecordingHandler::new();
+
+    let client = [10, 0, 0, 1];
+    let server = [10, 0, 0, 2];
+
+    let syn = make_tcp_packet(
+        client,
+        12345,
+        server,
+        80,
+        1000,
+        &[],
+        true,
+        false,
+        false,
+        false,
+    );
+    reassembler.process_packet(&syn, 1, &mut handler);
+
+    // Insert 2 non-contiguous segments (gap at offset 1 keeps them buffered)
+    let p1 = make_tcp_packet(
+        client, 12345, server, 80, 1002, b"a", false, false, false, false,
+    );
+    let p2 = make_tcp_packet(
+        client, 12345, server, 80, 1004, b"b", false, false, false, false,
+    );
+    reassembler.process_packet(&p1, 2, &mut handler);
+    reassembler.process_packet(&p2, 3, &mut handler);
+
+    // 3rd segment should hit segment limit
+    let p3 = make_tcp_packet(
+        client, 12345, server, 80, 1006, b"c", false, false, false, false,
+    );
+    reassembler.process_packet(&p3, 4, &mut handler);
+
+    assert_eq!(reassembler.stats().segments_segment_limit, 1);
+
+    // Before finalize: no summary-level finding yet
+    let findings_before = reassembler.findings().len();
+
+    reassembler.finalize(&mut handler);
+
+    // After finalize: should have a summary finding about segment limit
+    let findings_after = reassembler.findings();
+    assert!(
+        findings_after.len() > findings_before,
+        "finalize should generate a segment-limit finding"
+    );
+
+    let limit_finding = findings_after
+        .iter()
+        .find(|f| f.summary.contains("segment count limit"))
+        .expect("should find segment-limit summary finding");
+    assert!(limit_finding.summary.contains("1 segments dropped"));
+}
+
+#[test]
+fn test_finalize_no_finding_when_no_segment_limit_hits() {
+    let config = ReassemblyConfig::default();
+    let mut reassembler = TcpReassembler::new(config);
+    let mut handler = RecordingHandler::new();
+
+    let client = [10, 0, 0, 1];
+    let server = [10, 0, 0, 2];
+
+    let syn = make_tcp_packet(
+        client,
+        12345,
+        server,
+        80,
+        1000,
+        &[],
+        true,
+        false,
+        false,
+        false,
+    );
+    reassembler.process_packet(&syn, 1, &mut handler);
+
+    let data = make_tcp_packet(
+        client, 12345, server, 80, 1001, b"hello", false, false, false, false,
+    );
+    reassembler.process_packet(&data, 2, &mut handler);
+
+    let findings_before = reassembler.findings().len();
+    reassembler.finalize(&mut handler);
+
+    // No segment limit hits — no summary finding should be generated
+    let new_findings: Vec<_> = reassembler.findings()[findings_before..]
+        .iter()
+        .filter(|f| f.summary.contains("segment count limit"))
+        .collect();
+    assert!(
+        new_findings.is_empty(),
+        "should not generate segment-limit finding when counter is 0"
+    );
+}


### PR DESCRIPTION
## Summary

- Add `summarize()` to `TcpReassembler` returning `AnalysisSummary` with all reassembly counters (flows, segments, overlaps, out-of-window, segment-limit, evictions, bytes reassembled)
- Wire into main.rs so stats appear in terminal and JSON output alongside DNS/HTTP/TLS summaries
- Generate summary Finding in `finalize()` when `segments_segment_limit > 0` (security-relevant per Suricata convention)
- Out-of-window and eviction counters surfaced as operational stats only (not Findings), following Suricata practice

Validated with Perplexity: Suricata treats memcap/depth drops as operational counters in stats.log, not EVE alerts. Only rule-triggered events (like overlapping data) become alerts. Design follows this convention.

Fixes #38

## Test plan

- [x] `test_summarize_returns_reassembly_stats` — verifies AnalysisSummary fields and detail values
- [x] `test_finalize_generates_segment_limit_finding` — forces segment limit, verifies Finding generated
- [x] `test_finalize_no_finding_when_no_segment_limit_hits` — negative test, no spurious Finding
- [x] All 129 tests pass
- [x] `cargo fmt` and `cargo clippy` clean
- [x] Code reviewer: no issues
- [x] Silent-failure-hunter: F1 (MAX_FINDINGS cap bypass), F6 (finalize guard), F7 (missing stats), F8 (grammar) fixed