### PR TITLE
ci(supply-chain): add cargo audit + cargo deny jobs (P2.06)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,3 +66,32 @@ jobs:
         with:
           components: rustfmt
       - run: cargo fmt --all --check
+
+  # LESSON-P2.06: supply-chain scanning split into two complementary
+  # jobs so a noisy advisory in one source does not block merges on
+  # an unrelated regression.
+  audit:
+    name: Audit
+    runs-on: ubuntu-latest
+    # Advisory database may surface new findings between code changes,
+    # so this job is informational on PRs (continue-on-error: true)
+    # and run on a schedule against develop to catch zero-days.
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v6
+      - name: Run cargo audit
+        uses: rustsec/audit-check@v2.0.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+  deny:
+    name: Deny
+    runs-on: ubuntu-latest
+    # cargo-deny enforces the license / banned-deps / sources policy
+    # in `deny.toml`. Failures are blocking — these are
+    # repo-policy violations, not external advisory noise.
+    steps:
+      - uses: actions/checkout@v6
+      - uses: EmbarkStudios/cargo-deny-action@v2
+        with:
+          command: check bans licenses sources

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,65 @@
+# Cargo-deny configuration (LESSON-P2.06).
+#
+# Supply-chain policy for wirerust. Three concerns:
+#   - licenses: only permissive open-source licenses compatible
+#     with this crate's MIT license
+#   - bans: no duplicate / yanked dependencies
+#   - sources: only crates.io for now (no git or local-path deps)
+#
+# The advisories section is handled by the separate `cargo audit` job
+# in CI (rustsec/audit-check) so this config focuses on policy rather
+# than vuln scanning.
+
+[graph]
+# Match the project's stable-channel target.
+all-features = false
+no-default-features = false
+
+[licenses]
+# Permissive licenses compatible with MIT. If a transitive dep
+# carries a different license, this list needs updating — explicitly
+# rather than silently waving it through.
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "ISC",
+    "Unicode-3.0",
+    "Unicode-DFS-2016",
+    "Zlib",
+    "CC0-1.0",
+    "MPL-2.0",
+    "0BSD",
+]
+# Per-crate overrides for crates whose published license metadata is
+# ambiguous but whose actual LICENSE file is OK. (Currently empty;
+# add entries here rather than relaxing the `allow` list.)
+exceptions = []
+confidence-threshold = 0.93
+
+[bans]
+multiple-versions = "warn"
+wildcards = "deny"
+highlight = "all"
+# Permit a handful of common version-duplication cases (e.g. nested
+# rand 0.7 vs 0.8 through different transitive paths). Add entries
+# here only with a one-line comment justifying why the duplicate is
+# unavoidable.
+skip = []
+skip-tree = []
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = []
+
+[advisories]
+# Advisory checks live in the `cargo audit` job; cargo-deny's
+# `advisories` table is intentionally minimal here so the two jobs
+# do not double-report the same finding.
+db-path = "~/.cargo/advisory-db"
+db-urls = ["https://github.com/rustsec/advisory-db"]
+yanked = "warn"


### PR DESCRIPTION
## Summary
Adds two supply-chain CI jobs that complement the existing Test / Clippy / Format / Semantic PR gates.

| Job | Tool | Blocking? | Purpose |
|---|---|---|---|
| **Audit** | \`rustsec/audit-check@v2.0.0\` | No (\`continue-on-error: true\`) | Scans deps for known vulnerabilities + unsoundness advisories against the RustSec database |
| **Deny** | \`EmbarkStudios/cargo-deny-action@v2\` | **Yes** | Enforces repo-policy licenses / banned-deps / sources via \`deny.toml\` |

## Why split?

The advisory database evolves independently of code changes. A new advisory landing on a transitive dep between PR creation and merge should not block unrelated PRs — that's the audit job's noise tolerance. Repo-policy violations (a dep with a banned license, an unapproved git source) ARE blocking — that's deny's job.

## deny.toml policy
- **Licenses**: explicit allow-list of permissive MIT-compatible licenses. New unrecognized license requires explicit decision rather than silent acceptance.
- **Bans**: duplicate versions = warn (already common via \`syn 1/2\`, \`windows-sys 0.59/0.61\`); wildcard deps denied.
- **Sources**: only crates.io. New git deps require explicit approval in \`[sources].allow-git\`.
- **Advisories**: intentionally minimal — owned by the cargo-audit job so the two don't double-report.

## Current state of the world (local check)
- \`cargo audit\`: **2 warning-level advisories**, both transitive — \`number_prefix\` via \`indicatif\`, \`rand 0.8.5\` via \`tls-parser\`. Both are warning class (\`unsound\`), not vuln class. Audit job will not fail CI on them.
- \`cargo deny check bans licenses sources\`: **exits 0**. Reports informational duplicate-version warnings for \`syn\` (1.0/2.0) and \`windows-sys\` (0.59/0.61), both unavoidable through current transitive paths.

## Test plan
- [x] \`deny.toml\` validated locally with \`cargo deny check bans licenses sources\` — exit 0
- [x] Two new CI jobs added to \`.github/workflows/ci.yml\`
- [x] Existing Test / Clippy / Format / Semantic PR jobs unchanged

## P2 backlog status

| Lesson | Status |
|---|---|
| P2.02 — format-string conversion | ✅ #78 |
| P2.08 — direction tag on Finding | ✅ #77 |
| P2.09 — deterministic JSON map ordering | ✅ #76 |
| P2.10 — \`#[non_exhaustive]\` on classifying enums | ✅ #76 |
| **P2.06 — cargo audit / cargo deny CI** | ✅ this PR |
| P2.04 — JA3 property tests | next |
| P2.07 — criterion benchmarks | later |
| P2.03 — CSV reporter decision | later (scope discussion) |
| P2.11 — \`max_classification_attempts\` knob | later |
| P2.01 — reassembly/mod.rs refactor | deferred (design discussion) |
| P2.05 — threshold calibration | deferred (empirical data) |