### PR TITLE
fix(http): detect empty-value Host header as RFC 7230 §5.4 anomaly

### DIFF
--- a/src/analyzer/http.rs
+++ b/src/analyzer/http.rs
@@ -247,18 +247,40 @@ impl HttpAnalyzer {
             });
         }
 
-        // 5. Missing Host header (HTTP/1.1 requires it)
-        if parsed.version == 1 && parsed.host.is_none() {
-            self.all_findings.push(Finding {
-                category: ThreatCategory::Anomaly,
-                verdict: Verdict::Inconclusive,
-                confidence: Confidence::Medium,
-                summary: "HTTP/1.1 request without Host header".to_string(),
-                evidence: vec![format!("{} {}", parsed.method, parsed.uri)],
-                mitre_technique: None,
-                source_ip: None,
-                timestamp: None,
-            });
+        // 5. Missing or empty Host header on HTTP/1.1.
+        //
+        // RFC 7230 §5.4 (and successor RFC 9112 §3.2) require an HTTP/1.1
+        // request to carry exactly one non-empty `Host` field-value; both
+        // absent-Host and empty-value-Host are equally non-compliant and
+        // are documented evasion lanes in front-end/back-end request-
+        // smuggling research (PortSwigger; Node.js CVE-2022-35256). The
+        // closest comparator tool (Suricata) surfaces these as two
+        // separate events (sids 2221014 `http.missing_host_header` and
+        // 2221028 `http.request_header_host_invalid`); we fold both into
+        // one Anomaly finding but disambiguate via the summary text so
+        // downstream analysts can grep either case.
+        //
+        // Note: `find_header` already trims whitespace from header
+        // values, so `Some("")` here covers both `Host:\r\n` and
+        // `Host:   \r\n`.
+        if parsed.version == 1 {
+            let host_anomaly_summary = match parsed.host.as_deref() {
+                None => Some("HTTP/1.1 request without Host header"),
+                Some("") => Some("HTTP/1.1 request with empty Host header"),
+                Some(_) => None,
+            };
+            if let Some(summary) = host_anomaly_summary {
+                self.all_findings.push(Finding {
+                    category: ThreatCategory::Anomaly,
+                    verdict: Verdict::Inconclusive,
+                    confidence: Confidence::Medium,
+                    summary: summary.to_string(),
+                    evidence: vec![format!("{} {}", parsed.method, parsed.uri)],
+                    mitre_technique: None,
+                    source_ip: None,
+                    timestamp: None,
+                });
+            }
         }
 
         // 6. Long URI (> 2048 chars)
@@ -275,7 +297,31 @@ impl HttpAnalyzer {
             });
         }
 
