### PR TITLE
fix(reassembly): guarantee finalize() on ?-bail + Drop lifecycle tripwire

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -100,50 +100,64 @@ fn run_analyze(
     };
     let mut dispatcher = StreamDispatcher::new(http_analyzer, tls_analyzer);
 
-    for target in targets {
-        let pcap_files = resolve_targets(target)?;
-        for path in &pcap_files {
-            let source = PcapSource::from_file(path)
-                .with_context(|| format!("Failed to read {}", path.display()))?;
+    // Capture loop wrapped in an immediately-invoked closure so any `?`-bail
+    // inside (e.g. unreadable pcap, malformed progress-bar template) is
+    // captured as an `Err` *without* short-circuiting `run_analyze` itself.
+    // This guarantees we always reach the reassembler `finalize` call below,
+    // which is what `impl Drop for TcpReassembler` only warns about — see
+    // LESSON-P0.03 / architecture smell #9 ("no-Drop / finalize-fragile").
+    let capture_result: Result<()> = (|| {
+        for target in targets {
+            let pcap_files = resolve_targets(target)?;
+            for path in &pcap_files {
+                let source = PcapSource::from_file(path)
+                    .with_context(|| format!("Failed to read {}", path.display()))?;
 
-            let pb = ProgressBar::new(source.packets.len() as u64);
-            pb.set_style(ProgressStyle::with_template(
-                "[{elapsed_precise}] {bar:40} {pos}/{len} packets",
-            )?);
+                let pb = ProgressBar::new(source.packets.len() as u64);
+                pb.set_style(ProgressStyle::with_template(
+                    "[{elapsed_precise}] {bar:40} {pos}/{len} packets",
+                )?);
 
-            for raw in &source.packets {
-                match decode_packet(&raw.data, source.datalink) {
-                    Ok(parsed) => {
-                        summary.ingest(&parsed);
-                        if enable_dns && dns_analyzer.can_decode(&parsed) {
-                            let findings = dns_analyzer.analyze(&parsed);
-                            all_findings.extend(findings);
+                for raw in &source.packets {
+                    match decode_packet(&raw.data, source.datalink) {
+                        Ok(parsed) => {
+                            summary.ingest(&parsed);
+                            if enable_dns && dns_analyzer.can_decode(&parsed) {
+                                let findings = dns_analyzer.analyze(&parsed);
+                                all_findings.extend(findings);
+                            }
+                            if let Some(ref mut reasm) = reassembler {
+                                reasm.process_packet(&parsed, raw.timestamp_secs, &mut dispatcher);
+                            }
                         }
-                        if let Some(ref mut reasm) = reassembler {
-                            reasm.process_packet(&parsed, raw.timestamp_secs, &mut dispatcher);
+                        Err(e) => {
+                            if total_decode_errors == 0 {
+                                eprintln!(
+                                    "Warning: failed to decode packet ({e}). Further errors counted silently."
+                                );
+                            }
+                            total_decode_errors += 1;
                         }
                     }
-                    Err(e) => {
-                        if total_decode_errors == 0 {
-                            eprintln!(
-                                "Warning: failed to decode packet ({e}). Further errors counted silently."
-                            );
-                        }
-                        total_decode_errors += 1;
-                    }
+                    pb.inc(1);
                 }
-                pb.inc(1);
+                pb.finish_and_clear();
             }
-            pb.finish_and_clear();
         }
-    }
+        Ok(())
+    })();
 
     summary.skipped_packets = total_decode_errors;
 
+    // ALWAYS finalize the reassembler before propagating any capture error,
+    // so the segment-limit summary finding and per-flow flush still happen
+    // on the partial state captured before the bail.
     if let Some(ref mut reasm) = reassembler {
         reasm.finalize(&mut dispatcher);
         all_findings.extend(reasm.findings().to_vec());
     }
+
+    capture_result?;
 
     if let Some(ref http) = dispatcher.http {
         all_findings.extend(http.findings());

--- a/src/reassembly/mod.rs
+++ b/src/reassembly/mod.rs
@@ -18,6 +18,7 @@ const OUT_OF_WINDOW_ALERT_THRESHOLD: u32 = 100;
 const MAX_FINDINGS: usize = 10_000;
 
 static CLOSE_FLOW_MISSING_WARNED: AtomicBool = AtomicBool::new(false);
+static FINALIZE_SKIPPED_WARNED: AtomicBool = AtomicBool::new(false);
 
 /// Configuration for the TCP reassembly engine.
 #[derive(Debug, Clone)]
@@ -427,6 +428,13 @@ impl TcpReassembler {
         &self.findings
     }
 
+    /// Returns `true` once [`Self::finalize`] has been called. Exposed so
+    /// callers and tests can observe the lifecycle invariant that
+    /// `impl Drop` defends.
+    pub fn is_finalized(&self) -> bool {
+        self.finalized
+    }
+
     /// Return the current total memory used by all flow buffers.
     pub fn total_memory(&self) -> usize {
         self.total_memory
@@ -560,5 +568,37 @@ impl TcpReassembler {
             source_ip: Some(src_ip),
             timestamp: None,
         });
+    }
+}
+
+/// Lifecycle tripwire: warn (once per process) if a reassembler is dropped
+/// without [`TcpReassembler::finalize`] having been called.
+///
+/// `finalize` requires a `&mut dyn StreamHandler`, which `Drop::drop`
+/// cannot accept, so this `impl Drop` cannot itself flush pending flows
+/// or emit summary-level findings. What it *can* do is make the
+/// "forgot-to-finalize" bug loud at runtime, including on unwind from
+/// a `?`-propagated `Err` further up the call stack — which is the
+/// failure mode that closes LESSON-P0.03 in the brownfield-ingest
+/// synthesis (architecture smell #9, "no-Drop / finalize-fragile").
+///
+/// The companion to this tripwire is the `run_analyze` control flow in
+/// `src/main.rs`, which wraps the fallible per-target loop so that
+/// `finalize` is reached before any `Err` escapes the function. The two
+/// pieces together — guaranteed finalize on the happy path + a noisy
+/// runtime check for regressions — replace the original silent skip.
+impl Drop for TcpReassembler {
+    fn drop(&mut self) {
+        if !self.finalized && !FINALIZE_SKIPPED_WARNED.swap(true, Ordering::Relaxed) {
+            eprintln!(
+                "wirerust: TcpReassembler dropped without calling finalize() \
+                 — {} flow(s) and {} byte(s) of buffered segment state were \
+                 discarded without producing summary-level findings. This \
+                 indicates a control-flow bug; further occurrences in this \
+                 process will be suppressed.",
+                self.flows.len(),
+                self.total_memory,
+            );
+        }
     }
 }

--- a/tests/reassembly_engine_tests.rs
+++ b/tests/reassembly_engine_tests.rs
@@ -1396,3 +1396,82 @@ fn test_depth_exceeded_counter() {
         "segments_depth_exceeded should appear in summarize() detail"
     );
 }
+
+// ---- LESSON-P0.03 / smell #9: Drop tripwire + finalize idempotency ----
+
+#[test]
+fn test_is_finalized_flips_on_finalize() {
+    // Lifecycle invariant: `is_finalized()` is false before `finalize` and
+    // true after. This is the field that `impl Drop for TcpReassembler`
+    // reads to decide whether to emit the lifecycle warning.
+    let mut reassembler = TcpReassembler::new(ReassemblyConfig::default());
+    let mut handler = RecordingHandler::new();
+    assert!(
+        !reassembler.is_finalized(),
+        "new reassembler should not yet be finalized"
+    );
+    reassembler.finalize(&mut handler);
+    assert!(
+        reassembler.is_finalized(),
+        "finalize() must flip is_finalized() to true"
+    );
+}
+
+#[test]
+fn test_finalize_is_idempotent() {
+    // The lesson observed that without `impl Drop`, finalize is a manual
+    // call. With the tripwire in place, finalize must also remain safely
+    // idempotent so that callers (or a future Drop guard wrapper) can
+    // invoke it more than once without re-emitting summary findings or
+    // re-flushing flows. Verifies the `if self.finalized { return; }`
+    // guard in mod.rs.
+    let mut reassembler = TcpReassembler::new(ReassemblyConfig::default());
+    let mut handler = RecordingHandler::new();
+    reassembler.finalize(&mut handler);
+    let first_findings = reassembler.findings().len();
+    let first_close_events = handler.close_events.len();
+    reassembler.finalize(&mut handler);
+    assert!(reassembler.is_finalized());
+    assert_eq!(
+        reassembler.findings().len(),
+        first_findings,
+        "second finalize call must not append additional findings"
+    );
+    assert_eq!(
+        handler.close_events.len(),
+        first_close_events,
+        "second finalize call must not re-emit on_flow_close events"
+    );
+}
+
+#[test]
+fn test_drop_without_finalize_does_not_panic() {
+    // `impl Drop for TcpReassembler` is intentionally non-panicking: it
+    // emits a one-shot eprintln warning so future regressions of the
+    // "forgot to call finalize" bug are visible at runtime, but it must
+    // never crash the process. Several existing unit tests construct a
+    // reassembler purely to exercise sub-engine behavior without ever
+    // driving it to a captured-state end-of-input, so the tripwire
+    // would be unusable as a `panic!` / `debug_assert!`.
+    //
+    // This test asserts that dropping an un-finalized reassembler is a
+    // safe, non-panicking operation. Stderr capture for the warning
+    // text itself is left to the integration layer.
+    let reassembler = TcpReassembler::new(ReassemblyConfig::default());
+    assert!(!reassembler.is_finalized());
+    drop(reassembler); // must not panic
+}
+
+#[test]
+fn test_drop_after_finalize_is_silent_path() {
+    // The happy path: caller drives finalize before letting the
+    // reassembler go out of scope. The Drop guard's `!self.finalized`
+    // check is the gating predicate for the warning; this test verifies
+    // we hit that predicate as false, so production runs do not spam
+    // stderr.
+    let mut reassembler = TcpReassembler::new(ReassemblyConfig::default());
+    let mut handler = RecordingHandler::new();
+    reassembler.finalize(&mut handler);
+    assert!(reassembler.is_finalized());
+    drop(reassembler); // must not panic and must be the silent branch
+}


### PR DESCRIPTION
## Summary
**Closes LESSON-P0.03** (architecture smell #9 — "no-Drop / finalize-fragile") from the brownfield-ingest Phase C synthesis. Any \`?\`-bail inside \`run_analyze\`'s capture loop previously skipped \`reasm.finalize(&mut dispatcher)\`, silently discarding partial flow state and its segment-limit summary finding. The lesson asked for \`impl Drop\` to close this, but \`finalize\` takes \`&mut dyn StreamHandler\` and \`Drop::drop\` cannot accept that — so the literal fix is impossible, and the design splits into two complementary halves.

## Design

| Half | What it does | Where |
|---|---|---|
| **Control-flow guarantee** | Wrap the fallible capture loop in an IIFE \`(\|\| -> Result<()> { ... })()\` so any \`?\` short-circuits the closure, not the function. Unconditionally call \`finalize\` on the partial state before \`capture_result?\` propagates the error. | \`src/main.rs::run_analyze\` |
| **Runtime tripwire** | \`impl Drop for TcpReassembler\` — one-shot \`eprintln!\` (not panic) when dropped without \`finalize\` having been called. Reports flow count + buffered bytes that were discarded. Catches future regressions. | \`src/reassembly/mod.rs\` |

The tripwire is intentionally **non-panicking** because several existing unit tests construct a reassembler purely to exercise sub-engine behavior without driving it to end-of-input — a panicking Drop would have broken ≥4 tests. The actual bypass is closed by the control-flow change; Drop is the runtime catch-net.

## Files changed

- \`src/reassembly/mod.rs\`
  - New static \`FINALIZE_SKIPPED_WARNED: AtomicBool\` mirroring the existing \`CLOSE_FLOW_MISSING_WARNED\` one-shot suppression pattern.
  - New public \`is_finalized() -> bool\` accessor — lets callers and tests observe the lifecycle bit.
  - New \`impl Drop for TcpReassembler\` with a one-shot eprintln when \`!self.finalized\`. Doc comment explains the \`finalize\`-needs-handler constraint and the two-half design.
- \`src/main.rs::run_analyze\`
  - Capture loop wrapped in an immediately-invoked \`Result\`-returning closure.
  - Post-loop block now does: \`reasm.finalize(&mut dispatcher)\` → merge findings → \`capture_result?\`. Comments cite the lesson and smell #9.
- \`tests/reassembly_engine_tests.rs\` (+4 tests, all under LESSON-P0.03 banner)
  - \`test_is_finalized_flips_on_finalize\`
  - \`test_finalize_is_idempotent\` — guards \`if self.finalized { return; }\` in mod.rs against double-emission of findings and close events
  - \`test_drop_without_finalize_does_not_panic\` — explicit safety contract for the tripwire
  - \`test_drop_after_finalize_is_silent_path\` — the production happy path

## Test plan
- [x] \`cargo fmt --check\` — clean
- [x] \`cargo clippy --all-targets -- -D warnings\` — clean
- [x] \`cargo test --all-targets\` — **225 passed, 0 failed** (was 221 before this PR; +4 new lifecycle tests)
- [x] All existing reassembly_engine_tests.rs cases (23 instantiations, 19 of which call finalize) still pass — confirms non-panicking Drop coexists with sub-engine unit tests
- [x] All existing http_integration_tests.rs / tls_integration_tests.rs cases still pass

## P0 backlog status after this PR
| Lesson | Status |
|---|---|
| P0.01 — MSRV declaration | ✅ #69 |
| P0.02 — pcapng glob removal | ✅ #69 |
| P0.04 — wire \`--json <FILE>\` to fs::write + bail on \`--csv\` | ✅ #70 |
| P0.05 — Host empty-value detection + UA asymmetry citations | ✅ #71 |
| **P0.03 — Drop guard + finalize control flow** | **this PR** |

All 5 P0 correctness gaps closed. P1 (7 lessons) is next.