### PR TITLE
fix(reader): accept snaplen-truncated captures via raw-record path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 .claude/worktrees/
 .factory/
+demo-evidence/

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -6,14 +6,27 @@
 //! in the brownfield-ingest synthesis); the directory-glob path in
 //! `src/main.rs` enforces that.
 //!
+//! ## Snaplen-truncated captures
+//!
+//! Captures taken with a snap length (`tcpdump -s 96`, etc.) record packets
+//! whose on-wire `orig_len` legitimately exceeds the file's `snaplen` — only
+//! the first `snaplen` bytes are actually stored. `pcap-file` 2.0.0's
+//! validated `next_packet()` path wrongly rejects every such record with
+//! `PacketHeader orig_len > snap_len` (the real invariant is only
+//! `incl_len <= snaplen`). Because snaplen-truncated captures are common in
+//! real-world forensics, this reader uses the *unvalidated*
+//! `next_raw_packet()` path and converts the timestamp itself. Buffer safety
+//! is unaffected: `RawPcapPacket` parsing still bounds `data` to exactly the
+//! captured `incl_len` bytes (an over-long `incl_len` yields a hard error).
+//!
 //! For very large captures the all-in-memory model is a known limitation;
 //! see the technical-debt register for a streaming-reader follow-up.
 
 use std::io::Read;
 
 use anyhow::{Context, Result, anyhow};
-use pcap_file::DataLink;
 use pcap_file::pcap::PcapReader;
