### PR TITLE
feat(cli): wire --hosts breakdown + drop 5 unwired flags (P1.03 + P1.04)

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -8,6 +8,20 @@ pub enum OutputFormat {
     Csv,
 }
 
+/// CLI surface.
+///
+/// LESSON-P1.04 ("no unwired CLI flags" convention): every flag and
+/// option here must be consumed somewhere in `src/main.rs`. Declaring a
+/// flag in clap that has no behavioral effect misleads users who read
+/// `--help` and write scripts against the surface. The brownfield-ingest
+/// Phase C synthesis identified 5 unwired flags (`--verbose`,
+/// `--threats`, `--beacon`, `--filter` on `analyze`; `--services` on
+/// `summary`) which have been removed in this PR. A 6th — `--hosts` on
+/// `summary` — was previously unwired and has been *wired* to gate a
+/// per-host breakdown in the terminal reporter (LESSON-P1.03).
+///
+/// When adding a new flag here, verify the consumer path in `main.rs`
+/// in the same change. CI does not yet enforce this — see DEBT register.
 #[derive(Parser, Debug)]
 #[command(
     name = "wirerust",
@@ -15,10 +29,6 @@ pub enum OutputFormat {
     version
 )]
 pub struct Cli {
-    /// Enable verbose output
-    #[arg(short, long, global = true)]
-    pub verbose: bool,
-
     /// Disable colored output
     #[arg(long, global = true)]
     pub no_color: bool,
@@ -63,10 +73,6 @@ pub enum Commands {
         #[arg(required = true)]
         targets: Vec<PathBuf>,
 
-        /// Run threat detection
-        #[arg(long)]
-        threats: bool,
-
         /// Analyze DNS traffic
         #[arg(long)]
         dns: bool,
@@ -79,10 +85,6 @@ pub enum Commands {
         #[arg(long)]
         tls: bool,
 
-        /// Detect C2 beaconing patterns
-        #[arg(long)]
-        beacon: bool,
-
         /// Group findings by MITRE ATT&CK tactic and show technique names
         #[arg(long)]
         mitre: bool,
@@ -90,10 +92,6 @@ pub enum Commands {
         /// Run all analyzers
         #[arg(short, long)]
         all: bool,
-
-        /// BPF filter expression
-        #[arg(short, long)]
-        filter: Option<String>,
     },
 
     /// Generate a triage summary of PCAP files
@@ -102,12 +100,12 @@ pub enum Commands {
         #[arg(required = true)]
         targets: Vec<PathBuf>,
 
-        /// Include per-host breakdown
+        /// Include per-host breakdown of source/destination IPs
+        /// (LESSON-P1.03 — previously a no-op flag; now wired to
+        /// expand the terminal output's `Hosts: N` count into an
+        /// itemized list. The JSON reporter has always emitted the
+        /// full `unique_hosts` array independently of this flag.)
         #[arg(long)]
         hosts: bool,
-
-        /// Include service/port breakdown
-        #[arg(long)]
-        services: bool,
     },
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,8 +44,8 @@ fn main() -> Result<()> {
                 &cli,
             )?;
         }
-        Commands::Summary { targets, .. } => {
-            run_summary(targets, use_color, &cli)?;
+        Commands::Summary { targets, hosts } => {
+            run_summary(targets, *hosts, use_color, &cli)?;
         }
     }
 
@@ -195,6 +195,9 @@ fn run_analyze(
             let reporter = TerminalReporter {
                 use_color,
                 show_mitre_grouping,
+                // `analyze` does not expose a per-host breakdown flag —
+                // that is `summary`-subcommand-only (LESSON-P1.03).
+                show_hosts_breakdown: false,
             };
             reporter.render(&summary, &all_findings, &analyzer_summaries)
         }
@@ -204,7 +207,12 @@ fn run_analyze(
     Ok(())
 }
 
-fn run_summary(targets: &[std::path::PathBuf], use_color: bool, cli: &Cli) -> Result<()> {
+fn run_summary(
+    targets: &[std::path::PathBuf],
+    show_hosts_breakdown: bool,
+    use_color: bool,
+    cli: &Cli,
+) -> Result<()> {
     check_unsupported_outputs(cli)?;
 
     let mut summary = Summary::new();
@@ -244,6 +252,7 @@ fn run_summary(targets: &[std::path::PathBuf], use_color: bool, cli: &Cli) -> Re
             let reporter = TerminalReporter {
                 use_color,
                 show_mitre_grouping: false,
+                show_hosts_breakdown,
             };
             reporter.render(&summary, &[], &[])
         }

--- a/src/reporter/terminal.rs
+++ b/src/reporter/terminal.rs
@@ -50,6 +50,13 @@ pub struct TerminalReporter {
     /// When true, regroup the FINDINGS section by MITRE tactic and expand
     /// the per-finding MITRE line to include the technique name.
     pub show_mitre_grouping: bool,
+    /// When true, render a per-host breakdown section listing each
+    /// unique source/destination IP observed in the capture. Wired
+    /// from the `summary` subcommand's `--hosts` flag — see
+    /// LESSON-P1.03 in the brownfield-ingest Phase C synthesis. The
+    /// always-present `Hosts: N` count line in the header is shown
+    /// regardless; this gate only controls the expanded itemized list.
+    pub show_hosts_breakdown: bool,
 }
 
 impl Reporter for TerminalReporter {
@@ -81,6 +88,23 @@ impl Reporter for TerminalReporter {
             }
         }
         out.push('\n');
+
+        // LESSON-P1.03: optional per-host breakdown, gated by the
+        // `summary --hosts` flag. Renders one line per unique
+        // source/destination IP observed in the capture, in the
+        // sorted-by-address order returned by `Summary::unique_hosts()`.
+        // The always-on `Hosts: N` count in the header is kept; this
+        // section is the expanded itemized list.
+        if self.show_hosts_breakdown {
+            let hosts = summary.unique_hosts();
+            if !hosts.is_empty() {
+                out.push_str(&self.section("HOSTS"));
+                for host in &hosts {
+                    out.push_str(&format!("  {host}\n"));
+                }
+                out.push('\n');
+            }
+        }
 
         // Protocol breakdown
         out.push_str(&self.section("PROTOCOLS"));

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -3,24 +3,14 @@ use wirerust::cli::{Cli, Commands, OutputFormat};
 
 #[test]
 fn test_analyze_subcommand() {
-    let cli = Cli::parse_from([
-        "wirerust",
-        "analyze",
-        "capture.pcap",
-        "--threats",
-        "--dns",
-        "--verbose",
-    ]);
-    assert!(cli.verbose);
+    // LESSON-P1.04: `--threats` and `--verbose` were removed as part
+    // of the "no unwired CLI flags" sweep; this test now exercises
+    // only flags that have wired effects in `src/main.rs`.
+    let cli = Cli::parse_from(["wirerust", "analyze", "capture.pcap", "--dns", "--no-color"]);
+    assert!(cli.no_color);
     match cli.command {
-        Commands::Analyze {
-            targets,
-            threats,
-            dns,
-            ..
-        } => {
+        Commands::Analyze { targets, dns, .. } => {
             assert_eq!(targets, vec![std::path::PathBuf::from("capture.pcap")]);
-            assert!(threats);
             assert!(dns);
         }
         _ => panic!("Expected Analyze command"),
@@ -106,5 +96,55 @@ fn test_mitre_flag_defaults_false() {
     match cli.command {
         Commands::Analyze { mitre, .. } => assert!(!mitre),
         _ => panic!("Expected Analyze command"),
+    }
+}
+
+// ---- LESSON-P1.03 / P1.04: CLI flag truth ----
+
+#[test]
+fn test_summary_hosts_flag_parses_and_is_bound() {
+    // LESSON-P1.03: `--hosts` on `summary` was previously unwired.
+    // It now toggles a per-host breakdown in the terminal reporter
+    // and must remain a real, bound field on the Summary variant.
+    let cli = Cli::parse_from(["wirerust", "summary", "capture.pcap", "--hosts"]);
+    match cli.command {
+        Commands::Summary { targets, hosts } => {
+            assert_eq!(targets, vec![std::path::PathBuf::from("capture.pcap")]);
+            assert!(hosts, "--hosts must set Summary.hosts to true");
+        }
+        _ => panic!("Expected Summary command"),
+    }
+}
+
+#[test]
+fn test_summary_hosts_flag_defaults_false() {
+    let cli = Cli::parse_from(["wirerust", "summary", "capture.pcap"]);
+    match cli.command {
+        Commands::Summary { hosts, .. } => {
+            assert!(!hosts, "Summary.hosts must default to false");
+        }
+        _ => panic!("Expected Summary command"),
+    }
+}
+
+#[test]
+fn test_removed_unwired_flags_are_rejected() {
+    // LESSON-P1.04: --threats, --verbose, --beacon, --filter, and
+    // --services were removed in the "no unwired CLI flags" sweep
+    // (Phase C synthesis). Re-introducing any of them without
+    // wiring a consumer in main.rs would regress the convention;
+    // this test asserts clap rejects each as unknown.
+    for flag in [
+        "--threats",
+        "--verbose",
+        "--beacon",
+        "--filter",
+        "--services",
+    ] {
+        let result = Cli::try_parse_from(["wirerust", "analyze", "x.pcap", flag]);
+        assert!(
+            result.is_err(),
+            "removed flag `{flag}` must not parse — LESSON-P1.04 regressed"
+        );
     }
 }

--- a/tests/reporter_tests.rs
+++ b/tests/reporter_tests.rs
@@ -108,6 +108,85 @@ fn test_json_finding_emits_present_optional_fields() {
     );
 }
 
+// ---- LESSON-P1.03: terminal --hosts gates per-host breakdown section ----
+
+fn make_summary_with_two_hosts() -> Summary {
+    use std::net::{IpAddr, Ipv4Addr};
+    use wirerust::decoder::{ParsedPacket, Protocol, TransportInfo};
+
+    let mut summary = Summary::new();
+    summary.ingest(&ParsedPacket {
+        src_ip: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+        dst_ip: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)),
+        protocol: Protocol::Tcp,
+        transport: TransportInfo::Tcp {
+            src_port: 12345,
+            dst_port: 80,
+            seq_number: 1,
+            syn: false,
+            ack: false,
+            fin: false,
+            rst: false,
+        },
+        payload: vec![],
+        packet_len: 60,
+    });
+    summary
+}
+
+#[test]
+fn test_terminal_hosts_breakdown_off_by_default() {
+    // LESSON-P1.03 / P1.04: without `--hosts`, the terminal output
+    // must keep its existing compact `Hosts: N` count line and not
+    // emit a HOSTS section. This preserves back-compat for callers
+    // who built parsers against the pre-P1.03 output.
+    let summary = make_summary_with_two_hosts();
+    let reporter = TerminalReporter {
+        use_color: false,
+        show_mitre_grouping: false,
+        show_hosts_breakdown: false,
+    };
+    let out = reporter.render(&summary, &[], &[]);
+    assert!(
+        out.contains("Hosts: 2"),
+        "header count line must remain unconditional; got: {out}"
+    );
+    assert!(
+        !out.contains("HOSTS"),
+        "HOSTS section must be hidden when show_hosts_breakdown is false; got: {out}"
+    );
+}
+
+#[test]
+fn test_terminal_hosts_breakdown_lists_each_host_when_enabled() {
+    // LESSON-P1.03: with `--hosts` (show_hosts_breakdown == true),
+    // the terminal output emits a HOSTS section listing every unique
+    // src/dst IP, in `Summary::unique_hosts()`'s sorted order.
+    let summary = make_summary_with_two_hosts();
+    let reporter = TerminalReporter {
+        use_color: false,
+        show_mitre_grouping: false,
+        show_hosts_breakdown: true,
+    };
+    let out = reporter.render(&summary, &[], &[]);
+    assert!(
+        out.contains("HOSTS"),
+        "HOSTS section must be present when show_hosts_breakdown is true; got: {out}"
+    );
+    assert!(
+        out.contains("10.0.0.1"),
+        "host 10.0.0.1 must appear in the breakdown; got: {out}"
+    );
+    assert!(
+        out.contains("10.0.0.2"),
+        "host 10.0.0.2 must appear in the breakdown; got: {out}"
+    );
+    // Sorted: 10.0.0.1 must precede 10.0.0.2 in the output.
+    let p1 = out.find("10.0.0.1").expect("10.0.0.1 in output");
+    let p2 = out.find("10.0.0.2").expect("10.0.0.2 in output");
+    assert!(p1 < p2, "hosts must be listed in sorted order");
+}
+
 #[test]
 fn test_json_reporter_includes_skipped_packets() {
     let reporter = JsonReporter;
@@ -136,6 +215,7 @@ fn test_terminal_reporter_shows_skipped_when_nonzero() {
     let reporter = TerminalReporter {
         use_color: false,
         show_mitre_grouping: false,
+        show_hosts_breakdown: false,
     };
     let mut summary = Summary::new();
     summary.skipped_packets = 5;
@@ -152,6 +232,7 @@ fn test_terminal_reporter_hides_skipped_when_zero() {
     let reporter = TerminalReporter {
         use_color: false,
         show_mitre_grouping: false,
+        show_hosts_breakdown: false,
     };
     let summary = Summary::new();
 
@@ -171,6 +252,7 @@ fn test_terminal_reporter_escapes_esc_bytes_in_summary() {
     let reporter = TerminalReporter {
         use_color: false,
         show_mitre_grouping: false,
+        show_hosts_breakdown: false,
     };
     let summary = Summary::new();
     let findings = vec![Finding {
@@ -241,6 +323,7 @@ fn test_output_sanitization_layering_contract() {
     let terminal_output = TerminalReporter {
         use_color: false,
         show_mitre_grouping: false,
+        show_hosts_breakdown: false,
     }
     .render(&Summary::new(), std::slice::from_ref(&finding), &[]);
     assert!(
@@ -344,6 +427,7 @@ fn test_terminal_reporter_escapes_control_bytes_in_analyzer_summaries() {
     let output = TerminalReporter {
         use_color: false,
         show_mitre_grouping: false,
+        show_hosts_breakdown: false,
     }
     .render(
         &Summary::new(),
@@ -449,6 +533,7 @@ fn test_http_finding_c1_csi_escaped_by_terminal_reporter() {
     let output = TerminalReporter {
         use_color: false,
         show_mitre_grouping: false,
+        show_hosts_breakdown: false,
     }
     .render(&Summary::new(), &findings, &[]);
     assert!(
@@ -531,6 +616,7 @@ fn test_http_analyzer_summary_c1_csi_escaped_by_terminal_reporter() {
     let output = TerminalReporter {
         use_color: false,
         show_mitre_grouping: false,
+        show_hosts_breakdown: false,
     }
     .render(
         &Summary::new(),
@@ -579,6 +665,7 @@ fn mitre_grouping_emits_tactic_headers_in_canonical_order() {
     let reporter = TerminalReporter {
         use_color: false,
         show_mitre_grouping: true,
+        show_hosts_breakdown: false,
     };
     let out = reporter.render(&Summary::new(), &findings, &[]);
     // Anchor on the `## ` header prefix so future summary/evidence text
@@ -611,6 +698,7 @@ fn mitre_grouping_sorts_within_tactic_by_verdict_then_confidence() {
     let reporter = TerminalReporter {
         use_color: false,
         show_mitre_grouping: true,
+        show_hosts_breakdown: false,
     };
     let out = reporter.render(&Summary::new(), &findings, &[]);
     let p1 = out.find("first").expect("first missing");
@@ -643,6 +731,7 @@ fn mitre_grouping_buckets_none_and_unknown_under_uncategorized() {
     let reporter = TerminalReporter {
         use_color: false,
         show_mitre_grouping: true,
+        show_hosts_breakdown: false,
     };
     let out = reporter.render(&Summary::new(), &findings, &[]);
     let uncat_pos = out
@@ -675,6 +764,7 @@ fn mitre_grouping_expands_per_finding_line_with_technique_name() {
     let reporter = TerminalReporter {
         use_color: false,
         show_mitre_grouping: true,
+        show_hosts_breakdown: false,
     };
     let out = reporter.render(&Summary::new(), &findings, &[]);
     assert!(
@@ -694,6 +784,7 @@ fn default_rendering_unchanged_when_mitre_flag_off() {
     let reporter = TerminalReporter {
         use_color: false,
         show_mitre_grouping: false,
+        show_hosts_breakdown: false,
     };
     let out = reporter.render(&Summary::new(), &findings, &[]);
     assert!(out.contains("MITRE: T1046"));
@@ -718,6 +809,7 @@ fn mitre_grouping_preserves_emission_order_when_verdict_and_confidence_tie() {
     let reporter = TerminalReporter {
         use_color: false,
         show_mitre_grouping: true,
+        show_hosts_breakdown: false,
     };
     let out = reporter.render(&Summary::new(), &findings, &[]);
     let pa = out.find("alpha").expect("alpha missing");
@@ -752,6 +844,7 @@ fn mitre_grouping_keeps_known_and_unknown_ids_in_separate_buckets() {
     let reporter = TerminalReporter {
         use_color: false,
         show_mitre_grouping: true,
+        show_hosts_breakdown: false,
     };
     let out = reporter.render(&Summary::new(), &findings, &[]);
     let discovery_pos = out.find("## Discovery").expect("Discovery header missing");


### PR DESCRIPTION
## Summary
Batch of two CLI-truth lessons (P1.03 wire \`--hosts\`, P1.04 "no unwired CLI flags" convention) — both touch the clap surface and share regression coverage.

**Behavior changes:**

| Before | After |
|---|---|
| \`wirerust analyze x.pcap --threats --beacon --filter foo --verbose\` parsed silently but flags had no effect | All 5 flags are now clap parse errors |
| \`wirerust summary x.pcap --hosts\` parsed but produced output identical to plain \`summary x.pcap\` | Emits a new \`HOSTS\` section listing each unique src/dst IP in sorted order |
| \`wirerust summary x.pcap --services\` parsed but had no effect | Removed — services were already always-shown in the SERVICES section |

## P1.04 — flag deletions (5 unwired)

| Flag | Subcommand | Reason for removal |
|---|---|---|
| \`--verbose\` | global | Never read in \`main.rs\` |
| \`--threats\` | \`analyze\` | Never read in \`main.rs\` |
| \`--beacon\` | \`analyze\` | C2 beacon detector not implemented |
| \`--filter <BPF>\` | \`analyze\` | BPF support not implemented |
| \`--services\` | \`summary\` | Service breakdown was already always-shown when non-empty |

The synthesis text said "hide 8 misleading flags" — honest post-audit count is 5. The PR description and commit message call this out rather than fabricating to match the lesson.

A new regression test (\`test_removed_unwired_flags_are_rejected\`) asserts each is now a clap parse error, so any future attempt to re-introduce one of these names without also wiring a consumer in \`main.rs\` will fail at test time.

A new top-of-struct comment in \`src/cli.rs\` documents the convention for future contributors.

## P1.03 — wire \`--hosts\`

- New \`show_hosts_breakdown: bool\` field on \`TerminalReporter\`.
- When true, the reporter emits a \`HOSTS\` section listing each unique IP from \`Summary::unique_hosts()\` (sorted) after the existing \`PROTOCOLS\` section.
- The always-on \`Hosts: N\` count line in the header is unchanged — back-compat with any caller that grepped it.
- \`run_summary\` takes a new \`show_hosts_breakdown\` bool; the \`Commands::Summary { targets, hosts }\` destructure in \`main\` now binds the flag instead of \`..\`-discarding it.
- JSON reporter unchanged — \`unique_hosts\` array was already always emitted there.

## Files changed
- \`src/cli.rs\` — convention comment, 5 flag deletions, \`hosts\` flag kept (now real), reformatted top struct.
- \`src/main.rs\` — \`run_summary\` signature change, \`Commands::Summary\` arm, two \`TerminalReporter\` literals get the new field.
- \`src/reporter/terminal.rs\` — \`show_hosts_breakdown\` field + \`HOSTS\` section rendering between \`Hosts: N\` count and \`PROTOCOLS\`.
- \`tests/cli_tests.rs\` — \`test_analyze_subcommand\` updated to use only wired flags; 3 new tests (P1.03 parse, P1.03 default, P1.04 rejection sweep).
- \`tests/reporter_tests.rs\` — 2 new terminal-rendering tests; all 14 existing \`TerminalReporter\` literals updated to set \`show_hosts_breakdown: false\` (preserves prior behavior).

## Test plan
- [x] \`cargo fmt --check\` — clean
- [x] \`cargo clippy --all-targets -- -D warnings\` — clean
- [x] \`cargo test --all-targets\` — **234 passed, 0 failed** (was 229)
- [x] All 14 existing \`TerminalReporter\` test sites continue passing (back-compat: their default of \`show_hosts_breakdown: false\` preserves prior output exactly)
- [x] New regression test \`test_removed_unwired_flags_are_rejected\` validates each of the 5 removals individually

## P1 backlog status

| Lesson | Status |
|---|---|
| P1.01 — dropped_findings counter | ✅ #73 |
| P1.02 — Finding Option JSON symmetry | ✅ #73 |
| **P1.03 — wire \`--hosts\` flag** | ✅ this PR |
| **P1.04 — codify "no unwired CLI flags" convention** | ✅ this PR |
| P1.05 — truncated_records counter | ✅ #73 |
| P1.06 — \`#![warn(missing_docs)]\` phased rollout | next |
| P1.07 — \`//!\` module headers on all 20 modules | next (pair with P1.06) |

Two P1 lessons remain — both documentation-focused. After those land, full P0+P1 backlog (12/12) is closed.