-        // 7. Empty User-Agent
+        // 7. Empty User-Agent (deliberately asymmetric with the Host
+        //    check above — only `Some("")` fires, absent UA is ignored).
+        //
+        // Rationale for not firing on absent UA:
+        //   - Many legitimate clients omit UA entirely (cron jobs,
+        //     internal microservices, healthchecks, embedded HTTP
+        //     libraries). Snort ships its "POLICY-OTHER HTTP Request
+        //     missing user-agent" rule (sid 1:38130) **disabled by
+        //     default** for this reason — it is treated as a policy
+        //     violation, not a malicious-traffic indicator.
+        //   - Empty-UA, in contrast, is a stronger signal. Kheir (2015,
+        //     "Malware Detection Using HTTP User-Agent Discrepancy
+        //     Identification") reports ~24% of malware samples in a
+        //     181k-sample Totalhash corpus emit an empty UA. Real
+        //     browsers always populate UA, and common tools (curl,
+        //     wget, Python `requests`) send a default string when one
+        //     is not overridden.
+        //   - Suricata's `http-events.rules` ships no built-in UA
+        //     presence/emptiness anomaly at all; both detections are
+        //     left to rule-authors via `http.user_agent` content
+        //     matching, which we do not do here.
+        //
+        // If a policy-mode "missing UA" finding is later desired, it
+        // should be added as a separate, lower-confidence finding
+        // rather than collapsing the two cases.
         if parsed.user_agent.as_deref() == Some("") {
             self.all_findings.push(Finding {
                 category: ThreatCategory::Anomaly,

--- a/tests/http_analyzer_tests.rs
+++ b/tests/http_analyzer_tests.rs
@@ -160,16 +160,69 @@ fn test_detect_unusual_method() {
 
 #[test]
 fn test_detect_missing_host_header() {
+    // HTTP/1.1 without any Host header is RFC 7230 §5.4 non-compliant
+    // and must produce a "without Host header" Anomaly finding.
     let mut analyzer = HttpAnalyzer::new();
     let fk = test_flow_key();
     let request = b"GET /path HTTP/1.1\r\n\r\n";
     analyzer.on_data(&fk, Direction::ClientToServer, request, 0);
     let findings = analyzer.findings();
+    let host_finding = findings
+        .iter()
+        .find(|f| f.summary.contains("without Host header"))
+        .expect("expected a missing-Host anomaly");
+    assert_eq!(host_finding.category, ThreatCategory::Anomaly);
+    assert_eq!(host_finding.verdict, Verdict::Inconclusive);
+    assert_eq!(host_finding.confidence, Confidence::Medium);
+}
+
+#[test]
+fn test_detect_empty_host_header() {
+    // An empty-value `Host:` is equally RFC 7230 §5.4 non-compliant and
+    // is the documented bypass that the `is_none()`-only check missed
+    // (Suricata surfaces this as sid 2221028
+    // `http.request_header_host_invalid`, separate from the
+    // sid-2221014 missing-Host event). It must produce an Anomaly
+    // finding with the distinct "empty Host header" summary so analysts
+    // can disambiguate it from the truly-absent case.
+    let mut analyzer = HttpAnalyzer::new();
+    let fk = test_flow_key();
+    let request = b"GET /path HTTP/1.1\r\nHost: \r\nUser-Agent: curl/8.0\r\n\r\n";
+    analyzer.on_data(&fk, Direction::ClientToServer, request, 0);
+    let findings = analyzer.findings();
+    let host_finding = findings
+        .iter()
+        .find(|f| f.summary.contains("empty Host header"))
+        .expect("expected an empty-Host anomaly");
+    assert_eq!(host_finding.category, ThreatCategory::Anomaly);
+    assert_eq!(host_finding.verdict, Verdict::Inconclusive);
+    assert_eq!(host_finding.confidence, Confidence::Medium);
+
+    // And the *missing* variant must not also fire on the empty case —
+    // they are surfaced via distinct summary strings.
     assert!(
-        findings
+        !findings
             .iter()
-            .any(|f| f.category == ThreatCategory::Anomaly),
-        "Should detect missing Host header"
+            .any(|f| f.summary.contains("without Host header")),
+        "empty-Host case must not also trigger the missing-Host variant"
+    );
+}
+
+#[test]
+fn test_detect_whitespace_only_host_header() {
+    // `Host:    ` (whitespace-only value) is folded into the empty case
+    // by `find_header`'s `.trim()` and must produce the same empty-Host
+    // anomaly as a literally-empty value.
+    let mut analyzer = HttpAnalyzer::new();
+    let fk = test_flow_key();
+    let request = b"GET /path HTTP/1.1\r\nHost:    \r\n\r\n";
+    analyzer.on_data(&fk, Direction::ClientToServer, request, 0);
+    assert!(
+        analyzer
+            .findings()
+            .iter()
+            .any(|f| f.summary.contains("empty Host header")),
+        "whitespace-only Host: must fire the empty-Host anomaly"
     );
 }
 
@@ -633,9 +686,15 @@ fn test_detect_empty_user_agent() {
 
 #[test]
 fn test_missing_user_agent_no_finding() {
-    // A missing User-Agent header (not present at all) should NOT
-    // trigger the empty-UA finding. The detection specifically checks
-    // for Some(""), not None.
+    // A missing User-Agent header (not present at all) must NOT trigger
+    // the empty-UA finding. This asymmetry with the Host check is
+    // deliberate and documented in `src/analyzer/http.rs` (rule 7
+    // comment): Snort ships its missing-UA rule (sid 1:38130) disabled
+    // by default because legitimate non-browser traffic (cron jobs,
+    // healthchecks, microservices, embedded clients) routinely omits
+    // UA, while empty-UA is a stronger malicious-traffic indicator
+    // (Kheir 2015 reports ~24% of malware samples emit empty UA).
+    // The detection specifically checks for `Some("")`, not `None`.
     let mut analyzer = HttpAnalyzer::new();
     let fk = test_flow_key();
 


### PR DESCRIPTION
## Summary
- **Closes LESSON-P0.05** from the brownfield-ingest Phase C synthesis: \`src/analyzer/http.rs\` previously only fired the missing-Host anomaly on \`parsed.host.is_none()\`, but \`find_header\` trims header values, so \`Host:\r\n\` and \`Host:   \r\n\` arrive as \`Some("")\` and silently bypassed detection — a real evasion lane.
- **Host fix:** detect absent **or** empty/whitespace-only Host on HTTP/1.1, with distinct summaries per case (\`"HTTP/1.1 request without Host header"\` vs \`"HTTP/1.1 request with empty Host header"\`).
- **User-Agent unchanged on purpose:** the lesson statement bundled Host + UA into one symmetric fix, but research showed they are not symmetric in IDS practice. UA logic remains \`Some("") only fires\`; the comment is upgraded with cited rationale.

## Decision: scope-narrowed from the literal lesson

LESSON-P0.05 in \`wirerust-pass-8-deep-synthesis.md\` recommended treating both Host and UA symmetrically as \`is_none() || value.trim().is_empty()\`. I dispatched a research-agent (Perplexity / Tavily, primary-source bias) before implementing. Findings:

| Aspect | Host | User-Agent |
|---|---|---|
| RFC stance | RFC 7230 §5.4 / RFC 9112 §3.2 require non-empty Host on HTTP/1.1; both absent and empty are 400-worthy | Optional header — no RFC requirement |
| Suricata | Surfaces \`http.missing_host_header\` (sid 2221014) **and** \`http.request_header_host_invalid\` (sid 2221028) separately | Ships **no** built-in UA presence/emptiness anomaly |
| Snort | No built-in protocol-anomaly rule for empty Host (rule-author territory) | Ships \`POLICY-OTHER HTTP Request missing user-agent\` (sid 1:38130) **disabled by default** — Talos treats absent UA as policy violation, not malicious indicator |
| Threat intel | Empty/duplicated Host is a primary request-smuggling lever (PortSwigger; CVE-2022-35256) | Kheir 2015 (181k-sample malware corpus) reports ~24% of malware emits empty UA; absent UA has high false-positive rate from cron / healthcheck / microservice / embedded traffic |
| **Conclusion** | Empty Host is a real bypass; close it | Asymmetric design (empty-UA fires, absent-UA ignored) is consistent with industry practice; preserve it |

So this PR implements **option (a)** from the research: fix Host symmetrically, keep UA asymmetric, upgrade the UA source comment from tribal knowledge to a cited convention.

## Files changed

- \`src/analyzer/http.rs\`
  - **Rule 5 (Host):** rewritten with a 3-way \`match\` on \`parsed.host.as_deref()\` producing distinct summary text for \`None\` vs \`Some("")\` so analysts can disambiguate. Block comment cites RFCs, Suricata sids, and the smuggling research.
  - **Rule 7 (UA):** unchanged logic. Block comment expanded with the three citations above.
- \`tests/http_analyzer_tests.rs\`
  - \`test_detect_missing_host_header\` — tightened to assert specific summary + category/verdict/confidence, not just "any Anomaly".
  - \`test_detect_empty_host_header\` (**new**) — \`Host:\r\n\` fires the empty-Host variant and *not* the missing-Host variant.
  - \`test_detect_whitespace_only_host_header\` (**new**) — \`Host:    \r\n\` folds into the empty-Host case (verifies the \`find_header\`-trims-the-value assumption that load-bears the fix).
  - \`test_missing_user_agent_no_finding\` — comment refreshed with citations.

## Test plan
- [x] \`cargo fmt --check\` — clean
- [x] \`cargo clippy --all-targets -- -D warnings\` — clean
- [x] \`cargo test --all-targets\` — 221 tests passed, 0 failed (was 219 before this PR; +2 new Host tests)
- [x] Existing \`test_missing_user_agent_no_finding\` still passes — asymmetric UA behavior preserved
- [x] Existing \`test_detect_empty_user_agent\` still passes
- [x] Existing \`test_detect_missing_host_header\` (now tightened) still passes

## Trade-offs called out
1. Empty-Host detection may flag some legitimately malformed-but-benign client traffic (older embedded HTTP libraries occasionally emit empty Host). Accepted: RFC compliance is unambiguous, and the smuggling-evasion value outweighs the noise.
2. Absent-UA from a malicious script will still not alert. Long-term mitigation should be a separate \`http.user_agent.suspicious\` rule (known-bad UA strings, single-char UAs) rather than alerting on absence.

## Cited sources
RFC 7230 §5.4 · RFC 9112 §3.2 · OISF Suricata \`http-events.rules\` (sids 2221014/2221028) · Snort rule_docs 1:38130 · F5 BIG-IP ASM HTTP-header config · Mozilla bug 474845 (empty vs absent header semantics) · Kheir 2015 ("Malware Detection Using HTTP User-Agent Discrepancy Identification") · PortSwigger Web Security Academy — HTTP request smuggling · Prelude Security on CVE-2022-35256.