### PR TITLE
fix: wire --json <FILE> to fs::write and bail loudly on --csv

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -61,6 +61,8 @@ fn run_analyze(
     use_color: bool,
     cli: &Cli,
 ) -> Result<()> {
+    check_unsupported_outputs(cli)?;
+
     let mut summary = Summary::new();
     let mut dns_analyzer = DnsAnalyzer::new();
     let mut all_findings = Vec::new();
@@ -169,7 +171,8 @@ fn run_analyze(
         analyzer_summaries.push(tls.summarize());
     }
 
-    let output = match cli.output_format {
+    let resolved_format = resolve_format(cli);
+    let output = match resolved_format {
         Some(OutputFormat::Json) => {
             let reporter = JsonReporter;
             reporter.render(&summary, &all_findings, &analyzer_summaries)
@@ -183,11 +186,13 @@ fn run_analyze(
         }
     };
 
-    println!("{output}");
+    write_output(&output, cli)?;
     Ok(())
 }
 
 fn run_summary(targets: &[std::path::PathBuf], use_color: bool, cli: &Cli) -> Result<()> {
+    check_unsupported_outputs(cli)?;
+
     let mut summary = Summary::new();
     let mut total_decode_errors: u64 = 0;
 
@@ -215,7 +220,8 @@ fn run_summary(targets: &[std::path::PathBuf], use_color: bool, cli: &Cli) -> Re
     }
     summary.skipped_packets = total_decode_errors;
 
-    let output = match cli.output_format {
+    let resolved_format = resolve_format(cli);
+    let output = match resolved_format {
         Some(OutputFormat::Json) => {
             let reporter = JsonReporter;
             reporter.render(&summary, &[], &[])
@@ -229,7 +235,50 @@ fn run_summary(targets: &[std::path::PathBuf], use_color: bool, cli: &Cli) -> Re
         }
     };
 
-    println!("{output}");
+    write_output(&output, cli)?;
+    Ok(())
+}
+
+/// Determine the output format, with `--json [<FILE>]` overriding `--output-format`.
+///
+/// Precedence (highest to lowest):
+/// 1. `--json` (with or without path) forces `OutputFormat::Json`.
+/// 2. `--output-format <fmt>` is honored as-is.
+/// 3. Default (terminal table) when neither flag is given.
+fn resolve_format(cli: &Cli) -> Option<OutputFormat> {
+    if cli.json.is_some() {
+        Some(OutputFormat::Json)
+    } else {
+        cli.output_format
+    }
+}
+
+/// Write rendered output either to a file (if `--json <FILE>` was given) or stdout.
+fn write_output(output: &str, cli: &Cli) -> Result<()> {
+    match &cli.json {
+        Some(Some(path)) => std::fs::write(path, output)
+            .with_context(|| format!("Failed to write JSON output to {}", path.display())),
+        _ => {
+            println!("{output}");
+            Ok(())
+        }
+    }
+}
+
+/// Bail before any analysis if the user requested CSV output. The CSV reporter
+/// is unimplemented; previously the request was silently downgraded to terminal
+/// output, hiding the failure. Make it loud until the CSV reporter lands.
+fn check_unsupported_outputs(cli: &Cli) -> Result<()> {
+    if cli.csv.is_some() {
+        anyhow::bail!(
+            "--csv output is not yet implemented; rerun without --csv (or use --output-format json --json <FILE> for file output)"
+        );
+    }
+    if matches!(cli.output_format, Some(OutputFormat::Csv)) {
+        anyhow::bail!(
+            "--output-format csv is not yet implemented; choose 'json' or omit the flag for the terminal table"
+        );
+    }
     Ok(())
 }
 

--- a/tests/cli_integration_tests.rs
+++ b/tests/cli_integration_tests.rs
@@ -1,0 +1,127 @@
+//! End-to-end CLI integration tests that spawn the `wirerust` binary.
+//!
+//! These tests exercise the `--json <FILE>` file-output path (LESSON-P0.04) and
+//! the loud-bail behavior on `--csv` / `--output-format csv`. They are the
+//! first activated use of the `assert_cmd` + `predicates` + `tempfile`
+//! dev-dependencies (previously dead per BC-ABS-009).
+
+use assert_cmd::Command;
+use predicates::str::contains;
+
+/// Smallest consumed pcap fixture in the tree (1,209 B). Produces a small but
+/// non-empty findings set when analyzed with `--all`.
+const FIXTURE: &str = "tests/fixtures/http-ooo.pcap";
+
+#[test]
+fn json_file_output_writes_json_content_to_path() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let out_path = tmp.path().join("out.json");
+
+    Command::cargo_bin("wirerust")
+        .expect("binary built")
+        .args([
+            "analyze",
+            FIXTURE,
+            "--all",
+            "--json",
+            out_path.to_str().expect("utf-8 path"),
+        ])
+        .assert()
+        .success();
+
+    let written = std::fs::read_to_string(&out_path).expect("output file exists");
+    assert!(
+        written.contains("\"summary\""),
+        "JSON output must contain a 'summary' key; got first 200 chars: {}",
+        &written[..200.min(written.len())]
+    );
+    assert!(
+        written.contains("\"findings\""),
+        "JSON output must contain a 'findings' key; got first 200 chars: {}",
+        &written[..200.min(written.len())]
+    );
+}
+
+#[test]
+fn json_file_output_overrides_terminal_output_format() {
+    // --output-format is not given; --json <FILE> alone should force JSON
+    // (i.e. the file is written even without --output-format json on the CLI).
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let out_path = tmp.path().join("forced.json");
+
+    Command::cargo_bin("wirerust")
+        .expect("binary built")
+        .args([
+            "analyze",
+            FIXTURE,
+            "--all",
+            "--json",
+            out_path.to_str().expect("utf-8 path"),
+        ])
+        .assert()
+        .success();
+
+    let written = std::fs::read_to_string(&out_path).expect("output file exists");
+    // The terminal reporter never emits raw `{`-prefixed JSON; if `--json
+    // <FILE>` did not force JSON, the file would either be terminal-table
+    // text or absent.
+    assert!(
+        written.trim_start().starts_with('{'),
+        "file must contain JSON object, got prefix: {:?}",
+        &written[..50.min(written.len())]
+    );
+}
+
+#[test]
+fn csv_flag_bails_with_clear_message() {
+    Command::cargo_bin("wirerust")
+        .expect("binary built")
+        .args(["analyze", FIXTURE, "--csv"])
+        .assert()
+        .failure()
+        .stderr(contains("--csv output is not yet implemented"));
+}
+
+#[test]
+fn csv_flag_with_path_bails_with_clear_message() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let out_path = tmp.path().join("would-not-be-written.csv");
+
+    Command::cargo_bin("wirerust")
+        .expect("binary built")
+        .args([
+            "analyze",
+            FIXTURE,
+            "--csv",
+            out_path.to_str().expect("utf-8 path"),
+        ])
+        .assert()
+        .failure()
+        .stderr(contains("--csv output is not yet implemented"));
+
+    assert!(
+        !out_path.exists(),
+        "CSV bail must not create the requested output file"
+    );
+}
+
+#[test]
+fn output_format_csv_bails_with_clear_message() {
+    Command::cargo_bin("wirerust")
+        .expect("binary built")
+        .args(["analyze", FIXTURE, "--output-format", "csv"])
+        .assert()
+        .failure()
+        .stderr(contains("--output-format csv is not yet implemented"));
+}
+
+#[test]
+fn summary_subcommand_also_honors_csv_bail() {
+    // The bail must fire for both subcommands, not just `analyze`.
+    Command::cargo_bin("wirerust")
+        .expect("binary built")
+        .args(["summary", FIXTURE, "--csv"])
+        .assert()
+        .failure()
+        .stderr(contains("--csv output is not yet implemented"));
+}


