### PR TITLE
fix: declare MSRV 1.91 and exclude .pcapng from directory expansion

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "wirerust"
 version = "0.1.0"
 edition = "2024"
+rust-version = "1.91"
 description = "Fast PCAP forensics and network triage CLI tool"
 license = "MIT"
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -244,7 +244,7 @@ fn resolve_targets(target: &Path) -> Result<Vec<std::path::PathBuf>> {
             let path = entry.path();
             if path.is_file()
                 && let Some(ext) = path.extension()
-                && (ext == "pcap" || ext == "pcapng")
+                && ext == "pcap"
             {
                 files.push(path);
             }


### PR DESCRIPTION
## Summary

Two small correctness gaps surfaced by Phase 0 brownfield ingestion (`.factory/semport/wirerust/wirerust-pass-8-deep-synthesis.md`, lessons P0.01 + P0.02):

1. **Declare effective MSRV in `Cargo.toml`** — `src/analyzer/http.rs:97` calls `str::floor_char_boundary`, stabilized in Rust 1.91.0. Without `rust-version`, users on 1.85..1.90 hit a confusing stdlib-pointing error. Now cargo emits a clear MSRV-mismatch diagnostic at manifest-load time.

2. **Stop globbing `*.pcapng` in directory expansion** — `resolve_targets` in `main.rs` matched both `*.pcap` and `*.pcapng`, but `PcapReader::new` rejects pcapng with the generic `"Failed to parse pcap header"`. Mixed-format directories now skip pcapng cleanly instead of producing an unhelpful error mid-run.

Earlier analysis had inferred MSRV=1.86 from a release date; clippy's `incompatible_msrv` lint pinned the correct value at 1.91 during local CI gate verification.

## Diff size

`+2 / -1` across two files (`Cargo.toml` and `src/main.rs`).

## Test plan

- [x] `cargo check` — passes
- [x] `cargo clippy --all-targets -- -D warnings` — passes (was failing before the MSRV bump to 1.91 because of the `incompatible_msrv` lint)
- [x] `cargo fmt --check` — passes
- [x] `cargo test --all-targets` — all suites pass (zero failures across all test files; existing `test_multiple_targets` still parses 3 positional args with mixed `.pcap` / `.pcapng` / dir paths, unaffected by the glob change since that's CLI parsing not expansion)
- [ ] CI passes on PR