### PR TITLE
style(format): inline format args + enforce via clippy lint (P2.02)

### DIFF
--- a/src/analyzer/tls.rs
+++ b/src/analyzer/tls.rs
@@ -560,7 +560,7 @@ impl TlsAnalyzer {
                 category: ThreatCategory::Anomaly,
                 verdict: Verdict::Likely,
                 confidence: Confidence::Medium,
-                summary: format!("ServerHello selected weak cipher suite ({})", name),
+                summary: format!("ServerHello selected weak cipher suite ({name})"),
                 evidence: vec![format!("Selected cipher: {} (0x{:04x})", name, sh.cipher.0)],
                 mitre_technique: None,
                 source_ip: None,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,11 @@
 //! in the technical-debt register; new public items added to an audited
 //! module MUST carry a doc comment.
 #![warn(missing_docs)]
+// LESSON-P2.02: enforce inlined format-string arguments
+// (`format!("{x}")` not `format!("{}", x)`) across the crate.
+// Combined with CI's `-D warnings`, this turns any regression
+// into a build failure.
+#![warn(clippy::uninlined_format_args)]
 
 #[allow(missing_docs)]
 pub mod analyzer;

--- a/src/reassembly/mod.rs
+++ b/src/reassembly/mod.rs
@@ -357,8 +357,7 @@ impl TcpReassembler {
                         verdict: Verdict::Inconclusive,
                         confidence: Confidence::Low,
                         summary: format!(
-                            "Excessive out-of-window segments ({}) on flow {}",
-                            count, key
+                            "Excessive out-of-window segments ({count}) on flow {key}"
                         ),
                         evidence: vec![format!(
                             "max_receive_window={} bytes; possible misconfiguration, evasion, or capture corruption",
@@ -536,11 +535,10 @@ impl TcpReassembler {
     fn close_flow(&mut self, key: &FlowKey, reason: CloseReason, handler: &mut dyn StreamHandler) {
         use crate::reassembly::handler::Direction;
         let Some(mut flow) = self.flows.remove(key) else {
-            debug_assert!(false, "close_flow called for non-existent key: {}", key);
+            debug_assert!(false, "close_flow called for non-existent key: {key}");
             if !CLOSE_FLOW_MISSING_WARNED.swap(true, Ordering::Relaxed) {
                 eprintln!(
-                    "wirerust: close_flow called for non-existent key: {} (reason: {:?})",
-                    key, reason
+                    "wirerust: close_flow called for non-existent key: {key} (reason: {reason:?})"
                 );
             }
             return;
@@ -597,7 +595,7 @@ impl TcpReassembler {
             category: ThreatCategory::Anomaly,
             verdict: Verdict::Likely,
             confidence: Confidence::High,
-            summary: format!("Conflicting TCP segment overlap on flow {}", key),
+            summary: format!("Conflicting TCP segment overlap on flow {key}"),
             evidence: vec!["Retransmitted segment contains different data".to_string()],
             mitre_technique: Some("T1036".to_string()),
             source_ip: Some(src_ip),
@@ -615,7 +613,7 @@ impl TcpReassembler {
             category: ThreatCategory::Anomaly,
             verdict: Verdict::Inconclusive,
             confidence: Confidence::Low,
-            summary: format!("Stream depth exceeded on flow {}", key),
+            summary: format!("Stream depth exceeded on flow {key}"),
             evidence: vec![format!("Max depth {} bytes reached", self.config.max_depth)],
             mitre_technique: None,
             source_ip: Some(src_ip),

--- a/src/reassembly/segment.rs
+++ b/src/reassembly/segment.rs
@@ -188,8 +188,7 @@ impl FlowDirection {
                         let old = self.segments.insert(gap_start, gap_data);
                         debug_assert!(
                             old.is_none(),
-                            "gap_start {} collided with existing segment",
-                            gap_start
+                            "gap_start {gap_start} collided with existing segment"
                         );
                         if let Some(old) = old {
                             self.buffered_bytes -= old.len();
@@ -218,8 +217,7 @@ impl FlowDirection {
         let old = self.segments.insert(offset, segment_data);
         debug_assert!(
             old.is_none(),
-            "offset {} collided with existing segment in no-overlap path",
-            offset
+            "offset {offset} collided with existing segment in no-overlap path"
         );
         if let Some(old) = old {
             self.buffered_bytes -= old.len();

--- a/tests/reporter_tests.rs
+++ b/tests/reporter_tests.rs
@@ -63,18 +63,15 @@ fn test_json_finding_omits_absent_optional_fields_symmetrically() {
     let obj = finding.as_object().expect("finding must be a JSON object");
     assert!(
         !obj.contains_key("mitre_technique"),
-        "absent mitre_technique must be omitted, got: {}",
-        finding
+        "absent mitre_technique must be omitted, got: {finding}"
     );
     assert!(
         !obj.contains_key("source_ip"),
-        "absent source_ip must be omitted, got: {}",
-        finding
+        "absent source_ip must be omitted, got: {finding}"
     );
     assert!(
         !obj.contains_key("timestamp"),
-        "absent timestamp must be omitted, got: {}",
-        finding
+        "absent timestamp must be omitted, got: {finding}"
     );
 }
 


### PR DESCRIPTION
## Summary
Mechanical format-string modernization plus a guardrail lint so the convention stays enforced.

**Before:**
\`\`\`rust
format!(\"Stream depth exceeded on flow {}\", key)
\`\`\`

**After:**
\`\`\`rust
format!(\"Stream depth exceeded on flow {key}\")
\`\`\`

Inlined format-string arguments have been stable since Rust 1.58 (2022-01) and are idiomatic in current Rust style guides.

## Sites converted
11 fixes auto-applied via \`cargo clippy --fix\`:
- \`src/reassembly/segment.rs\` (2 fixes)
- \`src/reassembly/mod.rs\` (5 fixes)
- \`src/analyzer/tls.rs\` (1 fix)
- \`tests/reporter_tests.rs\` (3 fixes)

## Enforcement
\`#![warn(clippy::uninlined_format_args)]\` added to \`src/lib.rs\` next to the existing \`#![warn(missing_docs)]\`. Combined with CI's \`-D warnings\` flag, any future regression to the verbose form becomes a build failure.

Same pattern as the P1.04 / P1.06 enforcement loops — make the convention machine-checked rather than reviewer-trust.

## Test plan
- [x] \`cargo fmt --check\` — clean
- [x] \`cargo clippy --all-targets -- -D warnings\` — clean (now includes \`uninlined_format_args\` as a hard gate)
- [x] \`cargo test --all-targets\` — **240 passed, 0 failed** (unchanged — no behavioral surface touched)

## P2 backlog status

| Lesson | Status |
|---|---|
| P2.08 — direction tag on Finding | ✅ #77 |
| P2.09 — deterministic JSON map ordering | ✅ #76 |
| P2.10 — \`#[non_exhaustive]\` on classifying enums | ✅ #76 |
| **P2.02 — format-string conversion** | ✅ this PR |
| P2.06 — cargo audit / cargo deny CI | next |
| P2.04 — JA3 property tests | later |
| P2.07 — criterion benchmarks | later |
| P2.03 — CSV reporter decision | later (scope discussion) |
| P2.11 — \`max_classification_attempts\` knob | later |
| P2.01 — reassembly/mod.rs refactor | deferred (design discussion) |
| P2.05 — threshold calibration | deferred (empirical data) |