### PR TITLE
perf: poison non-HTTP flows to avoid repeated parse-fail-clear cycles

### DIFF
--- a/src/analyzer/http.rs
+++ b/src/analyzer/http.rs
@@ -61,11 +61,19 @@ fn find_header(headers: &[httparse::Header<'_>], name: &str) -> Option<String> {
         .map(|h| String::from_utf8_lossy(h.value).trim().to_string())
 }
 
+/// Number of consecutive parse errors before poisoning a direction.
+/// Set > 1 to tolerate mid-stream joins where the first segment(s)
+/// are body data from a transfer that started before the capture.
+const POISON_THRESHOLD: u8 = 3;
+
 struct HttpFlowState {
     request_buf: Vec<u8>,
     response_buf: Vec<u8>,
     request_poisoned: bool,
     response_poisoned: bool,
+    request_error_count: u8,
+    response_error_count: u8,
+    counted_as_non_http: bool,
 }
 
 impl HttpFlowState {
@@ -75,6 +83,9 @@ impl HttpFlowState {
             response_buf: Vec::new(),
             request_poisoned: false,
             response_poisoned: false,
+            request_error_count: 0,
+            response_error_count: 0,
+            counted_as_non_http: false,
         }
     }
 }
@@ -98,6 +109,7 @@ pub struct HttpAnalyzer {
     all_findings: Vec<Finding>,
     parse_errors: u64,
     non_http_flows: u64,
+    poisoned_bytes_skipped: u64,
 }
 
 impl Default for HttpAnalyzer {
@@ -119,6 +131,7 @@ impl HttpAnalyzer {
             all_findings: Vec::new(),
             parse_errors: 0,
             non_http_flows: 0,
+            poisoned_bytes_skipped: 0,
         }
     }
 