### PR DESCRIPTION
## Summary

Closes **LESSON-P0.04** from the brownfield Phase 0 synthesis (`.factory/semport/wirerust/wirerust-pass-8-deep-synthesis.md`). Two CLI surfaces were silently failing:

- **`--json <FILE>` and `--csv <FILE>`** parsed an `Option<Option<PathBuf>>`, but `main.rs` never read either — output always went to stdout, the file path was discarded. Users running `wirerust analyze foo.pcap --json out.json` got no file and no warning.
- **`OutputFormat::Csv`** existed in the enum and `csv` was a declared dep, but no CSV reporter existed. The match arm only handled `Json`; everything else (incl. `Csv`) silently fell through to the terminal reporter.

## What changed

Three small helpers in `src/main.rs`, called from both subcommands:

- `check_unsupported_outputs(cli)` — bails up-front on `--csv` (any form) or `--output-format csv`. Loud failure is strictly better than silent terminal-output downgrade until a CSV reporter lands (tracked as LESSON-P2.03).
- `resolve_format(cli)` — gives `--json [<FILE>]` precedence over `--output-format`, so `wirerust ... --json out.json` no longer needs an explicit `--output-format json` to actually produce JSON in the file.
- `write_output(output, cli)` — writes to the path when `--json <FILE>` was given, else `println!` (unchanged default).

## Tests

New file `tests/cli_integration_tests.rs` activates the three previously-dead dev-deps (`assert_cmd`, `predicates`, `tempfile` — BC-ABS-009) with 6 end-to-end tests:

1. `--json <FILE>` writes JSON content (verifies `summary` and `findings` keys land in the file)
2. `--json <FILE>` forces JSON format even without `--output-format json` (file starts with `{`)
3. `--csv` (bare flag) bails with clear message
4. `--csv <FILE>` bails AND verifies the file is NOT created
5. `--output-format csv` bails with clear message
6. `summary --csv` also honors the bail (both subcommands covered)

## Diff size

`+180 / -4` across `src/main.rs` (3 helpers + 4 wiring sites) and the new `tests/cli_integration_tests.rs` (~120 LOC of tests).

## Test plan

- [x] `cargo check` — passes
- [x] `cargo clippy --all-targets -- -D warnings` — passes
- [x] `cargo fmt --check` — passes
- [x] `cargo test --all-targets` — all suites pass (213 prior tests + 6 new = 219 tests total; 0 failures)
- [ ] CI passes on PR

## Follow-up

- **LESSON-P0.05** (next PR): fix inverted missing-Host vs missing-UA contracts in `src/analyzer/http.rs`.
- **LESSON-P2.03** (future): implement the actual CSV reporter so `--csv` and `--output-format csv` produce real output instead of bailing.