### PR TITLE
feat(findings): direction tag on Finding (P2.08)

### DIFF
--- a/src/analyzer/http.rs
+++ b/src/analyzer/http.rs
@@ -198,6 +198,7 @@ impl HttpAnalyzer {
                 mitre_technique: Some("T1083".to_string()),
                 source_ip: None,
                 timestamp: None,
+                direction: Some(Direction::ClientToServer),
             });
         }
 
@@ -227,6 +228,7 @@ impl HttpAnalyzer {
                 mitre_technique: Some("T1505.003".to_string()),
                 source_ip: None,
                 timestamp: None,
+                direction: Some(Direction::ClientToServer),
             });
         }
 
@@ -242,6 +244,7 @@ impl HttpAnalyzer {
                 mitre_technique: Some("T1046".to_string()),
                 source_ip: None,
                 timestamp: None,
+                direction: Some(Direction::ClientToServer),
             });
         }
 
@@ -257,6 +260,7 @@ impl HttpAnalyzer {
                 mitre_technique: None,
                 source_ip: None,
                 timestamp: None,
+                direction: Some(Direction::ClientToServer),
             });
         }
 
@@ -292,6 +296,7 @@ impl HttpAnalyzer {
                     mitre_technique: None,
                     source_ip: None,
                     timestamp: None,
+                    direction: Some(Direction::ClientToServer),
                 });
             }
         }
@@ -307,6 +312,7 @@ impl HttpAnalyzer {
                 mitre_technique: None,
                 source_ip: None,
                 timestamp: None,
+                direction: Some(Direction::ClientToServer),
             });
         }
 
@@ -345,6 +351,7 @@ impl HttpAnalyzer {
                 mitre_technique: None,
                 source_ip: None,
                 timestamp: None,
+                direction: Some(Direction::ClientToServer),
             });
         }
     }
@@ -416,6 +423,7 @@ impl HttpAnalyzer {
                                 mitre_technique: Some("T1499.002".to_string()),
                                 source_ip: None,
                                 timestamp: None,
+                            direction: Some(Direction::ClientToServer),
                             });
                         }
                     }
@@ -474,6 +482,7 @@ impl HttpAnalyzer {
                                 mitre_technique: Some("T1499.002".to_string()),
                                 source_ip: None,
                                 timestamp: None,
+                            direction: Some(Direction::ServerToClient),
                             });
                         }
                     }

--- a/src/analyzer/tls.rs
+++ b/src/analyzer/tls.rs
@@ -431,6 +431,7 @@ impl TlsAnalyzer {
                         mitre_technique: Some("T1027".to_string()),
                         source_ip: None,
                         timestamp: None,
+                        direction: Some(Direction::ClientToServer),
                     });
                 }
                 SniValue::NonAsciiUtf8 { hostname, hex } => {
@@ -450,6 +451,7 @@ impl TlsAnalyzer {
                         mitre_technique: Some("T1027".to_string()),
                         source_ip: None,
                         timestamp: None,
+                        direction: Some(Direction::ClientToServer),
                     });
                 }
                 SniValue::NonUtf8 { lossy, hex } => {
@@ -469,6 +471,7 @@ impl TlsAnalyzer {
                         mitre_technique: Some("T1027".to_string()),
                         source_ip: None,
                         timestamp: None,
+                        direction: Some(Direction::ClientToServer),
                     });
                 }
             }
@@ -497,6 +500,7 @@ impl TlsAnalyzer {
                 mitre_technique: None,
                 source_ip: None,
                 timestamp: None,
+                direction: Some(Direction::ClientToServer),
             });
         }
 
@@ -518,6 +522,7 @@ impl TlsAnalyzer {
                 mitre_technique: None,
                 source_ip: None,
                 timestamp: None,
+            direction: Some(Direction::ClientToServer),
             });
         }
     }
@@ -560,6 +565,7 @@ impl TlsAnalyzer {
                 mitre_technique: None,
                 source_ip: None,
                 timestamp: None,
+                direction: Some(Direction::ServerToClient),
             });
         }
 
@@ -581,6 +587,7 @@ impl TlsAnalyzer {
                 mitre_technique: None,
                 source_ip: None,
                 timestamp: None,
+            direction: Some(Direction::ServerToClient),
             });
         }
     }

--- a/src/findings.rs
+++ b/src/findings.rs
@@ -19,6 +19,8 @@ use std::net::IpAddr;
 use chrono::{DateTime, Utc};
 use serde::Serialize;
 