@@ -320,8 +333,14 @@ impl HttpAnalyzer {
                     if !had_success {
                         self.parse_errors += 1;
                         if let Some(state) = self.flows.get_mut(flow_key) {
-                            state.request_poisoned = true;
-                            self.non_http_flows += 1;
+                            state.request_error_count = state.request_error_count.saturating_add(1);
+                            if state.request_error_count >= POISON_THRESHOLD {
+                                state.request_poisoned = true;
+                                if !state.counted_as_non_http {
+                                    state.counted_as_non_http = true;
+                                    self.non_http_flows += 1;
+                                }
+                            }
                         }
                         if e == httparse::Error::TooManyHeaders {
                             self.all_findings.push(Finding {
@@ -370,8 +389,15 @@ impl HttpAnalyzer {
                     if !had_success {
                         self.parse_errors += 1;
                         if let Some(state) = self.flows.get_mut(flow_key) {
-                            state.response_poisoned = true;
-                            self.non_http_flows += 1;
+                            state.response_error_count =
+                                state.response_error_count.saturating_add(1);
+                            if state.response_error_count >= POISON_THRESHOLD {
+                                state.response_poisoned = true;
+                                if !state.counted_as_non_http {
+                                    state.counted_as_non_http = true;
+                                    self.non_http_flows += 1;
+                                }
+                            }
                         }
                         if e == httparse::Error::TooManyHeaders {
                             self.all_findings.push(Finding {
@@ -407,6 +433,7 @@ impl StreamHandler for HttpAnalyzer {
             match direction {
                 Direction::ClientToServer => {
                     if state.request_poisoned {
+                        self.poisoned_bytes_skipped += data.len() as u64;
                         return;
                     }
                     let remaining = MAX_HEADER_BUF.saturating_sub(state.request_buf.len());
@@ -418,6 +445,7 @@ impl StreamHandler for HttpAnalyzer {
                 }
                 Direction::ServerToClient => {
                     if state.response_poisoned {
+                        self.poisoned_bytes_skipped += data.len() as u64;
                         return;
                     }
                     let remaining = MAX_HEADER_BUF.saturating_sub(state.response_buf.len());
@@ -482,6 +510,10 @@ impl StreamAnalyzer for HttpAnalyzer {
         detail.insert(
             "non_http_flows".to_string(),
             serde_json::json!(self.non_http_flows),
+        );
+        detail.insert(
+            "poisoned_bytes_skipped".to_string(),
+            serde_json::json!(self.poisoned_bytes_skipped),
         );
 
         AnalysisSummary {

--- a/src/analyzer/http.rs
+++ b/src/analyzer/http.rs
@@ -64,6 +64,8 @@ fn find_header(headers: &[httparse::Header<'_>], name: &str) -> Option<String> {
 struct HttpFlowState {
     request_buf: Vec<u8>,
     response_buf: Vec<u8>,
+    request_poisoned: bool,
+    response_poisoned: bool,
 }
 
 impl HttpFlowState {
@@ -71,6 +73,8 @@ impl HttpFlowState {
         HttpFlowState {
             request_buf: Vec::new(),
             response_buf: Vec::new(),
+            request_poisoned: false,
+            response_poisoned: false,
         }
     }
 }
@@ -93,6 +97,7 @@ pub struct HttpAnalyzer {
     transactions: u64,
     all_findings: Vec<Finding>,
     parse_errors: u64,
+    non_http_flows: u64,
 }
 
 impl Default for HttpAnalyzer {
@@ -113,6 +118,7 @@ impl HttpAnalyzer {
             transactions: 0,
             all_findings: Vec::new(),
             parse_errors: 0,
+            non_http_flows: 0,
         }
     }
 
@@ -313,6 +319,10 @@ impl HttpAnalyzer {
                 Some(Err(e)) => {
                     if !had_success {
                         self.parse_errors += 1;
+                        if let Some(state) = self.flows.get_mut(flow_key) {
+                            state.request_poisoned = true;
+                            self.non_http_flows += 1;
+                        }
                         if e == httparse::Error::TooManyHeaders {
                             self.all_findings.push(Finding {
                                 category: ThreatCategory::Anomaly,
@@ -359,6 +369,10 @@ impl HttpAnalyzer {
                 Some(Err(e)) => {
                     if !had_success {
                         self.parse_errors += 1;
+                        if let Some(state) = self.flows.get_mut(flow_key) {
+                            state.response_poisoned = true;
+                            self.non_http_flows += 1;
+                        }
                         if e == httparse::Error::TooManyHeaders {
                             self.all_findings.push(Finding {
                                 category: ThreatCategory::Anomaly,
@@ -392,6 +406,9 @@ impl StreamHandler for HttpAnalyzer {
                 .or_insert_with(HttpFlowState::new);
             match direction {
                 Direction::ClientToServer => {
+                    if state.request_poisoned {
+                        return;
+                    }
                     let remaining = MAX_HEADER_BUF.saturating_sub(state.request_buf.len());
                     if remaining > 0 {
                         state
@@ -400,6 +417,9 @@ impl StreamHandler for HttpAnalyzer {
                     }
                 }
                 Direction::ServerToClient => {
+                    if state.response_poisoned {
+                        return;
+                    }
                     let remaining = MAX_HEADER_BUF.saturating_sub(state.response_buf.len());
                     if remaining > 0 {
                         state
@@ -458,6 +478,10 @@ impl StreamAnalyzer for HttpAnalyzer {
         detail.insert(
             "parse_errors".to_string(),
             serde_json::json!(self.parse_errors),
+        );
+        detail.insert(
+            "non_http_flows".to_string(),
+            serde_json::json!(self.non_http_flows),
         );
 
         AnalysisSummary {

--- a/src/analyzer/http.rs
+++ b/src/analyzer/http.rs
@@ -163,6 +163,10 @@ impl HttpAnalyzer {
         self.parse_errors
     }
 
+    pub fn poisoned_bytes_skipped(&self) -> u64 {
+        self.poisoned_bytes_skipped
+    }
+
     fn check_request_detections(&mut self, parsed: &ParsedRequest, _flow_key: &FlowKey) {
         let uri_lower = parsed.uri.to_lowercase();
 
@@ -326,6 +330,7 @@ impl HttpAnalyzer {
 
                     if let Some(state) = self.flows.get_mut(flow_key) {
                         state.request_buf.drain(..parsed.bytes_consumed);
+                        state.request_error_count = 0;
                     }
                 }
                 Some(Ok(None)) => return, // Partial — wait for more data
@@ -382,6 +387,7 @@ impl HttpAnalyzer {
 
                     if let Some(state) = self.flows.get_mut(flow_key) {
                         state.response_buf.drain(..parsed.bytes_consumed);
+                        state.response_error_count = 0;
                     }
                 }
                 Some(Ok(None)) => return,

--- a/tests/http_analyzer_tests.rs
+++ b/tests/http_analyzer_tests.rs
@@ -291,20 +291,97 @@ fn test_parse_error_in_response() {
 }
 
 #[test]
-fn test_parse_error_poisons_direction() {
+fn test_parse_error_poisons_direction_after_threshold() {
     let mut analyzer = HttpAnalyzer::new();
     let fk = test_flow_key();
 
-    // First: malformed request (triggers error, poisons request direction)
-    analyzer.on_data(&fk, Direction::ClientToServer, b"GARBAGE\r\n\r\n", 0);
-    assert_eq!(analyzer.parse_error_count(), 1);
+    // Send 3 consecutive errors to reach POISON_THRESHOLD
+    analyzer.on_data(&fk, Direction::ClientToServer, b"GARBAGE1\r\n\r\n", 0);
+    analyzer.on_data(&fk, Direction::ClientToServer, b"GARBAGE2\r\n\r\n", 0);
+    analyzer.on_data(&fk, Direction::ClientToServer, b"GARBAGE3\r\n\r\n", 0);
+    assert_eq!(analyzer.parse_error_count(), 3);
 
-    // Second: valid request on same flow — skipped because direction is poisoned
+    // Fourth: valid request — skipped because direction is now poisoned
     let valid = b"GET /index.html HTTP/1.1\r\nHost: example.com\r\n\r\n";
     analyzer.on_data(&fk, Direction::ClientToServer, valid, 0);
 
-    assert_eq!(analyzer.parse_error_count(), 1); // no new errors (poisoned, not retried)
+    assert_eq!(analyzer.parse_error_count(), 3); // no new errors (poisoned, not retried)
     assert!(analyzer.method_counts().get("GET").is_none()); // never parsed
+}
+
+#[test]
+fn test_single_error_does_not_poison() {
+    let mut analyzer = HttpAnalyzer::new();
+    let fk = test_flow_key();
+
+    // One error is below threshold — should NOT poison
+    analyzer.on_data(&fk, Direction::ClientToServer, b"GARBAGE\r\n\r\n", 0);
+    assert_eq!(analyzer.parse_error_count(), 1);
+
+    // Valid request should still parse (direction not poisoned yet)
+    let valid = b"GET /index.html HTTP/1.1\r\nHost: example.com\r\n\r\n";
+    analyzer.on_data(&fk, Direction::ClientToServer, valid, 0);
+
+    assert_eq!(analyzer.parse_error_count(), 1);
+    assert_eq!(*analyzer.method_counts().get("GET").unwrap(), 1);
+}
+
+#[test]
+fn test_poison_request_does_not_affect_response() {
+    let mut analyzer = HttpAnalyzer::new();
+    let fk = test_flow_key();
+
+    // Poison request direction (3 errors)
+    analyzer.on_data(&fk, Direction::ClientToServer, b"GARBAGE1\r\n\r\n", 0);
+    analyzer.on_data(&fk, Direction::ClientToServer, b"GARBAGE2\r\n\r\n", 0);
+    analyzer.on_data(&fk, Direction::ClientToServer, b"GARBAGE3\r\n\r\n", 0);
+    assert_eq!(analyzer.parse_error_count(), 3);
+
+    // Response direction should still work
+    let response = b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n";
+    analyzer.on_data(&fk, Direction::ServerToClient, response, 0);
+    assert_eq!(analyzer.transaction_count(), 1);
+    assert_eq!(*analyzer.status_code_counts().get(&200).unwrap(), 1);
+}
+
+#[test]
+fn test_non_http_flows_counts_per_flow_not_direction() {
+    let mut analyzer = HttpAnalyzer::new();
+    let fk = test_flow_key();
+
+    // Poison request direction (3 errors)
+    for _ in 0..3 {
+        analyzer.on_data(&fk, Direction::ClientToServer, b"GARBAGE\r\n\r\n", 0);
+    }
+    // Poison response direction (3 errors)
+    for _ in 0..3 {
+        analyzer.on_data(&fk, Direction::ServerToClient, b"GARBAGE\r\n\r\n", 0);
+    }
+
+    // Both directions poisoned, but non_http_flows should count 1 flow, not 2
+    let summary = analyzer.summarize();
+    assert_eq!(summary.detail["non_http_flows"], serde_json::json!(1));
+}
+
+#[test]
+fn test_poison_cleared_after_flow_close() {
+    use wirerust::reassembly::handler::CloseReason;
+
+    let mut analyzer = HttpAnalyzer::new();
+    let fk = test_flow_key();
+
+    // Poison request direction (3 errors)
+    for _ in 0..3 {
+        analyzer.on_data(&fk, Direction::ClientToServer, b"GARBAGE\r\n\r\n", 0);
+    }
+
+    // Close the flow
+    analyzer.on_flow_close(&fk, CloseReason::Fin);
+
+    // Reopen same 4-tuple — should NOT be poisoned
+    let valid = b"GET /index.html HTTP/1.1\r\nHost: example.com\r\n\r\n";
+    analyzer.on_data(&fk, Direction::ClientToServer, valid, 0);
+    assert_eq!(*analyzer.method_counts().get("GET").unwrap(), 1);
 }
 
 #[test]

--- a/tests/http_analyzer_tests.rs
+++ b/tests/http_analyzer_tests.rs
@@ -303,10 +303,15 @@ fn test_parse_error_poisons_direction_after_threshold() {
 
     // Fourth: valid request — skipped because direction is now poisoned
     let valid = b"GET /index.html HTTP/1.1\r\nHost: example.com\r\n\r\n";
+    let skipped_before = analyzer.poisoned_bytes_skipped();
     analyzer.on_data(&fk, Direction::ClientToServer, valid, 0);
 
     assert_eq!(analyzer.parse_error_count(), 3); // no new errors (poisoned, not retried)
     assert!(analyzer.method_counts().get("GET").is_none()); // never parsed
+    assert_eq!(
+        analyzer.poisoned_bytes_skipped(),
+        skipped_before + valid.len() as u64
+    );
 }
 
 #[test]

--- a/tests/http_analyzer_tests.rs
+++ b/tests/http_analyzer_tests.rs
@@ -291,20 +291,20 @@ fn test_parse_error_in_response() {
 }
 
 #[test]
-fn test_parse_error_clears_buffer_and_continues() {
+fn test_parse_error_poisons_direction() {
     let mut analyzer = HttpAnalyzer::new();
     let fk = test_flow_key();
 
-    // First: malformed request (triggers error, clears buffer)
+    // First: malformed request (triggers error, poisons request direction)
     analyzer.on_data(&fk, Direction::ClientToServer, b"GARBAGE\r\n\r\n", 0);
     assert_eq!(analyzer.parse_error_count(), 1);
 
-    // Second: valid request (should parse successfully on fresh buffer)
+    // Second: valid request on same flow — skipped because direction is poisoned
     let valid = b"GET /index.html HTTP/1.1\r\nHost: example.com\r\n\r\n";
     analyzer.on_data(&fk, Direction::ClientToServer, valid, 0);
 
-    assert_eq!(analyzer.parse_error_count(), 1); // no new errors
-    assert_eq!(*analyzer.method_counts().get("GET").unwrap(), 1);
+    assert_eq!(analyzer.parse_error_count(), 1); // no new errors (poisoned, not retried)
+    assert!(analyzer.method_counts().get("GET").is_none()); // never parsed
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Add per-direction poisoning to `HttpFlowState` to skip non-HTTP TCP flows after repeated parse failures
- Use `POISON_THRESHOLD` (3 consecutive errors) to tolerate mid-stream joins where initial segments are body data
- Track `non_http_flows` per flow (not per direction) and `poisoned_bytes_skipped` for observability
- Reduces parse_errors from 14 to 3 on http-full.cap fixture (the 3 remaining are legitimate first-attempt failures before threshold is reached)

Fixes #18

## Test plan

- [x] `test_parse_error_poisons_direction_after_threshold` — 3 errors poison, 4th data skipped
- [x] `test_single_error_does_not_poison` — 1 error below threshold, next valid request parses
- [x] `test_poison_request_does_not_affect_response` — direction independence
- [x] `test_non_http_flows_counts_per_flow_not_direction` — counter accuracy
- [x] `test_poison_cleared_after_flow_close` — poison doesn't persist across flow reuse
- [x] All 135 tests pass
- [x] `cargo fmt` clean
- [x] Code reviewer: fixed double-counting, added threshold, added tests
- [x] Silent-failure-hunter: added poisoned_bytes_skipped counter, threshold for mid-stream tolerance