### PR TITLE
perf(bench): add criterion micro-benchmarks for hot paths (P2.07)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloca"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7d05ea6aea7e9e64d25b9156ba2fee3fdd659e34e41063cd2fc7cd020d7f4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -19,6 +28,12 @@ checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
@@ -166,6 +181,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.2.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -193,6 +214,33 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
 ]
 
 [[package]]
@@ -267,6 +315,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "criterion"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "950046b2aa2492f9a536f5f4f9a3de7b9e2476e575e05bd6c333371add4d98f3"
+dependencies = [
+ "alloca",
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "itertools",
+ "num-traits",
+ "oorandom",
+ "page_size",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -290,6 +373,12 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -445,6 +534,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -540,6 +640,15 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -691,10 +800,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "owo-colors"
 version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
+
+[[package]]
+name = "page_size"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "pcap-file"
@@ -743,6 +868,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
 dependencies = [
  "siphasher",
+]
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
 ]
 
 [[package]]
@@ -1013,6 +1166,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "semver"
 version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1141,6 +1303,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "tls-parser"
 version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1227,6 +1399,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
 ]
 
 [[package]]
@@ -1327,6 +1509,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-sys"
+version = "0.3.94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd70027e39b12f0849461e08ffc50b9cd7688d942c1c8e3c7b22273236b4dd0a"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "web-time"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1335,6 +1527,37 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
@@ -1494,6 +1717,7 @@ dependencies = [
  "assert_cmd",
  "chrono",
  "clap",
+ "criterion",
  "csv",
  "etherparse",
  "httparse",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,3 +30,11 @@ assert_cmd = "2"
 predicates = "3"
 tempfile = "3"
 proptest = "1"
+criterion = "0.8"
+
+# LESSON-P2.07: criterion micro-benchmarks for the hot pcap-processing
+# paths. `harness = false` hands the test binary to criterion's own
+# runner instead of libtest. Run with `cargo bench`.
+[[bench]]
+name = "pipeline"
+harness = false

--- a/benches/pipeline.rs
+++ b/benches/pipeline.rs
@@ -1,0 +1,113 @@
+//! Criterion micro-benchmarks for the wirerust pcap-processing pipeline
+//! (LESSON-P2.07).
+//!
+//! Three benchmark groups cover the genuinely hot paths:
+//!
+//!   - `decode`  — raw frame → `ParsedPacket` decoding throughput.
+//!   - `summary` — capture-level `Summary::ingest` accumulation.
+//!   - `reassembly` — the full TCP reassembly + content-dispatch +
+//!     per-protocol analyzer path.
+//!
+//! Each benchmark loads its pcap fixture once, outside the timed
+//! closure, so file I/O is not counted. Run with `cargo bench`;
+//! results land in `target/criterion/`.
+//!
+//! Fixture choices favor the larger consumed fixtures so the
+//! benchmark exercises a realistic packet count rather than a
+//! handful of frames.
+
+use std::hint::black_box;
+use std::path::Path;
+
+use criterion::{Criterion, criterion_group, criterion_main};
+
+use wirerust::analyzer::http::HttpAnalyzer;
+use wirerust::analyzer::tls::TlsAnalyzer;
+use wirerust::decoder::decode_packet;
+use wirerust::dispatcher::StreamDispatcher;
+use wirerust::reader::PcapSource;
+use wirerust::reassembly::{ReassemblyConfig, TcpReassembler};
+use wirerust::summary::Summary;
+
+/// Load a fixture's raw packets + datalink, panicking on failure —
+/// benchmarks have no meaningful error-recovery path.
+fn load(fixture: &str) -> PcapSource {
+    let path = format!("tests/fixtures/{fixture}");
+    PcapSource::from_file(Path::new(&path))
+        .unwrap_or_else(|e| panic!("failed to load benchmark fixture {path}: {e}"))
+}
+
+/// Benchmark: decode every frame in a fixture into a `ParsedPacket`.
+fn bench_decode(c: &mut Criterion) {
+    let mut group = c.benchmark_group("decode");
+    for fixture in ["segmented.pcap", "tls.pcap", "dns-remoteshell.pcap"] {
+        let source = load(fixture);
+        group.bench_function(fixture, |b| {
+            b.iter(|| {
+                for raw in &source.packets {
+                    let _ = black_box(decode_packet(&raw.data, source.datalink));
+                }
+            });
+        });
+    }
+    group.finish();
+}
+
+/// Benchmark: capture-level `Summary` accumulation over every
+/// successfully-decoded packet.
+fn bench_summary(c: &mut Criterion) {
+    let mut group = c.benchmark_group("summary");
+    for fixture in ["segmented.pcap", "dns-remoteshell.pcap"] {
+        let source = load(fixture);
+        // Pre-decode once so the benchmark isolates `Summary::ingest`.
+        let parsed: Vec<_> = source
+            .packets
+            .iter()
+            .filter_map(|raw| decode_packet(&raw.data, source.datalink).ok())
+            .collect();
+        group.bench_function(fixture, |b| {
+            b.iter(|| {
+                let mut summary = Summary::new();
+                for p in &parsed {
+                    summary.ingest(p);
+                }
+                black_box(summary.total_packets)
+            });
+        });
+    }
+    group.finish();
+}
+
+/// Benchmark: the full reassembly + dispatch + HTTP/TLS analysis path
+/// over a fixture, including the end-of-capture `finalize`.
+fn bench_reassembly(c: &mut Criterion) {
+    let mut group = c.benchmark_group("reassembly");
+    for fixture in ["segmented.pcap", "tls.pcap"] {
+        let source = load(fixture);
+        let parsed: Vec<_> = source
+            .packets
+            .iter()
+            .filter_map(|raw| {
+                decode_packet(&raw.data, source.datalink)
+                    .ok()
+                    .map(|p| (p, raw.timestamp_secs))
+            })
+            .collect();
+        group.bench_function(fixture, |b| {
+            b.iter(|| {
+                let mut reassembler = TcpReassembler::new(ReassemblyConfig::default());
+                let mut dispatcher =
+                    StreamDispatcher::new(Some(HttpAnalyzer::new()), Some(TlsAnalyzer::new()));
+                for (p, ts) in &parsed {
+                    reassembler.process_packet(p, *ts, &mut dispatcher);
+                }
+                reassembler.finalize(&mut dispatcher);
+                black_box(reassembler.findings().len())
+            });
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_decode, bench_summary, bench_reassembly);
+criterion_main!(benches);


### PR DESCRIPTION
## Summary
Adds a criterion benchmark suite so performance regressions on the pcap-processing hot paths are measurable rather than guessed-at.

New dev-dependency: \`criterion = "0.8"\` + a \`[[bench]]\` entry with \`harness = false\`.

## benches/pipeline.rs — three groups

| Group | What it measures | Fixtures |
|---|---|---|
| \`decode\` | Raw frame → \`ParsedPacket\` decoding throughput | segmented.pcap, tls.pcap, dns-remoteshell.pcap |
| \`summary\` | \`Summary::ingest\` accumulation (packets pre-decoded to isolate ingest) | segmented.pcap, dns-remoteshell.pcap |
| \`reassembly\` | Full reassembly + dispatch + HTTP/TLS analysis incl. \`finalize\` | segmented.pcap, tls.pcap |

Each group loads its fixture once outside the timed closure so file I/O is excluded.

## Smoke-run numbers (10 samples, abbreviated)
\`\`\`
decode/segmented.pcap        ~1.46 µs
decode/tls.pcap              ~3.0 µs
decode/dns-remoteshell.pcap  ~4.48 µs
summary/segmented.pcap       ~600 ns
\`\`\`
Full baselines land in \`target/criterion/\` on \`cargo bench\`.

## CI integration — deliberate scope
- The bench binary **is** compile-checked by the existing \`cargo clippy --all-targets\` job → prevents bit-rot.
- Running \`cargo bench\` in CI is **intentionally not added**: without a committed baseline + regression-threshold harness the per-PR numbers aren't actionable, and the run is slow. \`cargo bench\` stays a local/manual tool. A baseline-comparison CI job is a possible future follow-up.

## Test plan
- [x] \`cargo bench --no-run\` — benchmark binary compiles
- [x] Smoke run (\`--sample-size 10\`) produces stable numbers
- [x] \`cargo fmt --check\` — clean
- [x] \`cargo clippy --all-targets -- -D warnings\` — clean (benches in scope)
- [x] \`cargo test --all-targets\` — 252 passed (unchanged — benches aren't libtest tests)
- [x] \`cargo deny check\` — licenses ok (criterion's transitive deps all permissive)

## P2 backlog status

| Lesson | Status |
|---|---|
| P2.02 / P2.04 / P2.06 / P2.08 / P2.09 / P2.10 / P2.11 | ✅ #76–#82 |
| **P2.07 — criterion benchmarks** | ✅ this PR |
| P2.03 — CSV reporter decision | last P2 — scope discussion |
| P2.01 — reassembly/mod.rs refactor | deferred (design discussion) |
| P2.05 — threshold calibration | deferred (empirical data) |