### PR TITLE
perf: enable overflow-checks in release profile for safety

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,9 @@ indicatif = "0.17"
 chrono = { version = "0.4", features = ["serde"] }
 rayon = "1"
 
+[profile.release]
+overflow-checks = true
+
 [dev-dependencies]
 assert_cmd = "2"
 predicates = "3"


### PR DESCRIPTION
## Summary

Add `overflow-checks = true` to `[profile.release]` in Cargo.toml so arithmetic overflow panics in release builds instead of wrapping silently.

Fixes #23

## Test plan

- [x] Release build succeeds with overflow-checks enabled
- [x] All 135 tests pass
- [x] No overflow panics on fixture files (http-full.cap, tls.pcap, etc.)