### PR TITLE
chore: ignore .factory/ worktree at repo root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 .claude/worktrees/
+.factory/


### PR DESCRIPTION
## Summary

- Add `.factory/` to root `.gitignore` so the VSDD factory worktree (mounted on the orphan `factory-artifacts` branch) stops appearing as untracked when you `git status` on `develop`.
- Mirrors how `.claude/worktrees/` is already ignored — same reason, same shape, one-line change.

## Why

`.factory/` is a separate git worktree, not source code. The orphan branch `factory-artifacts` was bootstrapped to hold VSDD pipeline artifacts (STATE.md, behavioral-contract specs, holdout scenarios, etc.) without polluting the application history. From `develop`'s point of view, the directory is a sibling worktree — git treats it as untracked because the parent branch's index doesn't know about it.

## Test plan

- [ ] CI passes (test, clippy, fmt — this is a docs/ignore change so no behavior is exercised)
- [ ] Semantic PR title check passes (`chore:` is in the allowed type list)
- [ ] After merge, `git status` on `develop` no longer shows `?? .factory/`