### PR TITLE
feat(observability): P1.01 dropped_findings + P1.02 JSON symmetry + P1.05 truncated_records

### DIFF
--- a/src/analyzer/tls.rs
+++ b/src/analyzer/tls.rs
@@ -277,6 +277,12 @@ pub struct TlsAnalyzer {
     cipher_counts: HashMap<String, u64>,
     handshakes_seen: u64,
     parse_errors: u64,
+    /// TLS records whose declared `payload_len` exceeded
+    /// `MAX_RECORD_PAYLOAD` and were dropped before parsing. Counted
+    /// separately from `parse_errors` so that DoS-protection drops are
+    /// distinguishable from genuinely malformed records — see
+    /// LESSON-P1.05 (CNV-PAT-002 follow-up).
+    truncated_records: u64,
     all_findings: Vec<Finding>,
 }
 
@@ -297,6 +303,7 @@ impl TlsAnalyzer {
             cipher_counts: HashMap::new(),
             handshakes_seen: 0,
             parse_errors: 0,
+            truncated_records: 0,
             all_findings: Vec::new(),
         }
     }
@@ -321,6 +328,12 @@ impl TlsAnalyzer {
 
     pub fn parse_error_count(&self) -> u64 {
         self.parse_errors
+    }
+
+    /// TLS records dropped before parsing because their declared
+    /// payload length exceeded `MAX_RECORD_PAYLOAD`. See LESSON-P1.05.
+    pub fn truncated_record_count(&self) -> u64 {
+        self.truncated_records
     }
 
     pub fn handshake_count(&self) -> u64 {
@@ -584,9 +597,18 @@ impl TlsAnalyzer {
                 (record_type, payload_len)
             };
 
-            // Reject impossibly large records (DoS protection)
+            // Reject impossibly large records (DoS protection).
+            //
+            // LESSON-P1.05 / CNV-PAT-002 follow-up: bump the dedicated
+            // `truncated_records` counter in addition to `parse_errors`
+            // so JSON consumers can distinguish "record dropped because
+            // its declared length blew the cap" (a capacity/DoS event)
+            // from "record contents failed to parse" (a malformed-data
+            // event). `parse_errors` is kept incremented to preserve
+            // back-compatibility with existing dashboards.
             if payload_len > MAX_RECORD_PAYLOAD {
                 self.parse_errors += 1;
+                self.truncated_records += 1;
                 if let Some(state) = self.flows.get_mut(flow_key) {
                     match direction {
                         Direction::ClientToServer => state.client_buf.clear(),
@@ -735,6 +757,10 @@ impl StreamAnalyzer for TlsAnalyzer {
         detail.insert(
             "parse_errors".to_string(),
             serde_json::json!(self.parse_errors),
+        );
+        detail.insert(
+            "truncated_records".to_string(),
+            serde_json::json!(self.truncated_records),
         );
 
         AnalysisSummary {

--- a/src/findings.rs
+++ b/src/findings.rs
@@ -63,7 +63,15 @@ pub struct Finding {
     pub confidence: Confidence,
     pub summary: String,
     pub evidence: Vec<String>,
+    // LESSON-P1.02 / NFR OBS-010: all three `Option<_>` fields are
+    // emitted symmetrically — absent values are omitted from the JSON
+    // object rather than serialized as `null`. Previously only
+    // `timestamp` carried this attribute, producing an asymmetric
+    // mixed-shape output (`mitre_technique: null` vs no `timestamp`
+    // key at all) that made JSON consumers harder to write.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub mitre_technique: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub source_ip: Option<IpAddr>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub timestamp: Option<DateTime<Utc>>,

--- a/src/reassembly/mod.rs
+++ b/src/reassembly/mod.rs
@@ -70,6 +70,11 @@ pub struct ReassemblyStats {
     pub segments_depth_exceeded: u64,
     pub bytes_reassembled: u64,
     pub evictions: u64,
+    /// Anomaly findings that were suppressed because `self.findings` had
+    /// already reached `MAX_FINDINGS`. Exposed in `summarize()` under
+    /// `dropped_findings` so JSON consumers can detect when the cap was
+    /// hit and per-flow signal was silently lost — see LESSON-P1.01.
+    pub dropped_findings: u64,
 }
 
 /// The main TCP reassembly engine.
@@ -268,67 +273,82 @@ impl TcpReassembler {
             // Check anomaly thresholds on the direction
             let flow = self.flows.get_mut(&key).unwrap();
             let flow_dir = flow.get_direction_mut(dir);
-            if flow_dir.overlap_count > OVERLAP_ALERT_THRESHOLD
-                && !flow_dir.overlap_alert_fired
-                && self.findings.len() < MAX_FINDINGS
-            {
+            // LESSON-P1.01: the per-direction alert latches now flip
+            // unconditionally once their threshold trips, even when the
+            // finding push is suppressed by the MAX_FINDINGS cap. This
+            // prevents re-evaluating the same threshold on every
+            // subsequent packet (which would also miscount as multiple
+            // dropped_findings rather than one) and lets the
+            // dropped_findings counter accurately reflect distinct
+            // anomalies lost to the cap.
+            if flow_dir.overlap_count > OVERLAP_ALERT_THRESHOLD && !flow_dir.overlap_alert_fired {
                 flow_dir.overlap_alert_fired = true;
-                self.findings.push(Finding {
-                    category: ThreatCategory::Anomaly,
-                    verdict: Verdict::Likely,
-                    confidence: Confidence::Medium,
-                    summary: format!(
-                        "Excessive segment overlaps ({}) on flow {}",
-                        flow_dir.overlap_count, key
-                    ),
-                    evidence: vec!["Possible evasion attempt".into()],
-                    mitre_technique: Some("T1036".into()),
-                    source_ip: Some(packet.src_ip),
-                    timestamp: None,
-                });
+                if self.findings.len() < MAX_FINDINGS {
+                    self.findings.push(Finding {
+                        category: ThreatCategory::Anomaly,
+                        verdict: Verdict::Likely,
+                        confidence: Confidence::Medium,
+                        summary: format!(
+                            "Excessive segment overlaps ({}) on flow {}",
+                            flow_dir.overlap_count, key
+                        ),
+                        evidence: vec!["Possible evasion attempt".into()],
+                        mitre_technique: Some("T1036".into()),
+                        source_ip: Some(packet.src_ip),
+                        timestamp: None,
+                    });
+                } else {
+                    self.stats.dropped_findings += 1;
+                }
             }
             if flow_dir.small_segment_count > SMALL_SEGMENT_ALERT_THRESHOLD
                 && !flow_dir.small_segment_alert_fired
-                && self.findings.len() < MAX_FINDINGS
             {
                 flow_dir.small_segment_alert_fired = true;
-                self.findings.push(Finding {
-                    category: ThreatCategory::Anomaly,
-                    verdict: Verdict::Inconclusive,
-                    confidence: Confidence::Medium,
-                    summary: format!(
-                        "Excessive small segments ({}) on flow {}",
-                        flow_dir.small_segment_count, key
-                    ),
-                    evidence: vec!["Possible IDS evasion".into()],
-                    mitre_technique: None,
-                    source_ip: Some(packet.src_ip),
-                    timestamp: None,
-                });
+                if self.findings.len() < MAX_FINDINGS {
+                    self.findings.push(Finding {
+                        category: ThreatCategory::Anomaly,
+                        verdict: Verdict::Inconclusive,
+                        confidence: Confidence::Medium,
+                        summary: format!(
+                            "Excessive small segments ({}) on flow {}",
+                            flow_dir.small_segment_count, key
+                        ),
+                        evidence: vec!["Possible IDS evasion".into()],
+                        mitre_technique: None,
+                        source_ip: Some(packet.src_ip),
+                        timestamp: None,
+                    });
+                } else {
+                    self.stats.dropped_findings += 1;
+                }
             }
             if flow_dir.out_of_window_count > OUT_OF_WINDOW_ALERT_THRESHOLD
                 && !flow_dir.out_of_window_alert_fired
-                && self.findings.len() < MAX_FINDINGS
             {
                 flow_dir.out_of_window_alert_fired = true;
                 let count = flow_dir.out_of_window_count;
                 let window = self.config.max_receive_window;
-                self.findings.push(Finding {
-                    category: ThreatCategory::Anomaly,
-                    verdict: Verdict::Inconclusive,
-                    confidence: Confidence::Low,
-                    summary: format!(
-                        "Excessive out-of-window segments ({}) on flow {}",
-                        count, key
-                    ),
-                    evidence: vec![format!(
-                        "max_receive_window={} bytes; possible misconfiguration, evasion, or capture corruption",
-                        window
-                    )],
-                    mitre_technique: None,
-                    source_ip: Some(packet.src_ip),
-                    timestamp: None,
-                });
+                if self.findings.len() < MAX_FINDINGS {
+                    self.findings.push(Finding {
+                        category: ThreatCategory::Anomaly,
+                        verdict: Verdict::Inconclusive,
+                        confidence: Confidence::Low,
+                        summary: format!(
+                            "Excessive out-of-window segments ({}) on flow {}",
+                            count, key
+                        ),
+                        evidence: vec![format!(
+                            "max_receive_window={} bytes; possible misconfiguration, evasion, or capture corruption",
+                            window
+                        )],
+                        mitre_technique: None,
+                        source_ip: Some(packet.src_ip),
+                        timestamp: None,
+                    });
+                } else {
+                    self.stats.dropped_findings += 1;
+                }
             }
 
             // Flush contiguous data
@@ -472,6 +492,7 @@ impl TcpReassembler {
             s.segments_depth_exceeded.into(),
         );
         detail.insert("bytes_reassembled".into(), s.bytes_reassembled.into());
+        detail.insert("dropped_findings".into(), s.dropped_findings.into());
         AnalysisSummary {
             analyzer_name: "TCP Reassembly".into(),
             packets_analyzed: s.packets_tcp,
@@ -540,6 +561,7 @@ impl TcpReassembler {
 
     fn generate_conflicting_overlap_finding(&mut self, key: &FlowKey, src_ip: std::net::IpAddr) {
         if self.findings.len() >= MAX_FINDINGS {
+            self.stats.dropped_findings += 1;
             return;
         }
         self.findings.push(Finding {
@@ -556,6 +578,7 @@ impl TcpReassembler {
 
     fn generate_truncated_finding(&mut self, key: &FlowKey, src_ip: std::net::IpAddr) {
         if self.findings.len() >= MAX_FINDINGS {
+            self.stats.dropped_findings += 1;
             return;
         }
         self.findings.push(Finding {

--- a/tests/reassembly_engine_tests.rs
+++ b/tests/reassembly_engine_tests.rs
@@ -1475,3 +1475,61 @@ fn test_drop_after_finalize_is_silent_path() {
     assert!(reassembler.is_finalized());
     drop(reassembler); // must not panic and must be the silent branch
 }
+
+// ---- LESSON-P1.01: dropped_findings counter surfaces MAX_FINDINGS suppressions ----
+
+#[test]
+fn test_dropped_findings_zero_on_normal_flow() {
+    // On a happy-path single-flow capture, the dropped_findings
+    // counter must be zero — the field is contractually a
+    // "cap-hit" signal, not a per-anomaly counter.
+    let config = ReassemblyConfig::default();
+    let mut reassembler = TcpReassembler::new(config);
+    let mut handler = RecordingHandler::new();
+
+    let client = [10, 0, 0, 1];
+    let server = [10, 0, 0, 2];
+
+    let syn = make_tcp_packet(
+        client,
+        12345,
+        server,
+        80,
+        1000,
+        &[],
+        true,
+        false,
+        false,
+        false,
+    );
+    reassembler.process_packet(&syn, 1, &mut handler);
+    let data = make_tcp_packet(
+        client, 12345, server, 80, 1001, b"hi", false, false, false, false,
+    );
+    reassembler.process_packet(&data, 2, &mut handler);
+    reassembler.finalize(&mut handler);
+
+    let summary = reassembler.summarize();
+    assert_eq!(
+        summary.detail.get("dropped_findings"),
+        Some(&serde_json::Value::from(0u64)),
+        "happy-path capture must report dropped_findings == 0"
+    );
+}
+
+#[test]
+fn test_dropped_findings_key_present_in_summarize() {
+    // Structural contract: the `dropped_findings` key always appears in
+    // the summarize() detail map (mirrors the pattern for
+    // `segments_segment_limit`, `parse_errors`, etc.). Catches a
+    // regression that removes the field-to-detail wiring even if no
+    // counter ever increments during a particular run.
+    let mut reassembler = TcpReassembler::new(ReassemblyConfig::default());
+    let mut handler = RecordingHandler::new();
+    reassembler.finalize(&mut handler);
+    let summary = reassembler.summarize();
+    assert!(
+        summary.detail.contains_key("dropped_findings"),
+        "summarize() detail must always contain `dropped_findings` — LESSON-P1.01 regressed"
+    );
+}

--- a/tests/reporter_tests.rs
+++ b/tests/reporter_tests.rs
@@ -35,6 +35,80 @@ fn test_json_reporter_produces_valid_json() {
 }
 
 #[test]
+fn test_json_finding_omits_absent_optional_fields_symmetrically() {
+    // LESSON-P1.02 / NFR OBS-010: a `Finding` whose three `Option<_>`
+    // fields are all `None` must emit a JSON object with *none* of
+    // those three keys present. Previously `timestamp` had
+    // `skip_serializing_if = "Option::is_none"` while `mitre_technique`
+    // and `source_ip` did not, producing asymmetric mixed-shape output
+    // (`mitre_technique: null` and `source_ip: null` appeared as keys
+    // while `timestamp` was omitted).
+    let reporter = JsonReporter;
+    let summary = Summary::new();
+    let findings = vec![Finding {
+        category: ThreatCategory::Anomaly,
+        verdict: Verdict::Inconclusive,
+        confidence: Confidence::Low,
+        summary: "P1.02 symmetry test".into(),
+        evidence: vec![],
+        mitre_technique: None,
+        source_ip: None,
+        timestamp: None,
+    }];
+    let output = reporter.render(&summary, &findings, &[]);
+    let parsed: serde_json::Value = serde_json::from_str(&output).unwrap();
+    let finding = &parsed["findings"][0];
+    let obj = finding.as_object().expect("finding must be a JSON object");
+    assert!(
+        !obj.contains_key("mitre_technique"),
+        "absent mitre_technique must be omitted, got: {}",
+        finding
+    );
+    assert!(
+        !obj.contains_key("source_ip"),
+        "absent source_ip must be omitted, got: {}",
+        finding
+    );
+    assert!(
+        !obj.contains_key("timestamp"),
+        "absent timestamp must be omitted, got: {}",
+        finding
+    );
+}
+
+#[test]
+fn test_json_finding_emits_present_optional_fields() {
+    // LESSON-P1.02 companion: present `Option::Some(_)` values must
+    // still be serialized as JSON object members. Confirms that the
+    // skip_serializing_if attribute only suppresses None, not Some.
+    let reporter = JsonReporter;
+    let summary = Summary::new();
+    let findings = vec![Finding {
+        category: ThreatCategory::Anomaly,
+        verdict: Verdict::Likely,
+        confidence: Confidence::High,
+        summary: "P1.02 presence test".into(),
+        evidence: vec![],
+        mitre_technique: Some("T1036".into()),
+        source_ip: Some(IpAddr::V4(std::net::Ipv4Addr::new(10, 0, 0, 1))),
+        timestamp: None, // intentionally None — verifies mixed presence
+    }];
+    let output = reporter.render(&summary, &findings, &[]);
+    let parsed: serde_json::Value = serde_json::from_str(&output).unwrap();
+    let finding = &parsed["findings"][0];
+    let obj = finding.as_object().expect("finding must be a JSON object");
+    assert_eq!(
+        obj.get("mitre_technique"),
+        Some(&serde_json::json!("T1036"))
+    );
+    assert_eq!(obj.get("source_ip"), Some(&serde_json::json!("10.0.0.1")));
+    assert!(
+        !obj.contains_key("timestamp"),
+        "the still-None timestamp must remain omitted"
+    );
+}
+
+#[test]
 fn test_json_reporter_includes_skipped_packets() {
     let reporter = JsonReporter;
     let mut summary = Summary::new();

--- a/tests/tls_integration_tests.rs
+++ b/tests/tls_integration_tests.rs
@@ -118,4 +118,20 @@ fn test_summarize_has_all_required_fields() {
         "missing cipher_suites"
     );
     assert!(detail.contains_key("parse_errors"), "missing parse_errors");
+    // LESSON-P1.05: capacity/DoS-class drops are now surfaced
+    // separately from parse_errors, so any JSON consumer can
+    // distinguish "record was malformed" from "record was over-cap".
+    assert!(
+        detail.contains_key("truncated_records"),
+        "missing truncated_records — LESSON-P1.05 regressed"
+    );
+    let truncated = detail
+        .get("truncated_records")
+        .expect("truncated_records key")
+        .as_u64()
+        .expect("truncated_records is u64");
+    assert_eq!(
+        truncated, 0,
+        "well-formed tls12 fixture must not trigger truncated_records"
+    );
 }


### PR DESCRIPTION
## Summary
Batch of three observability lessons (NFR OBS-010, RES-022, RES-023) from the brownfield-ingest Phase C synthesis. All three surface previously-invisible drop / DoS-protection events through the JSON output surface. None change finding semantics — only counter/serialization plumbing. Total cost ~12 LOC of fields + ~30 LOC of plumbing + tests.

## Lessons closed

| Lesson | What it does | Key code site |
|---|---|---|
| **P1.01** (RES-022) | New \`dropped_findings: u64\` on \`ReassemblyStats\` — counts anomaly findings suppressed because the \`MAX_FINDINGS = 10_000\` cap was hit. Visible in JSON under \`dropped_findings\`. | 5 push sites in \`src/reassembly/mod.rs\` (3 threshold-crossing checks + 2 helper fns) |
| **P1.02** (NFR OBS-010) | All three \`Option<_>\` fields on \`Finding\` (\`mitre_technique\`, \`source_ip\`, \`timestamp\`) now carry \`#[serde(skip_serializing_if = "Option::is_none")]\`. Previously only \`timestamp\` did, producing asymmetric JSON shape (\`mitre_technique: null\` + omitted \`timestamp\`). | \`src/findings.rs\` |
| **P1.05** (RES-023, CNV-PAT-002 follow-up) | New \`truncated_records: u64\` on \`TlsAnalyzer\` — counts TLS records dropped before parsing because their declared payload length exceeded \`MAX_RECORD_PAYLOAD\` (DoS protection). Distinguishes "over-cap drop" from "malformed contents" (\`parse_errors\` is still bumped in parallel for back-compat). | \`src/analyzer/tls.rs\` line 588 |

## Semantic improvement in P1.01 (called out so it's visible in review)

At the three per-direction threshold sites (overlap / small-segment / out-of-window), the \`*_alert_fired\` latch now flips **unconditionally** once the threshold trips, even when the finding push is suppressed by the cap. Previously a cap-suppressed crossing left the latch un-flipped, so:

- every subsequent packet on the same flow direction re-evaluated the same threshold;
- the new \`dropped_findings\` counter would have incremented N times for one distinct anomaly.

With the latch+drop pattern, the counter has its intended meaning: **one increment per distinct anomaly lost to the cap**, not one per packet.

## Files changed
- \`src/findings.rs\` — three serde attributes (was one), inline comment cites LESSON-P1.02 / NFR OBS-010.
- \`src/reassembly/mod.rs\` — new field, 5 increment sites, latch-flip restructure, summarize() wiring.
- \`src/analyzer/tls.rs\` — new field, public accessor, increment at over-cap drop site, summarize() wiring.
- \`tests/reassembly_engine_tests.rs\` — 2 new tests (zero on happy path; key always present in summarize).
- \`tests/reporter_tests.rs\` — 2 new tests (absent → omitted; present → emitted).
- \`tests/tls_integration_tests.rs\` — \`test_summarize_has_all_required_fields\` extended to require \`truncated_records\` and assert it is zero on tls12 fixture.

## Test plan
- [x] \`cargo fmt --check\` — clean
- [x] \`cargo clippy --all-targets -- -D warnings\` — clean
- [x] \`cargo test --all-targets\` — **229 passed, 0 failed** (was 225)
- [x] No existing test asserted the old \`null\`-shape JSON or the absent counters, so no fixtures needed updating
- [x] All 21 existing reassembly engine tests still pass with the latch-flip semantic change (the latch is internal to the threshold-firing decision; observable behavior on the happy path is unchanged)

## P1 backlog status

| Lesson | Status |
|---|---|
| **P1.01 — dropped_findings counter** | ✅ this PR |
| **P1.02 — Finding Option JSON symmetry** | ✅ this PR |
| P1.03 — wire \`--hosts\` flag | next |
| P1.04 — codify "no unwired CLI flags" convention | next (pair with P1.03) |
| **P1.05 — truncated_records counter** | ✅ this PR |
| P1.06 — \`#![warn(missing_docs)]\` phased rollout | later |
| P1.07 — \`//!\` module headers on all 20 modules | later |