### PR TITLE
feat(reporter): implement CSV reporter, retire the loud bail (P2.03)

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -48,11 +48,13 @@ pub struct Cli {
     #[arg(long, global = true, value_enum)]
     pub output_format: Option<OutputFormat>,
 
-    /// Write JSON output to file
-    #[arg(long, global = true)]
+    /// Write JSON output to file (or stdout if no path given).
+    /// Mutually exclusive with --csv.
+    #[arg(long, global = true, conflicts_with = "csv")]
     pub json: Option<Option<PathBuf>>,
 
-    /// Write CSV output to file
+    /// Write CSV output to file (or stdout if no path given).
+    /// Emits the findings table only — see the CSV reporter docs.
     #[arg(long, global = true)]
     pub csv: Option<Option<PathBuf>>,
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,9 +10,10 @@
 //!   reassembly), with optional per-host breakdown in the terminal
 //!   reporter when `summary --hosts` is given (LESSON-P1.03).
 //!
-//! Both pipelines respect the `--json <FILE>` / `--output-format` /
-//! `--csv` flags; CSV currently bails loudly via
-//! [`check_unsupported_outputs`] until a CSV reporter lands.
+//! Both pipelines respect the `--json [<FILE>]`, `--csv [<FILE>]`, and
+//! `--output-format {json,csv}` flags ([`resolve_format`]); each writes
+//! to a file when a path is given, else to stdout ([`write_output`]).
+//! `--json` and `--csv` are mutually exclusive (LESSON-P2.03).
 
 use std::path::Path;
 
@@ -31,6 +32,7 @@ use wirerust::reader::PcapSource;
 use wirerust::reassembly::handler::StreamAnalyzer;
 use wirerust::reassembly::{ReassemblyConfig, TcpReassembler};
 use wirerust::reporter::Reporter;
+use wirerust::reporter::csv::CsvReporter;
 use wirerust::reporter::json::JsonReporter;
 use wirerust::reporter::terminal::TerminalReporter;
 use wirerust::summary::Summary;
@@ -77,8 +79,6 @@ fn run_analyze(
     use_color: bool,
     cli: &Cli,
 ) -> Result<()> {
-    check_unsupported_outputs(cli)?;
-
     let mut summary = Summary::new();
     let mut dns_analyzer = DnsAnalyzer::new();
     let mut all_findings = Vec::new();
@@ -207,6 +207,10 @@ fn run_analyze(
             let reporter = JsonReporter;
             reporter.render(&summary, &all_findings, &analyzer_summaries)
         }
+        Some(OutputFormat::Csv) => {
+            let reporter = CsvReporter;
+            reporter.render(&summary, &all_findings, &analyzer_summaries)
+        }
         _ => {
             let reporter = TerminalReporter {
                 use_color,
@@ -229,8 +233,6 @@ fn run_summary(
     use_color: bool,
     cli: &Cli,
 ) -> Result<()> {
-    check_unsupported_outputs(cli)?;
-
     let mut summary = Summary::new();
     let mut total_decode_errors: u64 = 0;
 
@@ -264,6 +266,10 @@ fn run_summary(
             let reporter = JsonReporter;
             reporter.render(&summary, &[], &[])
         }
+        Some(OutputFormat::Csv) => {
+            let reporter = CsvReporter;
+            reporter.render(&summary, &[], &[])
+        }
         _ => {
             let reporter = TerminalReporter {
                 use_color,
@@ -278,47 +284,40 @@ fn run_summary(
     Ok(())
 }
 
-/// Determine the output format, with `--json [<FILE>]` overriding `--output-format`.
+/// Determine the output format.
 ///
 /// Precedence (highest to lowest):
-/// 1. `--json` (with or without path) forces `OutputFormat::Json`.
-/// 2. `--output-format <fmt>` is honored as-is.
-/// 3. Default (terminal table) when neither flag is given.
+/// 1. `--json [<FILE>]` forces `OutputFormat::Json`.
+/// 2. `--csv [<FILE>]` forces `OutputFormat::Csv`. (`--json` and `--csv`
+///    are mutually exclusive — clap rejects the combination.)
+/// 3. `--output-format <fmt>` is honored as-is.
+/// 4. Default (terminal table) when no flag is given.
 fn resolve_format(cli: &Cli) -> Option<OutputFormat> {
     if cli.json.is_some() {
         Some(OutputFormat::Json)
+    } else if cli.csv.is_some() {
+        Some(OutputFormat::Csv)
     } else {
         cli.output_format
     }
 }
 
-/// Write rendered output either to a file (if `--json <FILE>` was given) or stdout.
+/// Write rendered output to a file (if `--json <FILE>` or `--csv <FILE>`
+/// was given with a path) or to stdout otherwise.
+///
+/// `--json` and `--csv` are mutually exclusive (enforced by clap), so at
+/// most one of the file-path arms can be active.
 fn write_output(output: &str, cli: &Cli) -> Result<()> {
-    match &cli.json {
-        Some(Some(path)) => std::fs::write(path, output)
+    match (&cli.json, &cli.csv) {
+        (Some(Some(path)), _) => std::fs::write(path, output)
             .with_context(|| format!("Failed to write JSON output to {}", path.display())),
+        (_, Some(Some(path))) => std::fs::write(path, output)
+            .with_context(|| format!("Failed to write CSV output to {}", path.display())),
         _ => {
             println!("{output}");
             Ok(())
         }
     }
-}
-
-/// Bail before any analysis if the user requested CSV output. The CSV reporter
-/// is unimplemented; previously the request was silently downgraded to terminal
-/// output, hiding the failure. Make it loud until the CSV reporter lands.
-fn check_unsupported_outputs(cli: &Cli) -> Result<()> {
-    if cli.csv.is_some() {
-        anyhow::bail!(
-            "--csv output is not yet implemented; rerun without --csv (or use --output-format json --json <FILE> for file output)"
-        );
-    }
-    if matches!(cli.output_format, Some(OutputFormat::Csv)) {
-        anyhow::bail!(
-            "--output-format csv is not yet implemented; choose 'json' or omit the flag for the terminal table"
-        );
-    }
-    Ok(())
 }
 
 fn resolve_targets(target: &Path) -> Result<Vec<std::path::PathBuf>> {

--- a/src/reporter/csv.rs
+++ b/src/reporter/csv.rs
@@ -1,0 +1,107 @@
+//! CSV reporter — flat tabular rendering of the findings list
+//! (LESSON-P2.03).
+//!
+//! Emits the `findings` slice as an RFC 4180 CSV table, one row per
+//! [`Finding`], with a fixed header. This is the analyst-pipe-into-a-
+//! spreadsheet output channel.
+//!
+//! ## Scope: findings only
+//!
+//! CSV is a flat row-oriented format. The capture-level [`Summary`]
+//! (protocol / service / host maps) and the per-analyzer
+//! [`AnalysisSummary`] detail blocks are nested and heterogeneous —
+//! they do not map cleanly onto a single CSV table. The CSV reporter
+//! therefore renders **only** the findings table; callers who need the
+//! summary / analyzer data should use the JSON or terminal reporter.
+//! This is an intentional, documented limitation, not an oversight.
+//!
+//! ## CSV-injection neutralization
+//!
+//! `Finding::summary` and `Finding::evidence` carry attacker-controlled
+//! bytes from packet payloads (see ADR 0003). When a CSV is opened in a
+//! spreadsheet application (Excel, LibreOffice, Google Sheets), a cell
+//! whose value begins with `=`, `+`, `-`, `@`, TAB, or CR is
+//! interpreted as a *formula* — a well-known "CSV injection" /
+//! "formula injection" vector (OWASP). Because wirerust is a forensics
+//! tool that deliberately surfaces hostile input, every field is run
+//! through [`neutralize_csv_injection`], which prepends a single quote
+//! to any cell starting with a formula-trigger character. This mirrors
+//! the terminal reporter's control-byte escaping: the raw [`Finding`]
+//! keeps unmodified bytes; the display/export layer sanitizes.
+
+use crate::analyzer::AnalysisSummary;
+use crate::findings::Finding;
+use crate::reporter::Reporter;
+use crate::summary::Summary;
+
+/// Prepend a single quote to any value that a spreadsheet would
+/// otherwise interpret as a formula. See the module docs for the
+/// CSV-injection rationale.
+fn neutralize_csv_injection(s: &str) -> String {
+    match s.chars().next() {
+        Some('=' | '+' | '-' | '@' | '\t' | '\r') => format!("'{s}"),
+        _ => s.to_string(),
+    }
+}
+
+/// CSV reporter. See the module documentation for the findings-only
+/// scope and the CSV-injection neutralization policy.
+pub struct CsvReporter;
+
+impl Reporter for CsvReporter {
+    fn render(
+        &self,
+        _summary: &Summary,
+        findings: &[Finding],
+        _analyzer_summaries: &[AnalysisSummary],
+    ) -> String {
+        let mut writer = csv::WriterBuilder::new().from_writer(Vec::new());
+
+        // Fixed header. Order is stable so downstream parsers can rely
+        // on column positions.
+        writer
+            .write_record([
+                "category",
+                "verdict",
+                "confidence",
+                "summary",
+                "evidence",
+                "mitre_technique",
+                "source_ip",
+                "direction",
+                "timestamp",
+            ])
+            .expect("writing CSV header to an in-memory buffer cannot fail");
+
+        for f in findings {
+            // `evidence` is a Vec<String>; flatten with "; " so the
+            // whole list lives in one cell. The csv crate quotes the
+            // cell automatically if it contains the separator, commas,
+            // quotes, or newlines (RFC 4180).
+            let evidence = f.evidence.join("; ");
+            let mitre = f.mitre_technique.as_deref().unwrap_or("");
+            let source_ip = f.source_ip.map(|ip| ip.to_string()).unwrap_or_default();
+            let direction = f.direction.map(|d| format!("{d:?}")).unwrap_or_default();
+            let timestamp = f.timestamp.map(|t| t.to_rfc3339()).unwrap_or_default();
+
+            writer
+                .write_record([
+                    neutralize_csv_injection(&f.category.to_string()),
+                    neutralize_csv_injection(&f.verdict.to_string()),
+                    neutralize_csv_injection(&f.confidence.to_string()),
+                    neutralize_csv_injection(&f.summary),
+                    neutralize_csv_injection(&evidence),
+                    neutralize_csv_injection(mitre),
+                    neutralize_csv_injection(&source_ip),
+                    neutralize_csv_injection(&direction),
+                    neutralize_csv_injection(&timestamp),
+                ])
+                .expect("writing a CSV record to an in-memory buffer cannot fail");
+        }
+
+        let bytes = writer
+            .into_inner()
+            .expect("flushing the in-memory CSV buffer cannot fail");
+        String::from_utf8(bytes).expect("CSV content is built from UTF-8 String inputs")
+    }
+}

--- a/src/reporter/mod.rs
+++ b/src/reporter/mod.rs
@@ -1,15 +1,21 @@
 //! Output reporters and the [`Reporter`] trait.
 //!
-//! Two concrete implementations: [`json::JsonReporter`] (machine-readable
-//! emission for downstream tooling, no escaping) and
-//! [`terminal::TerminalReporter`] (TTY-friendly table with ADR 0003
-//! control-byte escaping).
+//! Three concrete implementations:
+//! - [`json::JsonReporter`] — machine-readable emission for downstream
+//!   tooling, no escaping.
+//! - [`terminal::TerminalReporter`] — TTY-friendly table with ADR 0003
+//!   control-byte escaping.
+//! - [`csv::CsvReporter`] — flat RFC 4180 findings table for
+//!   spreadsheet import (LESSON-P2.03), with CSV-injection
+//!   neutralization. Renders the findings list only — see its module
+//!   docs for the scope rationale.
 //!
 //! Each implementation receives the same three inputs — a [`Summary`], a
 //! `&[Finding]`, and a `&[AnalysisSummary]` — and produces a `String`.
 //! See ADR 0003 (`docs/adr/0003-reporting-pipeline-layering.md`) for the
 //! escaping-layer rationale and the security-bug regression it prevented.
 
+pub mod csv;
 pub mod json;
 pub mod terminal;
 

--- a/tests/cli_integration_tests.rs
+++ b/tests/cli_integration_tests.rs
@@ -1,12 +1,11 @@
 //! End-to-end CLI integration tests that spawn the `wirerust` binary.
 //!
-//! These tests exercise the `--json <FILE>` file-output path (LESSON-P0.04) and
-//! the loud-bail behavior on `--csv` / `--output-format csv`. They are the
-//! first activated use of the `assert_cmd` + `predicates` + `tempfile`
-//! dev-dependencies (previously dead per BC-ABS-009).
+//! These tests exercise the `--json <FILE>` file-output path (LESSON-P0.04)
+//! and the `--csv` reporter (LESSON-P2.03). They were the first activated
+//! use of the `assert_cmd` + `predicates` + `tempfile` dev-dependencies
+//! (previously dead per BC-ABS-009).
 
 use assert_cmd::Command;
-use predicates::str::contains;
 
 /// Smallest consumed pcap fixture in the tree (1,209 B). Produces a small but
 /// non-empty findings set when analyzed with `--all`.
@@ -72,56 +71,108 @@ fn json_file_output_overrides_terminal_output_format() {
     );
 }
 
-#[test]
-fn csv_flag_bails_with_clear_message() {
-    Command::cargo_bin("wirerust")
-        .expect("binary built")
-        .args(["analyze", FIXTURE, "--csv"])
-        .assert()
-        .failure()
-        .stderr(contains("--csv output is not yet implemented"));
-}
+// ---- LESSON-P2.03: CSV reporter ----
 
 #[test]
-fn csv_flag_with_path_bails_with_clear_message() {
+fn csv_flag_with_path_writes_csv_findings_table() {
+    // `--csv <FILE>` writes the findings table to the file. The
+    // fixture analyzed with `--all` produces a non-empty findings set,
+    // so the CSV has the header row plus at least one data row.
     let tmp = tempfile::tempdir().expect("tempdir");
-    let out_path = tmp.path().join("would-not-be-written.csv");
+    let out_path = tmp.path().join("out.csv");
 
     Command::cargo_bin("wirerust")
         .expect("binary built")
         .args([
             "analyze",
             FIXTURE,
+            "--all",
             "--csv",
             out_path.to_str().expect("utf-8 path"),
         ])
         .assert()
-        .failure()
-        .stderr(contains("--csv output is not yet implemented"));
+        .success();
 
+    let written = std::fs::read_to_string(&out_path).expect("output file exists");
+    let mut lines = written.lines();
+    // Fixed header row, exact column order.
+    assert_eq!(
+        lines.next(),
+        Some(
+            "category,verdict,confidence,summary,evidence,mitre_technique,source_ip,direction,timestamp"
+        ),
+        "CSV must start with the fixed header row"
+    );
     assert!(
-        !out_path.exists(),
-        "CSV bail must not create the requested output file"
+        lines.next().is_some(),
+        "CSV must contain at least one finding row for the --all analysis of the fixture"
     );
 }
 
 #[test]
-fn output_format_csv_bails_with_clear_message() {
-    Command::cargo_bin("wirerust")
+fn csv_flag_without_path_writes_csv_to_stdout() {
+    // `--csv` with no path emits the CSV table to stdout. The terminal
+    // reporter never emits the CSV header line, so its presence proves
+    // the CSV reporter ran.
+    let output = Command::cargo_bin("wirerust")
         .expect("binary built")
-        .args(["analyze", FIXTURE, "--output-format", "csv"])
+        .args(["analyze", FIXTURE, "--all", "--csv"])
         .assert()
-        .failure()
-        .stderr(contains("--output-format csv is not yet implemented"));
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let stdout = String::from_utf8(output).expect("utf-8 stdout");
+    assert!(
+        stdout.starts_with("category,verdict,confidence,summary,"),
+        "stdout must begin with the CSV header, got: {:?}",
+        &stdout[..60.min(stdout.len())]
+    );
 }
 
 #[test]
-fn summary_subcommand_also_honors_csv_bail() {
-    // The bail must fire for both subcommands, not just `analyze`.
-    Command::cargo_bin("wirerust")
+fn output_format_csv_emits_csv() {
+    // `--output-format csv` is honored identically to `--csv`.
+    let output = Command::cargo_bin("wirerust")
+        .expect("binary built")
+        .args(["analyze", FIXTURE, "--all", "--output-format", "csv"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let stdout = String::from_utf8(output).expect("utf-8 stdout");
+    assert!(
+        stdout.starts_with("category,verdict,confidence,"),
+        "--output-format csv must produce CSV output"
+    );
+}
+
+#[test]
+fn summary_subcommand_also_supports_csv() {
+    // The CSV reporter is wired for both subcommands. `summary` has no
+    // findings, so the CSV is just the header row.
+    let output = Command::cargo_bin("wirerust")
         .expect("binary built")
         .args(["summary", FIXTURE, "--csv"])
         .assert()
-        .failure()
-        .stderr(contains("--csv output is not yet implemented"));
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let stdout = String::from_utf8(output).expect("utf-8 stdout");
+    assert!(
+        stdout.starts_with("category,verdict,confidence,"),
+        "summary --csv must produce the CSV header"
+    );
+}
+
+#[test]
+fn json_and_csv_flags_are_mutually_exclusive() {
+    // clap `conflicts_with` must reject `--json` + `--csv` together.
+    Command::cargo_bin("wirerust")
+        .expect("binary built")
+        .args(["analyze", FIXTURE, "--json", "--csv"])
+        .assert()
+        .failure();
 }

--- a/tests/reporter_tests.rs
+++ b/tests/reporter_tests.rs
@@ -108,6 +108,135 @@ fn test_json_finding_emits_present_optional_fields() {
     );
 }
 
+// ---- LESSON-P2.03: CSV reporter ----
+
+#[test]
+fn test_csv_reporter_emits_header_and_one_row_per_finding() {
+    use wirerust::reporter::csv::CsvReporter;
+
+    let reporter = CsvReporter;
+    let findings = vec![
+        Finding {
+            category: ThreatCategory::Reconnaissance,
+            verdict: Verdict::Likely,
+            confidence: Confidence::High,
+            summary: "first finding".into(),
+            evidence: vec!["ev-a".into(), "ev-b".into()],
+            mitre_technique: Some("T1046".into()),
+            source_ip: None,
+            timestamp: None,
+            direction: None,
+        },
+        Finding {
+            category: ThreatCategory::Anomaly,
+            verdict: Verdict::Inconclusive,
+            confidence: Confidence::Low,
+            summary: "second finding".into(),
+            evidence: vec![],
+            mitre_technique: None,
+            source_ip: None,
+            timestamp: None,
+            direction: None,
+        },
+    ];
+    let out = reporter.render(&Summary::new(), &findings, &[]);
+    let lines: Vec<&str> = out.lines().collect();
+    assert_eq!(
+        lines[0],
+        "category,verdict,confidence,summary,evidence,mitre_technique,source_ip,direction,timestamp"
+    );
+    // Header + 2 data rows.
+    assert_eq!(lines.len(), 3, "expected header + 2 rows, got: {out}");
+    assert!(lines[1].contains("first finding"));
+    assert!(lines[1].contains("T1046"));
+    // Multi-value evidence is flattened into one cell with "; ".
+    assert!(lines[1].contains("ev-a; ev-b"));
+    assert!(lines[2].contains("second finding"));
+}
+
+#[test]
+fn test_csv_reporter_empty_findings_emits_header_only() {
+    use wirerust::reporter::csv::CsvReporter;
+
+    let reporter = CsvReporter;
+    let out = reporter.render(&Summary::new(), &[], &[]);
+    let lines: Vec<&str> = out.lines().collect();
+    assert_eq!(lines.len(), 1, "empty findings → header row only");
+    assert!(lines[0].starts_with("category,verdict,confidence,"));
+}
+
+#[test]
+fn test_csv_reporter_neutralizes_formula_injection() {
+    // LESSON-P2.03 security: a Finding summary controlled by an
+    // attacker that begins with a spreadsheet formula-trigger char
+    // (`=`, `+`, `-`, `@`) must be neutralized with a leading `'` so
+    // that opening the CSV in Excel/Sheets does not execute it.
+    use wirerust::reporter::csv::CsvReporter;
+
+    let reporter = CsvReporter;
+    let findings = vec![Finding {
+        category: ThreatCategory::Anomaly,
+        verdict: Verdict::Inconclusive,
+        confidence: Confidence::Low,
+        // Classic CSV-injection payload.
+        summary: "=cmd|'/c calc'!A1".into(),
+        evidence: vec!["@SUM(1+1)".into()],
+        mitre_technique: None,
+        source_ip: None,
+        timestamp: None,
+        direction: None,
+    }];
+    let out = reporter.render(&Summary::new(), &findings, &[]);
+    // Parse the CSV back and check the field values directly.
+    let mut rdr = csv::Reader::from_reader(out.as_bytes());
+    let record = rdr
+        .records()
+        .next()
+        .expect("one data row")
+        .expect("valid CSV record");
+    let summary_cell = &record[3];
+    let evidence_cell = &record[4];
+    assert!(
+        summary_cell.starts_with('\''),
+        "formula-trigger summary must be neutralized with a leading quote, got: {summary_cell:?}"
+    );
+    assert!(
+        evidence_cell.starts_with('\''),
+        "formula-trigger evidence must be neutralized, got: {evidence_cell:?}"
+    );
+}
+
+#[test]
+fn test_csv_reporter_ignores_summary_and_analyzer_data() {
+    // LESSON-P2.03 documented scope: the CSV reporter renders the
+    // findings table ONLY. A populated Summary / AnalysisSummary must
+    // not leak into the CSV output.
+    use wirerust::analyzer::AnalysisSummary;
+    use wirerust::reporter::csv::CsvReporter;
+
+    let mut summary = Summary::new();
+    summary.skipped_packets = 999;
+    let mut detail: std::collections::BTreeMap<String, serde_json::Value> =
+        std::collections::BTreeMap::new();
+    detail.insert(
+        "sentinel_key".to_string(),
+        serde_json::json!("sentinel_val"),
+    );
+    let analyzer = AnalysisSummary {
+        analyzer_name: "sentinel_analyzer".to_string(),
+        packets_analyzed: 7,
+        detail,
+    };
+
+    let reporter = CsvReporter;
+    let out = reporter.render(&summary, &[], &[analyzer]);
+    assert!(!out.contains("999"), "summary data must not appear in CSV");
+    assert!(
+        !out.contains("sentinel_key") && !out.contains("sentinel_analyzer"),
+        "analyzer-summary data must not appear in CSV; got: {out}"
+    );
+}
+
 // ---- LESSON-P2.08: direction tag on Finding ----
 
 #[test]


### PR DESCRIPTION
## Summary
LESSON-P2.03 — "CSV reporter **decision**". The \`csv = "1"\` dependency was declared in Cargo.toml but entirely unused; \`--csv\` / \`--output-format csv\` bailed loudly since #70.

**Decision: implement the CSV reporter** rather than remove the flag.

Rationale: the \`csv\` dependency was added with clear intent; CSV export is a standard analyst feature for a forensics CLI (pipe findings into a spreadsheet); the \`--csv [<FILE>]\` surface was already wired for the bail. Removing the flag would also have meant deleting a deliberately-added dependency.

## The CSV reporter — \`src/reporter/csv.rs\`

- Emits the findings slice as an RFC 4180 CSV table: fixed 9-column header (\`category, verdict, confidence, summary, evidence, mitre_technique, source_ip, direction, timestamp\`) + one row per Finding.
- \`evidence\` (a \`Vec<String>\`) is flattened into one cell with \`; \`.
- **Findings-only scope** (documented): CSV is flat & row-oriented; the nested \`Summary\` / per-analyzer \`AnalysisSummary\` blocks don't map onto a single table, so they are intentionally omitted. JSON/terminal remain the channels for that data.
- **CSV-injection neutralization** 🔒: \`summary\` / \`evidence\` carry attacker-controlled bytes (ADR 0003). A cell beginning with \`=\`, \`+\`, \`-\`, \`@\`, TAB, or CR is interpreted as a *formula* by Excel / LibreOffice / Sheets — the OWASP "CSV injection" vector. \`neutralize_csv_injection\` prepends a \`'\` to any such cell. This mirrors the terminal reporter's control-byte escaping: raw \`Finding\` keeps unmodified bytes, the export layer sanitizes.

## Wiring
- \`check_unsupported_outputs\` + both call sites **removed** — CSV is now supported.
- \`resolve_format\` gains a \`--csv → Csv\` branch; both \`run_analyze\` / \`run_summary\` render matches gain a \`Csv => CsvReporter\` arm.
- \`write_output\` writes to a file for \`--csv <FILE>\`, else stdout — mirroring \`--json <FILE>\`.
- \`--json\` and \`--csv\` are now **mutually exclusive** via clap \`conflicts_with\` (both force a format; combining is ambiguous).

## Tests
- \`cli_integration_tests.rs\`: the 4 CSV-bail tests → 5 CSV-behavior tests (file output, stdout output, \`--output-format csv\`, \`summary --csv\`, \`--json\`/\`--csv\` mutual-exclusion rejection).
- \`reporter_tests.rs\`: 4 new \`CsvReporter\` unit tests — header + row-per-finding, empty-findings header-only, **formula-injection neutralization** (parsed back with \`csv::Reader\`, checked field-wise), and findings-only scope (sentinel \`Summary\`/\`AnalysisSummary\` values must not leak).

## Test plan
- [x] \`cargo fmt --check\` — clean
- [x] \`cargo clippy --all-targets -- -D warnings\` — clean
- [x] \`cargo test --all-targets\` — **257 passed, 0 failed** (was 252)
- [x] \`csv\` crate is no longer a dead dependency

## P2 backlog status

| Lesson | Status |
|---|---|
| P2.02 / P2.04 / P2.06 / P2.07 / P2.08 / P2.09 / P2.10 / P2.11 | ✅ #76–#83 |
| **P2.03 — CSV reporter** | ✅ this PR |
| P2.01 — reassembly/mod.rs refactor | deferred (design discussion) |
| P2.05 — threshold calibration | deferred (empirical data) |

9 of 11 P2 lessons closed. The remaining two are explicitly deferred — P2.01 (refactor) needs a design discussion, P2.05 (threshold calibration) needs empirical false-positive-rate data from real captures.