+use pcap_file::{DataLink, TsResolution};
 
 #[derive(Debug, Clone)]
 pub struct RawPacket {
@@ -32,7 +45,8 @@ impl PcapSource {
     pub fn from_pcap_reader<R: Read>(reader: R) -> Result<Self> {
         let mut pcap_reader = PcapReader::new(reader).context("Failed to parse pcap header")?;
 
-        let datalink = pcap_reader.header().datalink;
+        let header = pcap_reader.header();
+        let datalink = header.datalink;
         match datalink {
             DataLink::ETHERNET
             | DataLink::RAW
@@ -46,13 +60,21 @@ impl PcapSource {
             }
         }
 
+        // Whether the per-packet `ts_frac` field is microseconds or
+        // nanoseconds is set by the file's magic number (see module docs
+        // on why the raw-record path is used).
+        let ts_resolution = header.ts_resolution;
         let mut packets = Vec::new();
 
-        while let Some(raw_packet) = pcap_reader.next_packet() {
+        while let Some(raw_packet) = pcap_reader.next_raw_packet() {
             let raw_packet = raw_packet.context("Failed to read packet")?;
+            let timestamp_usecs = match ts_resolution {
+                TsResolution::MicroSecond => raw_packet.ts_frac,
+                TsResolution::NanoSecond => raw_packet.ts_frac / 1_000,
+            };
             packets.push(RawPacket {
-                timestamp_secs: raw_packet.timestamp.as_secs() as u32,
-                timestamp_usecs: raw_packet.timestamp.subsec_micros(),
+                timestamp_secs: raw_packet.ts_sec,
+                timestamp_usecs,
                 data: raw_packet.data.into_owned(),
             });
         }

--- a/tests/reader_tests.rs
+++ b/tests/reader_tests.rs
@@ -146,3 +146,52 @@ fn test_reader_accepts_linux_sll_linktype() {
     let source = PcapSource::from_pcap_reader(Cursor::new(buf)).unwrap();
     assert_eq!(source.datalink, DataLink::LINUX_SLL);
 }
+
+/// Build a pcap with one packet record whose on-wire `orig_len` exceeds
+/// the file's `snaplen` — i.e. a snaplen-truncated capture, as produced
+/// by `tcpdump -s <small>`. `incl_len` (captured bytes) stays within
+/// `snaplen`; only `orig_len` (the real wire length) is larger.
+fn snaplen_truncated_pcap_bytes() -> Vec<u8> {
+    let mut buf = Vec::new();
+
+    // Global header: snaplen = 96.
+    buf.extend_from_slice(&0xa1b2c3d4u32.to_le_bytes()); // magic (LE, microsecond)
+    buf.extend_from_slice(&2u16.to_le_bytes()); // version major
+    buf.extend_from_slice(&4u16.to_le_bytes()); // version minor
+    buf.extend_from_slice(&0i32.to_le_bytes()); // thiszone
+    buf.extend_from_slice(&0u32.to_le_bytes()); // sigfigs
+    buf.extend_from_slice(&96u32.to_le_bytes()); // snaplen = 96
+    buf.extend_from_slice(&1u32.to_le_bytes()); // network = Ethernet
+
+    // Packet record: incl_len = 96 (<= snaplen), orig_len = 1500 (> snaplen).
+    buf.extend_from_slice(&100u32.to_le_bytes()); // ts_sec
+    buf.extend_from_slice(&42u32.to_le_bytes()); // ts_frac (microseconds)
+    buf.extend_from_slice(&96u32.to_le_bytes()); // incl_len = 96
+    buf.extend_from_slice(&1500u32.to_le_bytes()); // orig_len = 1500
+    buf.extend_from_slice(&[0u8; 96]); // 96 captured bytes
+
+    buf
+}
+
+#[test]
+fn test_reader_accepts_snaplen_truncated_capture() {
+    // Regression: a capture taken with a snap length (`tcpdump -s 96`)
+    // has packet records whose `orig_len` legitimately exceeds the
+    // file `snaplen`. pcap-file 2.0.0's validated `next_packet()` path
+    // wrongly rejects these (`PacketHeader orig_len > snap_len`); the
+    // reader must use the raw-record path and accept them.
+    let buf = snaplen_truncated_pcap_bytes();
+    let source = PcapSource::from_pcap_reader(Cursor::new(buf))
+        .expect("snaplen-truncated capture must be readable");
+    assert_eq!(source.packets.len(), 1, "expected the single packet");
+    assert_eq!(
+        source.packets[0].data.len(),
+        96,
+        "captured data is exactly incl_len (96) bytes"
+    );
+    assert_eq!(source.packets[0].timestamp_secs, 100);
+    assert_eq!(
+        source.packets[0].timestamp_usecs, 42,
+        "microsecond-resolution ts_frac is carried through verbatim"
+    );
+}


### PR DESCRIPTION
## Summary
wirerust could not read captures taken with a snap length (`tcpdump -s 96` and similar) — it failed with `Invalid field value: PacketHeader orig_len > snap_len`. Snaplen-truncated captures are **common in real-world forensics** (capturing only the first N bytes per packet to conserve disk), so this was a genuine capability gap in a forensics tool. It also blocked the `nfs_bad_stalls.cap` reassembly fixture in #86.

## Root cause
`pcap-file` 2.0.0's validated packet path (`PcapPacket::try_from_raw_packet`, `packet.rs:96`) rejects any record with `orig_len > snap_len`. **That check is wrong.** `orig_len` is the packet's original *on-wire* length, which legitimately exceeds the capture `snaplen` whenever a snap length was used — that's the whole point of snaplen. The real invariants are `incl_len <= snaplen` and `incl_len <= orig_len` (pcap-file checks those correctly); the spurious `orig_len` check just fires first.

## Fix
`PcapSource::from_pcap_reader` now reads via pcap-file's **unvalidated** `PcapReader::next_raw_packet()` (`RawPcapPacket`) instead of the validated `next_packet()`. The raw path does no `orig_len`/`snaplen` comparison.

- wirerust never used `orig_len` — it consumes only the captured `data` (length `incl_len`) and the timestamp — so dropping the validated wrapper loses nothing functional.
- **Buffer safety unaffected:** `RawPcapPacket::from_slice` still bounds `data` to exactly `incl_len` bytes and returns `IncompleteBuffer` on an over-long `incl_len`.
- **Timestamps handled explicitly:** the file magic sets microsecond-vs-nanosecond `ts_frac` resolution (`PcapHeader::ts_resolution`); the reader converts to `timestamp_usecs` accordingly — byte-identical to what the old validated path produced.

## Tests
`test_reader_accepts_snaplen_truncated_capture` builds a pcap with `snaplen=96`, `incl_len=96`, `orig_len=1500` and asserts the reader accepts it, returns the packet with 96 bytes of data, and carries the microsecond timestamp through. Fails before the fix, passes after.

## Also
Adds `demo-evidence/` to `.gitignore` — the `.factory/` worktree copy is already ignored; this guards against a stray root-level copy reaching the remote.

## Test plan
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo test --all-targets` — **260 passed, 0 failed** (was 259)
- [x] All existing reader tests (normal captures, link-type variants) still pass — the raw path is a superset

## Follow-up unblocked
The `nfs_bad_stalls.cap` snaplen-96 capture that #86 had to drop is now readable; it could be re-added as a benign reassembly fixture in a future change.