### PR TITLE
test: expand TLS SNI edge-case coverage

### DIFF
--- a/tests/tls_analyzer_tests.rs
+++ b/tests/tls_analyzer_tests.rs
@@ -36,9 +36,10 @@ fn build_client_hello_with_sni_list(sni_entries: &[&[u8]], cipher_ids: &[u16]) -
 
     // SNI extension (type 0x0000)
     // The ServerNameList contents: for each entry, 1 byte host_name type + 2 byte name length + name bytes.
-    // Use checked conversions so a future test passing an out-of-range SNI (e.g. the
-    // 65,534-byte hostname requested in issue #52) panics with a clear message rather
-    // than silently wrapping through `as u16` and producing a malformed ClientHello.
+    // Use checked conversions so a future test passing an out-of-range SNI (e.g. a
+    // ~65,532-byte single hostname — u16::MAX minus 3 bytes of ServerName overhead
+    // per entry — requested in issue #52) panics with a clear message rather than
+    // silently wrapping through `as u16` and producing a malformed ClientHello.
     let mut sni_list_data = Vec::new();
     for entry in sni_entries {
         let name_len = u16::try_from(entry.len())
@@ -76,7 +77,12 @@ fn build_client_hello_with_sni_list(sni_entries: &[&[u8]], cipher_ids: &[u16]) -
     ch_body.extend_from_slice(&[0u8; 32]); // random
     ch_body.push(0x00); // session_id length: 0
 
-    let ciphers_len = (cipher_ids.len() * 2) as u16;
+    let ciphers_byte_len = cipher_ids
+        .len()
+        .checked_mul(2)
+        .expect("cipher_ids list byte length overflows usize");
+    let ciphers_len = u16::try_from(ciphers_byte_len)
+        .expect("cipher_ids list exceeds u16::MAX bytes (max 32,767 suites)");
     ch_body.extend_from_slice(&ciphers_len.to_be_bytes());
     for &id in cipher_ids {
         ch_body.extend_from_slice(&id.to_be_bytes());
@@ -85,7 +91,8 @@ fn build_client_hello_with_sni_list(sni_entries: &[&[u8]], cipher_ids: &[u16]) -
     ch_body.push(0x01); // compression methods length
     ch_body.push(0x00); // null compression
 
-    let ext_len = extensions.len() as u16;
+    let ext_len = u16::try_from(extensions.len())
+        .expect("ClientHello extensions block exceeds u16::MAX bytes");
     ch_body.extend_from_slice(&ext_len.to_be_bytes());
     ch_body.extend_from_slice(&extensions);
 
@@ -102,7 +109,8 @@ fn build_client_hello_with_sni_list(sni_entries: &[&[u8]], cipher_ids: &[u16]) -
     let mut record = Vec::new();
     record.push(0x16); // handshake
     record.extend_from_slice(&[0x03, 0x01]); // TLS 1.0 record version
-    let hs_len = handshake.len() as u16;
+    let hs_len = u16::try_from(handshake.len())
+        .expect("TLS handshake body exceeds u16::MAX bytes; record fragmentation not implemented");
     record.extend_from_slice(&hs_len.to_be_bytes());
     record.extend_from_slice(&handshake);
 

--- a/tests/tls_analyzer_tests.rs
+++ b/tests/tls_analyzer_tests.rs
@@ -20,17 +20,29 @@ fn build_client_hello(sni: &str, cipher_ids: &[u16]) -> Vec<u8> {
 /// Build a minimal TLS ClientHello record with arbitrary raw bytes for the SNI hostname.
 /// Used for tests that exercise non-UTF-8 / malformed SNI handling.
 fn build_client_hello_raw_sni(sni_bytes: &[u8], cipher_ids: &[u16]) -> Vec<u8> {
+    build_client_hello_with_sni_list(&[sni_bytes], cipher_ids)
+}
+
+/// Build a minimal TLS ClientHello record with an arbitrary number of SNI hostname
+/// entries (zero or more). Used for edge-case tests covering empty SNI lists,
+/// multi-name SNI lists, and other scenarios the single-hostname helpers don't reach.
+fn build_client_hello_with_sni_list(sni_entries: &[&[u8]], cipher_ids: &[u16]) -> Vec<u8> {
     let mut extensions = Vec::new();
 
     // SNI extension (type 0x0000)
-    let sni_list_len = (3 + sni_bytes.len()) as u16;
+    // The ServerNameList contents: for each entry, 1 byte host_name type + 2 byte name length + name bytes.
+    let mut sni_list_data = Vec::new();
+    for entry in sni_entries {
+        sni_list_data.push(0x00); // host_name type
+        sni_list_data.extend_from_slice(&(entry.len() as u16).to_be_bytes());
+        sni_list_data.extend_from_slice(entry);
+    }
+    let sni_list_len = sni_list_data.len() as u16;
     let sni_ext_len = 2 + sni_list_len;
     extensions.extend_from_slice(&[0x00, 0x00]); // extension type: server_name
     extensions.extend_from_slice(&sni_ext_len.to_be_bytes());
     extensions.extend_from_slice(&sni_list_len.to_be_bytes());
-    extensions.push(0x00); // host_name type
-    extensions.extend_from_slice(&(sni_bytes.len() as u16).to_be_bytes());
-    extensions.extend_from_slice(sni_bytes);
+    extensions.extend_from_slice(&sni_list_data);
 
     // Supported Groups extension (type 0x000a)
     extensions.extend_from_slice(&[0x00, 0x0a]); // extension type
@@ -401,5 +413,210 @@ fn test_non_utf8_sni_escapes_control_bytes_in_summary() {
             .any(|e| e.contains("ff1b5b33316d70776e64")),
         "expected raw bytes in hex evidence, got: {:?}",
         f.evidence
+    );
+}
+
+// ── SNI edge-case pin tests (issue #50) ──────────────────────────────────────
+//
+// These tests pin the analyzer's behavior for SNI inputs that the existing
+// tests don't reach. Each one documents the *current* behavior so a future
+// refactor can't silently change it.
+
+#[test]
+fn test_sni_extension_with_empty_hostname_list() {
+    // Pin: an SNI extension whose ServerNameList contains zero entries should
+    // be treated as "no SNI" — extract_sni returns None, no count, no finding.
+    // Whether tls_parser ever produces this on the wire is implementation-defined,
+    // but the analyzer's branch (`list.first()` returning None) must be safe.
+    let mut analyzer = TlsAnalyzer::new();
+    let fk = test_flow_key();
+
+    let record = build_client_hello_with_sni_list(&[], &[0x1301]);
+    analyzer.on_data(&fk, Direction::ClientToServer, &record, 0);
+
+    assert!(
+        analyzer.sni_counts().is_empty(),
+        "sni_counts should be untouched when SNI list is empty, got {:?}",
+        analyzer.sni_counts()
+    );
+    assert!(
+        analyzer.findings().is_empty(),
+        "no findings should fire for an empty SNI list, got {:?}",
+        analyzer.findings()
+    );
+    // The handshake itself still parsed, so handshake_count should advance.
+    assert_eq!(analyzer.handshake_count(), 1);
+}
+
+#[test]
+fn test_sni_with_empty_hostname_bytes() {
+    // Pin: an SNI hostname of zero bytes (b"") decodes via from_utf8 as Ok(""),
+    // so the analyzer counts it under the empty-string key and emits no finding.
+    // This is a degenerate but technically valid wire form.
+    let mut analyzer = TlsAnalyzer::new();
+    let fk = test_flow_key();
+
+    let record = build_client_hello_raw_sni(b"", &[0x1301]);
+    analyzer.on_data(&fk, Direction::ClientToServer, &record, 0);
+
+    assert_eq!(
+        *analyzer.sni_counts().get("").unwrap_or(&0),
+        1,
+        "expected empty-string SNI key with count 1, got {:?}",
+        analyzer.sni_counts()
+    );
+    let non_utf8_findings = analyzer
+        .findings()
+        .iter()
+        .filter(|f| f.summary.contains("non-UTF-8 bytes"))
+        .count();
+    assert_eq!(non_utf8_findings, 0);
+}
+
+#[test]
+fn test_valid_utf8_non_ascii_sni_currently_not_flagged() {
+    // Pin: a SNI value that is valid UTF-8 but contains non-ASCII characters
+    // (e.g. a raw U-label "café.example") is *also* a RFC 6066 §3 violation —
+    // the spec requires A-labels (RFC 5890 Punycode `xn--` form). The current
+    // analyzer does not flag this case (it's tracked separately in issue #51).
+    //
+    // This test pins the current "no finding emitted" behavior. When issue #51
+    // lands, this assertion should be flipped to expect a finding, and this
+    // comment removed.
+    let mut analyzer = TlsAnalyzer::new();
+    let fk = test_flow_key();
+
+    let record = build_client_hello("café.example", &[0x1301]);
+    analyzer.on_data(&fk, Direction::ClientToServer, &record, 0);
+
+    assert_eq!(
+        *analyzer.sni_counts().get("café.example").unwrap_or(&0),
+        1,
+        "expected café.example to be counted under its UTF-8 form, got {:?}",
+        analyzer.sni_counts()
+    );
+    let non_utf8_findings = analyzer
+        .findings()
+        .iter()
+        .filter(|f| f.summary.contains("non-UTF-8 bytes"))
+        .count();
+    assert_eq!(
+        non_utf8_findings, 0,
+        "valid UTF-8 must not trip the non-UTF-8 finding (see #51 for follow-up)"
+    );
+}
+
+#[test]
+fn test_non_utf8_sni_finding_fires_when_sni_counts_at_capacity() {
+    // Pin: when sni_counts is at MAX_MAP_ENTRIES (50,000), the increment for a
+    // new key is silently dropped, but the non-UTF-8 finding must STILL fire.
+    // The finding push and the count increment are independent — a refactor
+    // that nests one inside the other would silently break this invariant
+    // and forensic visibility into anomalous SNI in long-running captures
+    // would degrade past the cap.
+    //
+    // This test is intentionally slow (~1-3s in debug builds) because the only
+    // way to reach the capacity-full state via the public API is to feed 50k
+    // unique ClientHellos through it. The performance trade-off was discussed
+    // in the design phase: the alternative was adding a #[cfg(test)] test
+    // helper to TlsAnalyzer, which would expose internal state. Black-box
+    // brute force keeps the public API clean.
+    let mut analyzer = TlsAnalyzer::new();
+    let fk = test_flow_key();
+
+    // MAX_MAP_ENTRIES is private; this constant must stay in sync.
+    const MAX_MAP_ENTRIES: usize = 50_000;
+
+    // Fill sni_counts to capacity with unique valid-UTF-8 hostnames. Each
+    // ClientHello uses the same cipher list, so all 50k JA3 hashes collapse
+    // into a single ja3_counts entry — only sni_counts grows. The single
+    // per-flow state handles all 50k records in sequence via buffer draining;
+    // client_hello_seen stays true after the first iteration but that's
+    // harmless because only `done()` (requiring both hellos) short-circuits
+    // on_data, and we never send a ServerHello.
+    for i in 0..MAX_MAP_ENTRIES {
+        let sni = format!("filler{i:05}.example");
+        let record = build_client_hello(&sni, &[0x1301]);
+        analyzer.on_data(&fk, Direction::ClientToServer, &record, 0);
+    }
+
+    assert_eq!(
+        analyzer.sni_counts().len(),
+        MAX_MAP_ENTRIES,
+        "expected sni_counts to be full at MAX_MAP_ENTRIES, got {}",
+        analyzer.sni_counts().len()
+    );
+
+    // Snapshot the finding count before the capacity-test ClientHello so we can
+    // assert exactly one new finding fired.
+    let findings_before = analyzer.findings().len();
+
+    // Send one more ClientHello with a non-UTF-8 SNI. Its key cannot fit in
+    // sni_counts (the map is full and the key is new), but the finding push
+    // must still happen.
+    let raw_sni: &[u8] = &[0xff, 0xfe, b'a', b'.', b'c', b'o', b'm'];
+    let record = build_client_hello_raw_sni(raw_sni, &[0x1301]);
+    analyzer.on_data(&fk, Direction::ClientToServer, &record, 0);
+
+    // sni_counts should be unchanged in size — the new non-UTF-8 key was dropped.
+    assert_eq!(
+        analyzer.sni_counts().len(),
+        MAX_MAP_ENTRIES,
+        "non-UTF-8 SNI must not have been inserted past the cap"
+    );
+    assert!(
+        analyzer
+            .sni_counts()
+            .get("<non-utf8:fffe612e636f6d>")
+            .is_none(),
+        "non-UTF-8 hex key must not be present in sni_counts past the cap"
+    );
+
+    // The finding must still have fired.
+    let findings_after = analyzer.findings().len();
+    assert_eq!(
+        findings_after,
+        findings_before + 1,
+        "expected exactly one new finding from the non-UTF-8 SNI past the cap, \
+         got {findings_before} -> {findings_after}"
+    );
+    let f = analyzer
+        .findings()
+        .into_iter()
+        .find(|f| f.summary.contains("non-UTF-8 bytes"))
+        .expect("expected non-UTF-8 SNI finding even when sni_counts is full");
+    assert_eq!(f.confidence, wirerust::findings::Confidence::Low);
+}
+
+#[test]
+fn test_multi_name_sni_list_only_first_entry_counted() {
+    // Pin: when an SNI extension contains multiple ServerName entries,
+    // the analyzer reads only the first one. This matches the prior behavior
+    // (extract_sni uses `list.first()`) and matches what nearly all real-world
+    // TLS clients do — the spec allows multiple but no major client emits >1.
+    let mut analyzer = TlsAnalyzer::new();
+    let fk = test_flow_key();
+
+    let record = build_client_hello_with_sni_list(
+        &[b"first.example", b"second.example", b"third.example"],
+        &[0x1301],
+    );
+    analyzer.on_data(&fk, Direction::ClientToServer, &record, 0);
+
+    assert_eq!(
+        *analyzer.sni_counts().get("first.example").unwrap_or(&0),
+        1,
+        "expected first hostname to be counted, got {:?}",
+        analyzer.sni_counts()
+    );
+    assert!(
+        analyzer.sni_counts().get("second.example").is_none(),
+        "second hostname must not be counted, got {:?}",
+        analyzer.sni_counts()
+    );
+    assert!(
+        analyzer.sni_counts().get("third.example").is_none(),
+        "third hostname must not be counted, got {:?}",
+        analyzer.sni_counts()
     );
 }

--- a/tests/tls_analyzer_tests.rs
+++ b/tests/tls_analyzer_tests.rs
@@ -26,6 +26,11 @@ fn build_client_hello_raw_sni(sni_bytes: &[u8], cipher_ids: &[u16]) -> Vec<u8> {
 /// Build a minimal TLS ClientHello record with an arbitrary number of SNI hostname
 /// entries (zero or more). Used for edge-case tests covering empty SNI lists,
 /// multi-name SNI lists, and other scenarios the single-hostname helpers don't reach.
+///
+/// Passing `sni_entries: &[]` produces a `ServerNameList` of length 0 — this is a
+/// technically RFC-violating wire form (RFC 6066 §3 requires `server_name_list<1..2^16-1>`)
+/// but is used to exercise the analyzer's defensive `list.first() == None` branch in
+/// `extract_sni`. The current `tls_parser` crate accepts it at parse time.
 fn build_client_hello_with_sni_list(sni_entries: &[&[u8]], cipher_ids: &[u16]) -> Vec<u8> {
     let mut extensions = Vec::new();
 
@@ -434,6 +439,19 @@ fn test_sni_extension_with_empty_hostname_list() {
     let record = build_client_hello_with_sni_list(&[], &[0x1301]);
     analyzer.on_data(&fk, Direction::ClientToServer, &record, 0);
 
+    // Guard against a silent false-positive: if tls_parser ever tightens to
+    // reject zero-entry ServerNameList (RFC 6066 §3: server_name_list<1..2^16-1>),
+    // parse_tls_extensions would fail and the subsequent assertions would still
+    // pass — but for the wrong reason. The branch we actually want to pin is
+    // `list.first() == None`, which requires the extension to have parsed
+    // successfully as `TlsExtension::SNI(empty_list)`.
+    assert_eq!(
+        analyzer.parse_error_count(),
+        0,
+        "extensions must parse cleanly; an empty-list pin that fires because \
+         tls_parser rejected the extension is not pinning the extract_sni branch \
+         we think it is"
+    );
     assert!(
         analyzer.sni_counts().is_empty(),
         "sni_counts should be untouched when SNI list is empty, got {:?}",
@@ -478,7 +496,8 @@ fn test_valid_utf8_non_ascii_sni_currently_not_flagged() {
     // Pin: a SNI value that is valid UTF-8 but contains non-ASCII characters
     // (e.g. a raw U-label "café.example") is *also* a RFC 6066 §3 violation —
     // the spec requires A-labels (RFC 5890 Punycode `xn--` form). The current
-    // analyzer does not flag this case (it's tracked separately in issue #51).
+    // analyzer does not flag this case (tracked as a follow-up at
+    // https://github.com/Zious11/wirerust/issues/51).
     //
     // This test pins the current "no finding emitted" behavior. When issue #51
     // lands, this assertion should be flipped to expect a finding, and this
@@ -502,7 +521,9 @@ fn test_valid_utf8_non_ascii_sni_currently_not_flagged() {
         .count();
     assert_eq!(
         non_utf8_findings, 0,
-        "valid UTF-8 must not trip the non-UTF-8 finding (see #51 for follow-up)"
+        "valid UTF-8 must not trip the non-UTF-8 finding (see \
+         https://github.com/Zious11/wirerust/issues/51 for the planned follow-up; \
+         flip this assertion when that issue lands)"
     );
 }
 
@@ -515,12 +536,13 @@ fn test_non_utf8_sni_finding_fires_when_sni_counts_at_capacity() {
     // and forensic visibility into anomalous SNI in long-running captures
     // would degrade past the cap.
     //
-    // This test is intentionally slow (~1-3s in debug builds) because the only
-    // way to reach the capacity-full state via the public API is to feed 50k
-    // unique ClientHellos through it. The performance trade-off was discussed
-    // in the design phase: the alternative was adding a #[cfg(test)] test
-    // helper to TlsAnalyzer, which would expose internal state. Black-box
-    // brute force keeps the public API clean.
+    // This test is intentionally slower than the others (~650ms in debug builds,
+    // measured locally; budget ~2s for CI cold caches) because the only way to
+    // reach the capacity-full state via the public API is to feed 50k unique
+    // ClientHellos through it. The performance trade-off was discussed in the
+    // design phase: the alternative was adding a #[cfg(test)] test helper to
+    // TlsAnalyzer, which would expose internal state. Black-box brute force
+    // keeps the public API clean.
     let mut analyzer = TlsAnalyzer::new();
     let fk = test_flow_key();
 
@@ -547,9 +569,16 @@ fn test_non_utf8_sni_finding_fires_when_sni_counts_at_capacity() {
         analyzer.sni_counts().len()
     );
 
-    // Snapshot the finding count before the capacity-test ClientHello so we can
-    // assert exactly one new finding fired.
-    let findings_before = analyzer.findings().len();
+    // Snapshot the non-UTF-8 finding count before the capacity-test ClientHello
+    // so we can assert exactly one new non-UTF-8 finding fired. Filtering by
+    // category (not total length) keeps the assertion robust: a future refactor
+    // that adds an unrelated finding on every ClientHello wouldn't make this
+    // test pass vacuously.
+    let non_utf8_before = analyzer
+        .findings()
+        .iter()
+        .filter(|f| f.summary.contains("non-UTF-8 bytes"))
+        .count();
 
     // Send one more ClientHello with a non-UTF-8 SNI. Its key cannot fit in
     // sni_counts (the map is full and the key is new), but the finding push
@@ -572,13 +601,18 @@ fn test_non_utf8_sni_finding_fires_when_sni_counts_at_capacity() {
         "non-UTF-8 hex key must not be present in sni_counts past the cap"
     );
 
-    // The finding must still have fired.
-    let findings_after = analyzer.findings().len();
+    // The non-UTF-8 finding must still have fired — this is the real invariant
+    // the test guards: finding emission is independent of count insertion.
+    let non_utf8_after = analyzer
+        .findings()
+        .iter()
+        .filter(|f| f.summary.contains("non-UTF-8 bytes"))
+        .count();
     assert_eq!(
-        findings_after,
-        findings_before + 1,
-        "expected exactly one new finding from the non-UTF-8 SNI past the cap, \
-         got {findings_before} -> {findings_after}"
+        non_utf8_after,
+        non_utf8_before + 1,
+        "expected exactly one new non-UTF-8 finding past the cap, \
+         got {non_utf8_before} -> {non_utf8_after}"
     );
     let f = analyzer
         .findings()

--- a/tests/tls_analyzer_tests.rs
+++ b/tests/tls_analyzer_tests.rs
@@ -36,14 +36,22 @@ fn build_client_hello_with_sni_list(sni_entries: &[&[u8]], cipher_ids: &[u16]) -
 
     // SNI extension (type 0x0000)
     // The ServerNameList contents: for each entry, 1 byte host_name type + 2 byte name length + name bytes.
+    // Use checked conversions so a future test passing an out-of-range SNI (e.g. the
+    // 65,534-byte hostname requested in issue #52) panics with a clear message rather
+    // than silently wrapping through `as u16` and producing a malformed ClientHello.
     let mut sni_list_data = Vec::new();
     for entry in sni_entries {
+        let name_len = u16::try_from(entry.len())
+            .expect("SNI hostname entry exceeds u16::MAX; can't encode as RFC 6066 HostName");
         sni_list_data.push(0x00); // host_name type
-        sni_list_data.extend_from_slice(&(entry.len() as u16).to_be_bytes());
+        sni_list_data.extend_from_slice(&name_len.to_be_bytes());
         sni_list_data.extend_from_slice(entry);
     }
-    let sni_list_len = sni_list_data.len() as u16;
-    let sni_ext_len = 2 + sni_list_len;
+    let sni_list_len =
+        u16::try_from(sni_list_data.len()).expect("ServerNameList payload exceeds u16::MAX");
+    let sni_ext_len = sni_list_len
+        .checked_add(2)
+        .expect("SNI extension length would overflow u16");
     extensions.extend_from_slice(&[0x00, 0x00]); // extension type: server_name
     extensions.extend_from_slice(&sni_ext_len.to_be_bytes());
     extensions.extend_from_slice(&sni_list_len.to_be_bytes());
@@ -468,9 +476,13 @@ fn test_sni_extension_with_empty_hostname_list() {
 
 #[test]
 fn test_sni_with_empty_hostname_bytes() {
-    // Pin: an SNI hostname of zero bytes (b"") decodes via from_utf8 as Ok(""),
-    // so the analyzer counts it under the empty-string key and emits no finding.
-    // This is a degenerate but technically valid wire form.
+    // Pin current behavior for a degenerate, RFC-violating SNI hostname whose
+    // HostName bytes are empty (b""). RFC 6066 §3 defines `HostName<1..2^16-1>`,
+    // so a zero-byte hostname is not spec-valid wire form. Current tls_parser
+    // accepts it anyway; from_utf8 decodes it as Ok(""), so the analyzer counts
+    // it under the empty-string key and emits no non-UTF-8 finding. This pin
+    // guards the defensive path — the analyzer's existing branch handles the
+    // degenerate case without panicking or double-counting.
     let mut analyzer = TlsAnalyzer::new();
     let fk = test_flow_key();
 


### PR DESCRIPTION
## Summary
- Adds 5 pin-tests for SNI edge cases that the existing non-UTF-8 SNI tests (from #49) don't reach. Each new test documents the *current* analyzer behavior so a future refactor can't silently change it. Closes #50.
- Refactors the test fixture builder to support 0-or-more-entry SNI lists: extracted `build_client_hello_with_sni_list` from `build_client_hello_raw_sni`, preserving the existing API for prior tests.
- One test (#5) intentionally exercises the `MAX_MAP_ENTRIES` boundary by feeding 50,000 unique ClientHellos through the public API. Runtime ~650ms in debug (budget ~2s for CI). No production code changes — this is test-only.
- Code review (pr-test-analyzer) applied pre-merge: RFC 6066 §3 bounds verified, silent-false-positive guard added to test 1, test 5's finding-delta tightened to filter specifically for non-UTF-8 findings, comment drift fixed.
- S4 follow-up (non-zero `NameType`, max-length SNI, trailing bytes) filed as #52.

## New tests
1. **test_sni_extension_with_empty_hostname_list** — `ServerNameList` with zero entries. `extract_sni` returns `None`, no finding, no count, handshake still parses. Guards against tls_parser drift via an explicit `parse_error_count == 0` assertion (empty-list wire form is technically RFC-violating per `server_name_list<1..2^16-1>`; a future tls_parser strictness tightening would otherwise let this test pass for the wrong reason).
2. **test_sni_with_empty_hostname_bytes** — one entry but the hostname bytes are `b""`. Decodes via `from_utf8` as `Ok("")`, counted under the empty-string key, no finding. Degenerate but valid wire form.
3. **test_valid_utf8_non_ascii_sni_currently_not_flagged** — `"café.example"` (a raw U-label, also a RFC 6066 §3 violation per the A-label requirement). Pins current no-finding behavior; the assertion includes the explicit #51 URL so the cross-reference survives grep and will fire loud when that issue lands.
4. **test_multi_name_sni_list_only_first_entry_counted** — 3 ServerName entries; only the first is counted, matching `extract_sni`'s `list.first()` behavior.
5. **test_non_utf8_sni_finding_fires_when_sni_counts_at_capacity** — fills `sni_counts` to `MAX_MAP_ENTRIES = 50_000` via 50k unique ClientHellos through the public API, then sends a non-UTF-8 SNI ClientHello. Verifies the new non-UTF-8 key is dropped at the cap but the finding still fires. Pins a real invariant: finding emission is independent of count insertion. Delta is filtered by `summary.contains("non-UTF-8 bytes")` so the pin stays tight under refactors.

## Why brute-force for test 5 (not a test helper)
Reaching `MAX_MAP_ENTRIES = 50_000` via the public API was chosen over adding a `#[cfg(test)] pub(crate)` test helper on `TlsAnalyzer` to expose internal state. The trade-off was validated with Perplexity (rustc community tends to accept slow boundary tests over test-only production surface) and empirically: debug runtime ~650ms, release ~120ms. The constant is hand-duplicated in the test but self-corrects via the length assertion (any change to the cap would loudly fail).

## RFC validation
Before applying the code-reviewer's fixes, RFC 6066 §3 was fetched directly to confirm the relevant spec claims:
- `ServerNameList server_name_list<1..2^16-1>` — minimum 1 entry (empty lists are RFC-violating wire form, used in test 1 only to exercise the analyzer's defensive branch)
- `enum { host_name(0), (255) } NameType` — `(255)` reserves room for future types (informs the #52 follow-up for non-zero NameType testing)
- RFC 6066 is **silent** on duplicate SNI extensions, so that case was dropped from the follow-up list

## Test plan
- [x] `cargo test --test tls_analyzer_tests` — 18/18 pass (~650ms total, test 5 is ~650ms of that)
- [x] `cargo test` — full suite green
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] Code review pass (`pr-test-analyzer`): 1 important finding (I1 silent false-positive), 1 important (I2 panic message link), 3 suggestions — all applied before PR creation
- [x] RFC 6066 §3 claims validated via direct RFC fetch before applying review fixes