+use crate::reassembly::handler::Direction;
+
 /// Confidence that a [`Finding`] reflects a real threat.
 ///
 /// LESSON-P2.10: marked `#[non_exhaustive]` so downstream consumers
@@ -133,6 +135,14 @@ pub struct Finding {
     pub source_ip: Option<IpAddr>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub timestamp: Option<DateTime<Utc>>,
+    /// Direction of the TCP stream the finding came from, when
+    /// applicable. LESSON-P2.08: lets JSON consumers distinguish
+    /// client-side anomalies from server-side responses for the
+    /// same flow. `None` for findings emitted from non-stream
+    /// sources (e.g. the DNS UDP analyzer) or from engine-level
+    /// summary events.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub direction: Option<Direction>,
 }
 
 /// Produces the raw text representation of a finding for logging, debugging,

--- a/src/reassembly/handler.rs
+++ b/src/reassembly/handler.rs
@@ -7,21 +7,41 @@
 //! treat per-protocol analyzers uniformly. [`Direction`] and
 //! [`CloseReason`] are the shared event vocabulary.
 
+use serde::Serialize;
+
 use crate::analyzer::AnalysisSummary;
 use crate::findings::Finding;
 use crate::reassembly::flow::FlowKey;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// Per-flow byte direction inside a TCP stream.
+///
+/// LESSON-P2.08: implements `Serialize` so it can be carried on a
+/// [`crate::findings::Finding`] and surfaced in JSON output. The
+/// variant names serialize as their CamelCase identifiers
+/// ("ClientToServer", "ServerToClient") via serde's default
+/// representation for fieldless enums.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[non_exhaustive]
 pub enum Direction {
+    /// Bytes flowing from the initiator (typically the client that
+    /// emitted SYN) toward the responder.
     ClientToServer,
+    /// Bytes flowing from the responder back to the initiator.
     ServerToClient,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// Reason a TCP flow was closed (informational; carried in the
+/// `on_flow_close` callback).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[non_exhaustive]
 pub enum CloseReason {
+    /// Mutual FIN handshake completed normally.
     Fin,
+    /// One side sent RST.
     Rst,
+    /// `flow_timeout_secs` elapsed without activity.
     Timeout,
+    /// Engine evicted the flow under memcap pressure.
     MemoryPressure,
 }
 

--- a/src/reassembly/mod.rs
+++ b/src/reassembly/mod.rs
@@ -316,6 +316,7 @@ impl TcpReassembler {
                         mitre_technique: Some("T1036".into()),
                         source_ip: Some(packet.src_ip),
                         timestamp: None,
+                        direction: Some(dir),
                     });
                 } else {
                     self.stats.dropped_findings += 1;
@@ -338,6 +339,7 @@ impl TcpReassembler {
                         mitre_technique: None,
                         source_ip: Some(packet.src_ip),
                         timestamp: None,
+                        direction: Some(dir),
                     });
                 } else {
                     self.stats.dropped_findings += 1;
@@ -365,6 +367,7 @@ impl TcpReassembler {
                         mitre_technique: None,
                         source_ip: Some(packet.src_ip),
                         timestamp: None,
+                    direction: Some(dir),
                     });
                 } else {
                     self.stats.dropped_findings += 1;
@@ -454,6 +457,7 @@ impl TcpReassembler {
                 mitre_technique: None,
                 source_ip: None,
                 timestamp: None,
+                direction: None,
             });
         }
     }
@@ -598,6 +602,7 @@ impl TcpReassembler {
             mitre_technique: Some("T1036".to_string()),
             source_ip: Some(src_ip),
             timestamp: None,
+            direction: None,
         });
     }
 
@@ -615,6 +620,7 @@ impl TcpReassembler {
             mitre_technique: None,
             source_ip: Some(src_ip),
             timestamp: None,
+            direction: None,
         });
     }
 }

--- a/tests/findings_tests.rs
+++ b/tests/findings_tests.rs
@@ -11,6 +11,7 @@ fn test_finding_creation() {
         mitre_technique: Some("T1046".into()),
         source_ip: Some("10.0.0.1".parse().unwrap()),
         timestamp: None,
+        direction: None,
     };
     assert_eq!(finding.verdict, Verdict::Likely);
     assert_eq!(finding.confidence, Confidence::High);
@@ -28,6 +29,7 @@ fn test_finding_display() {
         mitre_technique: None,
         source_ip: None,
         timestamp: None,
+        direction: None,
     };
     let display = format!("{finding}");
     assert!(display.contains("C2"));

