### PR TITLE
fix: replace debug_assert with counters and eprintln for reassembly invariants

### DIFF
--- a/src/reassembly/mod.rs
+++ b/src/reassembly/mod.rs
@@ -254,6 +254,10 @@ impl TcpReassembler {
                 InsertResult::OutOfWindow => {
                     self.stats.segments_out_of_window += 1;
                 }
+                InsertResult::IsnMissing => {
+                    // Programming error — ISN should always be set before insert.
+                    // eprintln already emitted in insert_segment.
+                }
             }
 
             // Check anomaly thresholds on the direction
@@ -446,6 +450,7 @@ impl TcpReassembler {
     fn close_flow(&mut self, key: &FlowKey, reason: CloseReason, handler: &mut dyn StreamHandler) {
         use crate::reassembly::handler::Direction;
         let Some(mut flow) = self.flows.remove(key) else {
+            debug_assert!(false, "close_flow called for non-existent key: {}", key);
             eprintln!("wirerust: close_flow called for non-existent key: {}", key);
             return;
         };

--- a/src/reassembly/mod.rs
+++ b/src/reassembly/mod.rs
@@ -3,6 +3,7 @@ pub mod handler;
 pub mod segment;
 
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use crate::analyzer::AnalysisSummary;
 use crate::decoder::{ParsedPacket, Protocol, TransportInfo};
@@ -14,6 +15,8 @@ use crate::reassembly::segment::InsertResult;
 const OVERLAP_ALERT_THRESHOLD: u32 = 50;
 const SMALL_SEGMENT_ALERT_THRESHOLD: u32 = 2048;
 const MAX_FINDINGS: usize = 10_000;
+
+static CLOSE_FLOW_MISSING_WARNED: AtomicBool = AtomicBool::new(false);
 
 /// Configuration for the TCP reassembly engine.
 #[derive(Debug, Clone)]
@@ -451,7 +454,12 @@ impl TcpReassembler {
         use crate::reassembly::handler::Direction;
         let Some(mut flow) = self.flows.remove(key) else {
             debug_assert!(false, "close_flow called for non-existent key: {}", key);
-            eprintln!("wirerust: close_flow called for non-existent key: {}", key);
+            if !CLOSE_FLOW_MISSING_WARNED.swap(true, Ordering::Relaxed) {
+                eprintln!(
+                    "wirerust: close_flow called for non-existent key: {} (reason: {:?})",
+                    key, reason
+                );
+            }
             return;
         };
         let flow_mem = flow.memory_used();

--- a/src/reassembly/mod.rs
+++ b/src/reassembly/mod.rs
@@ -62,6 +62,7 @@ pub struct ReassemblyStats {
     pub segments_overlaps: u64,
     pub segments_out_of_window: u64,
     pub segments_segment_limit: u64,
+    pub segments_depth_exceeded: u64,
     pub bytes_reassembled: u64,
     pub evictions: u64,
 }
@@ -240,7 +241,7 @@ impl TcpReassembler {
                     self.generate_truncated_finding(&key, packet.src_ip);
                 }
                 InsertResult::DepthExceeded => {
-                    // Already tracked in the direction
+                    self.stats.segments_depth_exceeded += 1;
                 }
                 InsertResult::SegmentLimitReached => {
                     self.stats.segments_segment_limit += 1;
@@ -426,6 +427,10 @@ impl TcpReassembler {
             "segments_segment_limit".into(),
             s.segments_segment_limit.into(),
         );
+        detail.insert(
+            "segments_depth_exceeded".into(),
+            s.segments_depth_exceeded.into(),
+        );
         detail.insert("bytes_reassembled".into(), s.bytes_reassembled.into());
         AnalysisSummary {
             analyzer_name: "TCP Reassembly".into(),
@@ -441,7 +446,7 @@ impl TcpReassembler {
     fn close_flow(&mut self, key: &FlowKey, reason: CloseReason, handler: &mut dyn StreamHandler) {
         use crate::reassembly::handler::Direction;
         let Some(mut flow) = self.flows.remove(key) else {
-            debug_assert!(false, "close_flow called for non-existent key: {}", key);
+            eprintln!("wirerust: close_flow called for non-existent key: {}", key);
             return;
         };
         let flow_mem = flow.memory_used();

--- a/src/reassembly/segment.rs
+++ b/src/reassembly/segment.rs
@@ -10,6 +10,7 @@ pub enum InsertResult {
     DepthExceeded,
     SegmentLimitReached,
     OutOfWindow,
+    IsnMissing,
 }
 
 /// Compute the ISN-relative offset for a sequence number.
@@ -36,7 +37,7 @@ impl FlowDirection {
             Some(isn) => isn,
             None => {
                 eprintln!("wirerust: insert_segment called with no ISN set");
-                return InsertResult::DepthExceeded;
+                return InsertResult::IsnMissing;
             }
         };
 

--- a/src/reassembly/segment.rs
+++ b/src/reassembly/segment.rs
@@ -35,7 +35,7 @@ impl FlowDirection {
         let isn = match self.isn {
             Some(isn) => isn,
             None => {
-                debug_assert!(false, "insert_segment called with no ISN set");
+                eprintln!("wirerust: insert_segment called with no ISN set");
                 return InsertResult::DepthExceeded;
             }
         };

--- a/src/reassembly/segment.rs
+++ b/src/reassembly/segment.rs
@@ -1,4 +1,8 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+
 use crate::reassembly::flow::FlowDirection;
+
+static ISN_MISSING_WARNED: AtomicBool = AtomicBool::new(false);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum InsertResult {
@@ -36,7 +40,9 @@ impl FlowDirection {
         let isn = match self.isn {
             Some(isn) => isn,
             None => {
-                eprintln!("wirerust: insert_segment called with no ISN set");
+                if !ISN_MISSING_WARNED.swap(true, Ordering::Relaxed) {
+                    eprintln!("wirerust: insert_segment called with no ISN set");
+                }
                 return InsertResult::IsnMissing;
             }
         };

--- a/tests/reassembly_engine_tests.rs
+++ b/tests/reassembly_engine_tests.rs
@@ -1230,3 +1230,74 @@ fn test_finalize_no_finding_when_no_segment_limit_hits() {
         "should not generate segment-limit finding when counter is 0"
     );
 }
+
+#[test]
+fn test_depth_exceeded_counter() {
+    let config = ReassemblyConfig {
+        max_depth: 10, // tiny depth for testing
+        ..ReassemblyConfig::default()
+    };
+    let mut reassembler = TcpReassembler::new(config);
+    let mut handler = RecordingHandler::new();
+
+    let client = [10, 0, 0, 1];
+    let server = [10, 0, 0, 2];
+
+    let syn = make_tcp_packet(
+        client,
+        12345,
+        server,
+        80,
+        1000,
+        &[],
+        true,
+        false,
+        false,
+        false,
+    );
+    reassembler.process_packet(&syn, 1, &mut handler);
+
+    // First segment: 8 bytes, fits within 10-byte depth
+    let p1 = make_tcp_packet(
+        client,
+        12345,
+        server,
+        80,
+        1001,
+        b"AAAAAAAA",
+        false,
+        false,
+        false,
+        false,
+    );
+    reassembler.process_packet(&p1, 2, &mut handler);
+    assert_eq!(reassembler.stats().segments_inserted, 1);
+    assert_eq!(reassembler.stats().segments_depth_exceeded, 0);
+
+    // Second segment: 5 bytes, would exceed 10-byte depth (8 + 5 = 13 > 10)
+    // First 2 bytes are truncated+inserted, rest is depth-exceeded
+    let p2 = make_tcp_packet(
+        client, 12345, server, 80, 1009, b"BBBBB", false, false, false, false,
+    );
+    reassembler.process_packet(&p2, 3, &mut handler);
+
+    // Third segment: fully rejected — depth already exceeded
+    let p3 = make_tcp_packet(
+        client, 12345, server, 80, 1014, b"CCCCC", false, false, false, false,
+    );
+    reassembler.process_packet(&p3, 4, &mut handler);
+    assert_eq!(
+        reassembler.stats().segments_depth_exceeded,
+        1,
+        "depth_exceeded counter should track fully rejected segments"
+    );
+
+    // Verify it shows up in summarize()
+    reassembler.finalize(&mut handler);
+    let summary = reassembler.summarize();
+    let depth_val = summary.detail.get("segments_depth_exceeded");
+    assert!(
+        depth_val.is_some(),
+        "segments_depth_exceeded should appear in summarize() detail"
+    );
+}

--- a/tests/reassembly_engine_tests.rs
+++ b/tests/reassembly_engine_tests.rs
@@ -1275,7 +1275,7 @@ fn test_depth_exceeded_counter() {
     assert_eq!(reassembler.stats().segments_depth_exceeded, 0);
 
     // Second segment: 5 bytes, would exceed 10-byte depth (8 + 5 = 13 > 10)
-    // First 2 bytes are truncated+inserted, rest is depth-exceeded
+    // Truncated to 2 bytes and inserted (returns Truncated, not DepthExceeded)
     let p2 = make_tcp_packet(
         client, 12345, server, 80, 1009, b"BBBBB", false, false, false, false,
     );

--- a/tests/reassembly_segment_tests.rs
+++ b/tests/reassembly_segment_tests.rs
@@ -389,3 +389,14 @@ fn test_segment_limit_gap_loop_partial_insertion() {
     // Second gap (starting at offset 13) was NOT inserted
     assert!(!dir.segments.contains_key(&13));
 }
+
+#[test]
+fn test_isn_missing_returns_isn_missing() {
+    let mut dir = FlowDirection::new();
+    // Deliberately do NOT call dir.set_isn() — ISN is None
+
+    let result = dir.insert_segment(1001, b"hello", 10_485_760, 10_000, 10_485_760);
+    assert_eq!(result, InsertResult::IsnMissing);
+    assert!(dir.segments.is_empty()); // No data inserted
+    assert_eq!(dir.buffered_bytes, 0);
+}


### PR DESCRIPTION
## Summary

- Replace `debug_assert!(false, ...)` with `eprintln!` for production visibility in release builds
- Add `segments_depth_exceeded: u64` counter to `ReassemblyStats` (was a silent no-op)
- Add `InsertResult::IsnMissing` variant so ISN-missing case doesn't inflate `depth_exceeded` counter
- Keep `debug_assert` alongside `eprintln` in `close_flow` for debug-build crash-on-bug safety
- Surface `segments_depth_exceeded` in `summarize()` detail map

Validated with Perplexity: Suricata/Zeek use logging + counters + graceful degradation for invariant violations, not silent drops.

Fixes #36

## Test plan

- [x] `test_depth_exceeded_counter` — forces depth limit, verifies counter increments for fully rejected segments
- [x] `test_isn_missing_returns_isn_missing` — ISN not set, returns `IsnMissing` (not `DepthExceeded`)
- [x] All 131 tests pass
- [x] `cargo fmt` and `cargo clippy` clean
- [x] Code reviewer: IsnMissing variant addresses counter mis-attribution
- [x] Silent-failure-hunter: close_flow retains debug_assert for debug builds