### PR TITLE
feat: add unclassified_flows counter to StreamDispatcher

### DIFF
--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -109,7 +109,9 @@ impl StreamHandler for StreamDispatcher {
                 }
             }
             Some(DispatchTarget::None) | None => {
-                self.unclassified_flows += 1;
+                if self.http.is_some() || self.tls.is_some() {
+                    self.unclassified_flows += 1;
+                }
             }
         }
     }

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -16,6 +16,7 @@ pub struct StreamDispatcher {
     routes: HashMap<FlowKey, DispatchTarget>,
     pub http: Option<HttpAnalyzer>,
     pub tls: Option<TlsAnalyzer>,
+    unclassified_flows: u64,
 }
 
 impl StreamDispatcher {
@@ -24,7 +25,12 @@ impl StreamDispatcher {
             routes: HashMap::new(),
             http,
             tls,
+            unclassified_flows: 0,
         }
+    }
+
+    pub fn unclassified_flows(&self) -> u64 {
+        self.unclassified_flows
     }
 }
 
@@ -102,7 +108,9 @@ impl StreamHandler for StreamDispatcher {
                     tls.on_flow_close(flow_key, reason);
                 }
             }
-            _ => {}
+            Some(DispatchTarget::None) | None => {
+                self.unclassified_flows += 1;
+            }
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -149,7 +149,12 @@ fn run_analyze(
 
     let mut analyzer_summaries = Vec::new();
     if let Some(ref reasm) = reassembler {
-        analyzer_summaries.push(reasm.summarize());
+        let mut reasm_summary = reasm.summarize();
+        reasm_summary.detail.insert(
+            "unclassified_flows".to_string(),
+            serde_json::json!(dispatcher.unclassified_flows()),
+        );
+        analyzer_summaries.push(reasm_summary);
     }
     if enable_dns {
         analyzer_summaries.push(dns_analyzer.summarize());

--- a/tests/dispatcher_tests.rs
+++ b/tests/dispatcher_tests.rs
@@ -3,7 +3,7 @@ use wirerust::analyzer::http::HttpAnalyzer;
 use wirerust::analyzer::tls::TlsAnalyzer;
 use wirerust::dispatcher::StreamDispatcher;
 use wirerust::reassembly::flow::FlowKey;
-use wirerust::reassembly::handler::{Direction, StreamHandler};
+use wirerust::reassembly::handler::{CloseReason, Direction, StreamHandler};
 
 fn flow_key(src_port: u16, dst_port: u16) -> FlowKey {
     FlowKey::new(
@@ -69,4 +69,30 @@ fn test_dispatcher_port_fallback_short_data() {
     let http = dispatcher.http.as_ref().unwrap();
     assert_eq!(http.method_counts().len(), 0);
     assert_eq!(http.parse_error_count(), 0); // Confirms HTTP didn't try to parse TLS bytes
+}
+
+#[test]
+fn test_unclassified_flows_counter() {
+    let mut dispatcher = StreamDispatcher::new(Some(HttpAnalyzer::new()), Some(TlsAnalyzer::new()));
+    let fk = flow_key(49152, 9999); // Non-standard port
+
+    // Send data that doesn't match HTTP or TLS content signatures
+    dispatcher.on_data(&fk, Direction::ClientToServer, b"UNKNOWN_PROTOCOL", 0);
+    assert_eq!(dispatcher.unclassified_flows(), 0); // Not counted until close
+
+    // Close the flow — never classified
+    dispatcher.on_flow_close(&fk, CloseReason::Fin);
+    assert_eq!(dispatcher.unclassified_flows(), 1);
+}
+
+#[test]
+fn test_classified_flow_not_counted_as_unclassified() {
+    let mut dispatcher = StreamDispatcher::new(Some(HttpAnalyzer::new()), Some(TlsAnalyzer::new()));
+    let fk = flow_key(49152, 80);
+
+    let http_data = b"GET / HTTP/1.1\r\nHost: example.com\r\n\r\n";
+    dispatcher.on_data(&fk, Direction::ClientToServer, http_data, 0);
+    dispatcher.on_flow_close(&fk, CloseReason::Fin);
+
+    assert_eq!(dispatcher.unclassified_flows(), 0);
 }


### PR DESCRIPTION
## Summary

- Add `unclassified_flows: u64` counter to `StreamDispatcher`
- Increment on `on_flow_close` when the flow was never classified as HTTP or TLS
- Expose via `unclassified_flows()` accessor
- Surface in TCP Reassembly AnalysisSummary detail map

Verified: http-full.cap shows `unclassified_flows: 1` (the DNS flow on a non-standard port)

Fixes #29

## Test plan

- [x] All 137 tests pass
- [x] Verified on http-full.cap fixture — shows 1 unclassified flow
- [x] `cargo fmt` clean