--- a/tests/reporter_tests.rs
+++ b/tests/reporter_tests.rs
@@ -21,6 +21,7 @@ fn test_json_reporter_produces_valid_json() {
         mitre_technique: Some("T1046".into()),
         source_ip: None,
         timestamp: None,
+        direction: None,
     }];
     let analyzer_summaries = vec![];
 
@@ -54,6 +55,7 @@ fn test_json_finding_omits_absent_optional_fields_symmetrically() {
         mitre_technique: None,
         source_ip: None,
         timestamp: None,
+        direction: None,
     }];
     let output = reporter.render(&summary, &findings, &[]);
     let parsed: serde_json::Value = serde_json::from_str(&output).unwrap();
@@ -92,6 +94,7 @@ fn test_json_finding_emits_present_optional_fields() {
         mitre_technique: Some("T1036".into()),
         source_ip: Some(IpAddr::V4(std::net::Ipv4Addr::new(10, 0, 0, 1))),
         timestamp: None, // intentionally None — verifies mixed presence
+        direction: None,
     }];
     let output = reporter.render(&summary, &findings, &[]);
     let parsed: serde_json::Value = serde_json::from_str(&output).unwrap();
@@ -105,6 +108,81 @@ fn test_json_finding_emits_present_optional_fields() {
     assert!(
         !obj.contains_key("timestamp"),
         "the still-None timestamp must remain omitted"
+    );
+}
+
+// ---- LESSON-P2.08: direction tag on Finding ----
+
+#[test]
+fn test_json_finding_emits_direction_when_set() {
+    // LESSON-P2.08: a Finding with `direction: Some(Direction::*)` must
+    // surface the value in JSON under a `"direction"` key. Verifies the
+    // serde Serialize wiring on the Direction enum.
+    use wirerust::reassembly::handler::Direction;
+
+    let reporter = JsonReporter;
+    let summary = Summary::new();
+    let findings = vec![
+        Finding {
+            category: ThreatCategory::Anomaly,
+            verdict: Verdict::Likely,
+            confidence: Confidence::Medium,
+            summary: "client-side finding".into(),
+            evidence: vec![],
+            mitre_technique: None,
+            source_ip: None,
+            timestamp: None,
+            direction: Some(Direction::ClientToServer),
+        },
+        Finding {
+            category: ThreatCategory::Anomaly,
+            verdict: Verdict::Likely,
+            confidence: Confidence::Medium,
+            summary: "server-side finding".into(),
+            evidence: vec![],
+            mitre_technique: None,
+            source_ip: None,
+            timestamp: None,
+            direction: Some(Direction::ServerToClient),
+        },
+    ];
+    let output = reporter.render(&summary, &findings, &[]);
+    let parsed: serde_json::Value = serde_json::from_str(&output).unwrap();
+    assert_eq!(
+        parsed["findings"][0]["direction"],
+        serde_json::json!("ClientToServer")
+    );
+    assert_eq!(
+        parsed["findings"][1]["direction"],
+        serde_json::json!("ServerToClient")
+    );
+}
+
+#[test]
+fn test_json_finding_omits_direction_when_none() {
+    // LESSON-P2.08 companion to P1.02: absent direction must be
+    // omitted from the JSON object (skip_serializing_if), not
+    // emitted as `null`.
+    let reporter = JsonReporter;
+    let summary = Summary::new();
+    let findings = vec![Finding {
+        category: ThreatCategory::Anomaly,
+        verdict: Verdict::Likely,
+        confidence: Confidence::Medium,
+        summary: "directionless finding".into(),
+        evidence: vec![],
+        mitre_technique: None,
+        source_ip: None,
+        timestamp: None,
+        direction: None,
+    }];
+    let output = reporter.render(&summary, &findings, &[]);
+    let parsed: serde_json::Value = serde_json::from_str(&output).unwrap();
+    let finding = parsed["findings"][0].as_object().expect("object");
+    assert!(
+        !finding.contains_key("direction"),
+        "absent direction must be omitted from JSON, got: {}",
+        parsed["findings"][0]
     );
 }
 
@@ -363,6 +441,7 @@ fn test_terminal_reporter_escapes_esc_bytes_in_summary() {
         mitre_technique: None,
         source_ip: None,
         timestamp: None,
+        direction: None,
     }];
 
     let output = reporter.render(&summary, &findings, &[]);
@@ -406,6 +485,7 @@ fn test_output_sanitization_layering_contract() {
         mitre_technique: None,
         source_ip: None,
         timestamp: None,
+        direction: None,
     };
 
     // Layer 1: the struct preserves the raw ESC byte (forensic ground truth).
