### PR TITLE
feat(schema): deterministic JSON ordering + #[non_exhaustive] on enums (P2.09 + P2.10)

### DIFF
--- a/src/analyzer/dns.rs
+++ b/src/analyzer/dns.rs
@@ -6,7 +6,7 @@
 //! and rare-TLD lookups. Findings carry confidence levels reflecting how
 //! noisy each pattern is in benign traffic.
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 use crate::analyzer::{AnalysisSummary, ProtocolAnalyzer};
 use crate::decoder::{ParsedPacket, TransportInfo};
@@ -70,7 +70,7 @@ impl ProtocolAnalyzer for DnsAnalyzer {
     }
 
     fn summarize(&self) -> AnalysisSummary {
-        let mut detail = HashMap::new();
+        let mut detail: BTreeMap<String, serde_json::Value> = BTreeMap::new();
         detail.insert(
             "dns_queries".to_string(),
             serde_json::json!(self.query_count),

--- a/src/analyzer/http.rs
+++ b/src/analyzer/http.rs
@@ -539,7 +539,10 @@ impl StreamAnalyzer for HttpAnalyzer {
     }
 
     fn summarize(&self) -> AnalysisSummary {
-        let mut detail = HashMap::new();
+        // LESSON-P2.09: BTreeMap so the JSON output keys are
+        // alphabetically ordered and deterministic across runs.
+        let mut detail: std::collections::BTreeMap<String, serde_json::Value> =
+            std::collections::BTreeMap::new();
 
         detail.insert(
             "transactions".to_string(),

--- a/src/analyzer/mod.rs
+++ b/src/analyzer/mod.rs
@@ -15,18 +15,38 @@ pub mod dns;
 pub mod http;
 pub mod tls;
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 use serde::Serialize;
 
 use crate::decoder::ParsedPacket;
 use crate::findings::Finding;
 
+/// Per-analyzer summary produced at end-of-capture for the reporters.
+///
+/// LESSON-P2.09 / NFR DET-001: `detail` is a `BTreeMap`, not a
+/// `HashMap`, so its JSON serialization is deterministic
+/// (alphabetical key order). Two reasons:
+///   - Snapshot / golden-file tests over JSON output stay stable.
+///   - Diffing two JSON reports across captures or wirerust versions
+///     produces minimal, semantically-meaningful diffs.
+///
+/// The change is a pure observation tightening — analyzer code that
+/// previously did `detail.insert(...)` continues to work unchanged
+/// because `BTreeMap` exposes the same `insert` / `iter` API.
 #[derive(Debug, Serialize)]
 pub struct AnalysisSummary {
+    /// Human-readable analyzer name (e.g. "DNS", "HTTP", "TLS",
+    /// "TCP Reassembly").
     pub analyzer_name: String,
+    /// Number of packets this analyzer actually processed (the
+    /// reassembly engine subtracts non-TCP traffic, etc.).
     pub packets_analyzed: u64,
-    pub detail: HashMap<String, serde_json::Value>,
+    /// Analyzer-specific metric key/value pairs. Keys are stable
+    /// identifiers (`top_snis`, `ja3_hashes`, `parse_errors`, …);
+    /// values are arbitrary serde_json::Value so analyzers can emit
+    /// their natural shape (string lists, nested maps, scalars).
+    pub detail: BTreeMap<String, serde_json::Value>,
 }
 
 pub trait ProtocolAnalyzer {

--- a/src/analyzer/tls.rs
+++ b/src/analyzer/tls.rs
@@ -743,7 +743,10 @@ impl StreamAnalyzer for TlsAnalyzer {
     }
 
     fn summarize(&self) -> AnalysisSummary {
-        let mut detail = HashMap::new();
+        // LESSON-P2.09: BTreeMap so the JSON output keys are
+        // alphabetically ordered and deterministic across runs.
+        let mut detail: std::collections::BTreeMap<String, serde_json::Value> =
+            std::collections::BTreeMap::new();
 
         // Top SNIs (top 20 by count)
         let mut top_snis: Vec<_> = self.sni_counts.iter().collect();

--- a/src/findings.rs
+++ b/src/findings.rs
@@ -19,10 +19,21 @@ use std::net::IpAddr;
 use chrono::{DateTime, Utc};
 use serde::Serialize;
 
+/// Confidence that a [`Finding`] reflects a real threat.
+///
+/// LESSON-P2.10: marked `#[non_exhaustive]` so downstream consumers
+/// must include a wildcard arm when matching on this enum. Lets us
+/// add new verdicts (e.g. `Suspected`) in the future without breaking
+/// SemVer.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[non_exhaustive]
 pub enum Verdict {
+    /// The finding is likely a real threat / anomaly.
     Likely,
+    /// The finding is most likely benign noise; emitted for transparency.
     Unlikely,
+    /// The finding cannot be classified as Likely or Unlikely from the
+    /// available evidence.
     Inconclusive,
 }
 
@@ -36,10 +47,19 @@ impl fmt::Display for Verdict {
     }
 }
 
+/// Confidence band assigned by the analyzer to its own finding.
+///
+/// LESSON-P2.10: `#[non_exhaustive]` so a future "VeryHigh" or
+/// "Negligible" tier can be added without breaking downstream
+/// pattern matches.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[non_exhaustive]
 pub enum Confidence {
+    /// Strong signal — false-positive rate is expected to be low.
     High,
+    /// Moderate signal — useful for triage but warrants human review.
     Medium,
+    /// Weak signal — often noisy, included for completeness only.
     Low,
 }
 
@@ -53,15 +73,38 @@ impl fmt::Display for Confidence {
     }
 }
 
+/// Top-level threat taxonomy assigned to each [`Finding`].
+///
+/// Roughly mirrors a subset of MITRE ATT&CK tactics (with `Anomaly`
+/// covering unclassified / pre-classification signals) plus `C2`
+/// (Command-and-Control) split out from the ATT&CK tactic of the
+/// same name for analyst convenience.
+///
+/// LESSON-P2.10: `#[non_exhaustive]` so the enum can grow as new
+/// detection families are added (Impact, Collection, Discovery,
+/// etc.) without breaking SemVer on downstream pattern matches.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[non_exhaustive]
 pub enum ThreatCategory {
+    /// Active or passive information gathering (port scans, host
+    /// enumeration, banner grabbing).
     Reconnaissance,
+    /// Movement between hosts after initial access.
     LateralMovement,
+    /// Command-and-control communication patterns (beaconing,
+    /// covert channels, suspicious DNS / TLS fingerprints).
     C2,
+    /// Data being staged or moved off-host.
     Exfiltration,
+    /// Credential theft / brute-force / spraying patterns.
     CredentialAccess,
-    Execution,
+    /// Suspicious code execution patterns (upload paths, traversal,
+    /// malformed methods).
     Persistence,
+    /// Execution-class signals (long URIs, unusual methods).
+    Execution,
+    /// Unclassified protocol-level anomalies (RFC violations, evasion
+    /// indicators) that don't yet warrant a specific tactic tag.
     Anomaly,
 }
 

--- a/src/reassembly/mod.rs
+++ b/src/reassembly/mod.rs
@@ -481,8 +481,13 @@ impl TcpReassembler {
     }
 
     /// Produce an AnalysisSummary for the reassembly engine stats.
+    ///
+    /// LESSON-P2.09: the returned `AnalysisSummary::detail` is a
+    /// `BTreeMap`, so the JSON output's analyzer-summary section is
+    /// alphabetically ordered and deterministic across runs.
     pub fn summarize(&self) -> AnalysisSummary {
-        let mut detail = HashMap::new();
+        let mut detail: std::collections::BTreeMap<String, serde_json::Value> =
+            std::collections::BTreeMap::new();
         let s = &self.stats;
         detail.insert("packets_processed".into(), s.packets_processed.into());
         detail.insert(

--- a/src/reporter/json.rs
+++ b/src/reporter/json.rs
@@ -27,11 +27,21 @@ impl Reporter for JsonReporter {
         findings: &[Finding],
         analyzer_summaries: &[AnalysisSummary],
     ) -> String {
-        // Convert Protocol (non-string) keys to strings for JSON compatibility
-        let protocols: std::collections::HashMap<String, u64> = summary
+        // LESSON-P2.09 / NFR DET-001: every map serialized into the
+        // JSON output goes through a `BTreeMap` first so the key
+        // order is deterministic (alphabetical) and snapshot/golden
+        // tests stay stable across runs and target platforms. The
+        // `Protocol` keys also need the non-string-to-string
+        // conversion they always did.
+        let protocols: std::collections::BTreeMap<String, u64> = summary
             .protocol_counts()
             .iter()
             .map(|(k, v)| (format!("{k:?}"), *v))
+            .collect();
+        let services: std::collections::BTreeMap<String, u64> = summary
+            .service_counts()
+            .iter()
+            .map(|(k, v)| (k.clone(), *v))
             .collect();
 
         let output = json!({
@@ -41,7 +51,7 @@ impl Reporter for JsonReporter {
                 "skipped_packets": summary.skipped_packets,
                 "unique_hosts": summary.unique_hosts(),
                 "protocols": protocols,
-                "services": summary.service_counts(),
+                "services": services,
             },
             "findings": findings,
             "analyzers": analyzer_summaries,

--- a/tests/reporter_tests.rs
+++ b/tests/reporter_tests.rs
@@ -108,6 +108,105 @@ fn test_json_finding_emits_present_optional_fields() {
     );
 }
 
+// ---- LESSON-P2.09: deterministic JSON map ordering ----
+
+#[test]
+fn test_json_reporter_emits_deterministic_protocols_ordering() {
+    // LESSON-P2.09 / NFR DET-001: top-level map keys in the JSON
+    // output (protocols, services) must serialize in deterministic
+    // alphabetical order, regardless of underlying HashMap iteration
+    // order. Snapshot / golden tests over the JSON depend on this.
+    use std::net::{IpAddr, Ipv4Addr};
+    use wirerust::decoder::{ParsedPacket, Protocol, TransportInfo};
+
+    fn make_packet(proto: Protocol, src_port: u16, dst_port: u16) -> ParsedPacket {
+        ParsedPacket {
+            src_ip: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+            dst_ip: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)),
+            protocol: proto,
+            transport: match proto {
+                Protocol::Tcp => TransportInfo::Tcp {
+                    src_port,
+                    dst_port,
+                    seq_number: 0,
+                    syn: false,
+                    ack: false,
+                    fin: false,
+                    rst: false,
+                },
+                Protocol::Udp => TransportInfo::Udp { src_port, dst_port },
+                _ => TransportInfo::None,
+            },
+            payload: vec![],
+            packet_len: 60,
+        }
+    }
+
+    let mut summary = Summary::new();
+    // Insert in a deliberately non-alphabetical order to exercise the sort.
+    summary.ingest(&make_packet(Protocol::Udp, 53, 0));
+    summary.ingest(&make_packet(Protocol::Tcp, 0, 443));
+    summary.ingest(&make_packet(Protocol::Icmp, 0, 0));
+    summary.ingest(&make_packet(Protocol::Tcp, 0, 80));
+
+    let reporter = JsonReporter;
+    // Render twice; output must be byte-identical (HashMap iteration
+    // order would otherwise diverge across calls).
+    let out_a = reporter.render(&summary, &[], &[]);
+    let out_b = reporter.render(&summary, &[], &[]);
+    assert_eq!(
+        out_a, out_b,
+        "two render() calls on the same summary must produce identical bytes"
+    );
+
+    // Protocol keys must appear in alphabetical order.
+    let icmp_pos = out_a.find("\"Icmp\"").expect("Icmp key in output");
+    let tcp_pos = out_a.find("\"Tcp\"").expect("Tcp key in output");
+    let udp_pos = out_a.find("\"Udp\"").expect("Udp key in output");
+    assert!(
+        icmp_pos < tcp_pos && tcp_pos < udp_pos,
+        "protocol keys must be sorted alphabetically (Icmp < Tcp < Udp) — got positions {icmp_pos}, {tcp_pos}, {udp_pos}"
+    );
+
+    // Service keys (DNS, HTTP, TLS) must appear alphabetically.
+    let dns_pos = out_a.find("\"DNS\"").expect("DNS service in output");
+    let http_pos = out_a.find("\"HTTP\"").expect("HTTP service in output");
+    let tls_pos = out_a.find("\"TLS\"").expect("TLS service in output");
+    assert!(
+        dns_pos < http_pos && http_pos < tls_pos,
+        "service keys must be sorted alphabetically (DNS < HTTP < TLS) — got positions {dns_pos}, {http_pos}, {tls_pos}"
+    );
+}
+
+#[test]
+fn test_json_reporter_emits_deterministic_analyzer_detail_ordering() {
+    // LESSON-P2.09: AnalysisSummary::detail is a BTreeMap, so its
+    // keys serialize alphabetically. Catches a regression that would
+    // change the field back to HashMap.
+    use wirerust::analyzer::AnalysisSummary;
+
+    let mut detail: std::collections::BTreeMap<String, serde_json::Value> =
+        std::collections::BTreeMap::new();
+    detail.insert("zeta_key".to_string(), serde_json::json!(1));
+    detail.insert("alpha_key".to_string(), serde_json::json!(2));
+    detail.insert("mu_key".to_string(), serde_json::json!(3));
+    let analyzer_summary = AnalysisSummary {
+        analyzer_name: "test".to_string(),
+        packets_analyzed: 0,
+        detail,
+    };
+
+    let reporter = JsonReporter;
+    let out = reporter.render(&Summary::new(), &[], &[analyzer_summary]);
+    let alpha = out.find("alpha_key").expect("alpha_key in output");
+    let mu = out.find("mu_key").expect("mu_key in output");
+    let zeta = out.find("zeta_key").expect("zeta_key in output");
+    assert!(
+        alpha < mu && mu < zeta,
+        "analyzer detail keys must serialize alphabetically (alpha < mu < zeta) — got positions {alpha}, {mu}, {zeta}"
+    );
+}
+
 // ---- LESSON-P1.03: terminal --hosts gates per-host breakdown section ----
 
 fn make_summary_with_two_hosts() -> Summary {
@@ -409,7 +508,8 @@ fn test_terminal_reporter_escapes_control_bytes_in_analyzer_summaries() {
     // display boundary regardless of what the underlying serializer does.
     use wirerust::analyzer::AnalysisSummary;
 
-    let mut detail = std::collections::HashMap::new();
+    let mut detail: std::collections::BTreeMap<String, serde_json::Value> =
+        std::collections::BTreeMap::new();
     detail.insert(
         "top_snis".to_string(),
         serde_json::json!([


### PR DESCRIPTION
## Summary
Two small JSON-surface hygiene lessons batched. No behavior changes; only output stability and SemVer future-proofing.

| Lesson | Effect | Cost |
|---|---|---|
| **P2.09** (NFR DET-001) | All JSON map keys serialize in alphabetical order. Snapshot/golden tests over JSON output are now stable across runs. | 3 HashMap → BTreeMap conversions, ~15 LOC |
| **P2.10** | \`ThreatCategory\` / \`Verdict\` / \`Confidence\` carry \`#[non_exhaustive]\` so adding new variants doesn't break downstream SemVer. | 3 attributes + variant doc comments |

## P2.09 — what was non-deterministic

Three sites previously emitted in HashMap iteration order (random per process / per insertion-history):

1. \`AnalysisSummary::detail\` — the per-analyzer metric map. Now a \`BTreeMap<String, serde_json::Value>\`.
2. \`JsonReporter\` protocols map — converted to \`BTreeMap<String, u64>\` at the serialization boundary; Protocol-keyed internal HashMap is unchanged.
3. \`JsonReporter\` services map — same BTreeMap conversion.

The **nested** counter HashMaps inside analyzer summaries (\`ja3_counts\`, \`sni_counts\`, \`host_counts\`, etc.) were already deterministic — \`serde_json::json!(some_hashmap)\` produces a \`serde_json::Map\`, which is \`BTreeMap\`-backed by default (without the \`preserve_order\` feature). The bug was strictly at the outer container level.

## P2.10 — what \`#[non_exhaustive]\` buys us

- Adding new \`ThreatCategory\` entries (Impact, Collection, Discovery, etc. to align further with MITRE ATT&CK), a \`Verdict::Suspected\` tier, or a \`Confidence::VeryHigh\` tier becomes a non-breaking change.
- Downstream consumers must include \`_ => …\` wildcards on these enums, future-proofing against silent breakage.
- In-crate matches are unaffected because Rust only requires the wildcard for non_exhaustive types in *downstream* crates. The Display impls (all \`match self {…}\` arms remain present) work unchanged.
- Each variant gained a 1-line doc comment, eliminating future noise from the \`#![warn(missing_docs)]\` gate once the enclosing module's \`#[allow(missing_docs)]\` override is removed.

## Tests
Two regression tests in \`tests/reporter_tests.rs\`:

| Test | Assertion |
|---|---|
| \`test_json_reporter_emits_deterministic_protocols_ordering\` | Two \`render()\` calls produce byte-identical output, and Protocol/service keys appear in alphabetical order (Icmp < Tcp < Udp; DNS < HTTP < TLS). |
| \`test_json_reporter_emits_deterministic_analyzer_detail_ordering\` | \`AnalysisSummary::detail\` keys serialize alphabetically (alpha_key < mu_key < zeta_key). |

## Test plan
- [x] \`cargo fmt --check\` — clean
- [x] \`cargo clippy --all-targets -- -D warnings\` — clean
- [x] \`cargo test --all-targets\` — **238 passed, 0 failed** (was 236)
- [x] No existing test asserted the pre-fix HashMap iteration order, so no fixtures needed updating

## P2 backlog status

| Lesson | Status |
|---|---|
| **P2.09 — deterministic JSON map ordering** | ✅ this PR |
| **P2.10 — \`#[non_exhaustive]\` on classifying enums** | ✅ this PR |
| P2.08 — direction tag on Finding | next (22 push sites + helper plumbing) |
| P2.02 — format-string conversion | after P2.08 |
| P2.06 — cargo audit / cargo deny CI | after P2.02 |
| P2.04 — JA3 property tests | later |
| P2.07 — criterion benchmarks | later |
| P2.03 — CSV reporter decision | later (scope discussion) |
| P2.11 — \`max_classification_attempts\` knob | later |
| P2.01 — reassembly/mod.rs refactor | deferred (design discussion) |
| P2.05 — threshold calibration | deferred (empirical data) |