@@ -473,6 +553,7 @@ fn test_json_reporter_preserves_cyrillic_as_readable_unicode() {
         mitre_technique: None,
         source_ip: None,
         timestamp: None,
+        direction: None,
     };
 
     let json_output = JsonReporter.render(&Summary::new(), std::slice::from_ref(&finding), &[]);
@@ -752,6 +833,7 @@ fn base_finding_with_mitre(
         mitre_technique: technique.map(|s| s.to_string()),
         source_ip: None,
         timestamp: None,
+        direction: None,
     }
 }
 


### PR DESCRIPTION
## Summary
Adds an optional \`direction: Option<Direction>\` field to \`Finding\` so JSON consumers can distinguish client-side anomalies from server-side responses on the same flow.

## Schema change
- \`src/reassembly/handler.rs\`: \`Direction\` gains \`Serialize\` + \`#[non_exhaustive]\`. Variants serialize as identifier strings (\`"ClientToServer"\`, \`"ServerToClient"\`). \`CloseReason\` gains the same for parity.
- \`src/findings.rs\`: \`Finding\` gains the 4th \`Option<_>\` field with \`#[serde(skip_serializing_if = "Option::is_none")]\` — absent direction is omitted from JSON, matching the P1.02 symmetry pattern.

## Wiring map
| Site | Direction value | Rationale |
|---|---|---|
| \`http::check_request_detections\` (7 sites) + \`try_parse_requests\` too-many-headers | \`Some(ClientToServer)\` | All fire only on request side |
| \`http::try_parse_responses\` too-many-headers | \`Some(ServerToClient)\` | Response-parser-only |
| \`tls::handle_client_hello\` (5 sites: control bytes / non-ASCII SNI / weak ciphers / SSL3) | \`Some(ClientToServer)\` | ClientHello flow direction |
| \`tls::handle_server_hello\` (2 sites: weak cipher selection / deprecated protocol) | \`Some(ServerToClient)\` | ServerHello flow direction |
| \`reassembly::process_packet\` threshold sites (overlap / small-segment / out-of-window) | \`Some(dir)\` | Uses the existing \`dir\` value from \`flow.direction(...)\` |

## Left as \`direction: None\` (intentional, scope-limit)
- \`reassembly::generate_conflicting_overlap_finding\` and \`generate_truncated_finding\` helpers — would need threading a new \`dir: Direction\` parameter through both signatures. Marked as follow-up.
- \`reassembly::finalize\` segment-limit summary finding — global event, not flow-direction-specific.
- DNS analyzer findings — DNS over UDP has no TCP-stream direction concept.
- Test fixtures — placeholder Findings constructed in tests.

## Tests
Two new tests in \`tests/reporter_tests.rs\`:

| Test | Asserts |
|---|---|
| \`test_json_finding_emits_direction_when_set\` | \`Some(ClientToServer)\` / \`Some(ServerToClient)\` surface under \`"direction"\` key |
| \`test_json_finding_omits_direction_when_none\` | Absent direction is skipped, not emitted as \`null\` (matches P1.02 omission) |

## Test plan
- [x] \`cargo fmt --check\` — clean
- [x] \`cargo clippy --all-targets -- -D warnings\` — clean
- [x] \`cargo test --all-targets\` — **240 passed, 0 failed** (was 238)
- [x] All 22 \`Finding\` push sites in src/ updated (one of: hardcoded \`Some(Direction::*)\`, \`Some(dir)\` from in-scope variable, or explicit \`None\` with rationale)
- [x] All 11 test-fixture \`Finding\` literals updated to \`direction: None\` for back-compat

## P2 backlog status

| Lesson | Status |
|---|---|
| P2.09 — deterministic JSON map ordering | ✅ #76 |
| P2.10 — \`#[non_exhaustive]\` on classifying enums | ✅ #76 |
| **P2.08 — direction tag on Finding** | ✅ this PR |
| P2.02 — format-string conversion | next |
| P2.06 — cargo audit / cargo deny CI | after P2.02 |
| P2.04 — JA3 property tests | later |
| P2.07 — criterion benchmarks | later |
| P2.03 — CSV reporter decision | later (scope discussion) |
| P2.11 — \`max_classification_attempts\` knob | later |
| P2.01 — reassembly/mod.rs refactor | deferred (design discussion) |
| P2.05 — threshold calibration | deferred (empirical data) |