### PR TITLE
feat(reassembly): research-documented + CLI-configurable anomaly thresholds (P2.05)

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -74,6 +74,22 @@ pub struct Cli {
     #[arg(long, global = true, default_value_t = 1024)]
     pub reassembly_memcap: usize,
 
+    /// Override the overlapping-segment anomaly threshold (default: 50).
+    /// Per flow direction; see LESSON-P2.05 in the reassembly config.
+    #[arg(long, global = true)]
+    pub overlap_threshold: Option<u32>,
+
+    /// Override the small-segment anomaly threshold (default: 2048).
+    /// The default is permissive — lower it (low hundreds) to catch
+    /// fine-grained segmentation evasion. See LESSON-P2.05.
+    #[arg(long, global = true)]
+    pub small_segment_threshold: Option<u32>,
+
+    /// Override the out-of-window anomaly threshold (default: 100).
+    /// Per flow direction; see LESSON-P2.05.
+    #[arg(long, global = true)]
+    pub out_of_window_threshold: Option<u32>,
+
     #[command(subcommand)]
     pub command: Commands,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -94,11 +94,22 @@ fn run_analyze(
     }
 
     let mut reassembler = if needs_reassembly && !skip_reassembly {
-        let config = ReassemblyConfig {
+        let mut config = ReassemblyConfig {
             max_depth: cli.reassembly_depth * 1_048_576,
             memcap: cli.reassembly_memcap * 1_048_576,
             ..ReassemblyConfig::default()
         };
+        // LESSON-P2.05: anomaly thresholds are CLI-overridable; an
+        // absent flag leaves the `ReassemblyConfig::default()` value.
+        if let Some(v) = cli.overlap_threshold {
+            config.overlap_alert_threshold = v;
+        }
+        if let Some(v) = cli.small_segment_threshold {
+            config.small_segment_alert_threshold = v;
+        }
+        if let Some(v) = cli.out_of_window_threshold {
+            config.out_of_window_alert_threshold = v;
+        }
         Some(TcpReassembler::new(config))
     } else {
         None

--- a/src/reassembly/config.rs
+++ b/src/reassembly/config.rs
@@ -2,9 +2,25 @@
 //!
 //! [`ReassemblyConfig`] holds the resource ceilings that bound the
 //! [`crate::reassembly::TcpReassembler`] — per-direction depth, total
-//! memcap, idle timeout, concurrent-flow count, per-direction segment
-//! count, and the forward receive window. Extracted from `mod.rs` for
-//! LESSON-P2.01.
+//! memcap, idle timeout, concurrent-flow count, the forward receive
+//! window, and the three per-flow-direction anomaly-alert thresholds
+//! (LESSON-P2.05). Extracted from `mod.rs` for LESSON-P2.01.
+//!
+//! ## Anomaly thresholds (LESSON-P2.05)
+//!
+//! The three `*_alert_threshold` fields control when the engine emits
+//! overlap / small-segment / out-of-window Anomaly findings. A research
+//! pass against Suricata, Zeek, and Snort established that **no
+//! production NIDS exposes a directly-comparable "count occurrences per
+//! flow direction and alert at N" threshold** — Suricata acts
+//! per-event with exponential backoff, Zeek bounds byte volumes and
+//! ships its overlap detector disabled, and Snort's count-based knobs
+//! (`overlap_limit`, `small_segments`) both default to 0/disabled.
+//! These three values therefore cannot be "calibrated" against prior
+//! art; they are conservative engineering defaults, and each field's
+//! doc comment records the closest cited reference. They are also CLI-
+//! overridable (`--overlap-threshold`, `--small-segment-threshold`,
+//! `--out-of-window-threshold`) so operators can tune per-network.
 
 /// Configuration for the TCP reassembly engine.
 #[derive(Debug, Clone)]
@@ -22,17 +38,54 @@ pub struct ReassemblyConfig {
     /// Maximum distance (bytes) ahead of base_offset to accept a segment.
     /// Segments beyond this are dropped. Default 1MB matches Suricata/Zeek/Snort.
     pub max_receive_window: usize,
+    /// Overlapping-segment count, per flow direction, **above which** an
+    /// overlap Anomaly finding is emitted.
+    ///
+    /// LESSON-P2.05: no NIDS ships a count-based default for this —
+    /// Suricata acts per-overlap with exponential backoff, Zeek's
+    /// overlap detector (`tcp_max_old_segments`) ships disabled. The
+    /// closest analogue is Snort's `stream_tcp.overlap_limit`, a real
+    /// per-session overlapping-segment counter with a valid range of
+    /// 0–255 (default 0/unlimited). The default `50` is a conservative
+    /// engineering choice inside that sanctioned range — not a value
+    /// any source endorses.
+    pub overlap_alert_threshold: u32,
+    /// Small (undersized) segment count, per flow direction, **above
+    /// which** a small-segment Anomaly finding is emitted.
+    ///
+    /// LESSON-P2.05: research flagged this default as likely too
+    /// permissive. `2048` is the **maximum** of Snort's
+    /// `stream_tcp.small_segments.count` knob — whose actual default is
+    /// `0`/disabled — not a recommended detection value. A fine-grained
+    /// segmentation-evasion stream would need 2 KB+ of payload to trip
+    /// it. The value is retained as the default to avoid a behavior
+    /// change without false-positive data; operators tuning for evasion
+    /// detection should lower it via `--small-segment-threshold` (the
+    /// low hundreds is a reasonable starting point).
+    pub small_segment_alert_threshold: u32,
+    /// Out-of-window segment count, per flow direction, **above which**
+    /// an out-of-window Anomaly finding is emitted.
+    ///
+    /// LESSON-P2.05: no NIDS counts out-of-window *segments*. The
+    /// nearest cited analogue is Zeek's
+    /// `tcp_max_above_hole_without_any_acks` (16384 *bytes* above a
+    /// sequence hole), a different unit. The default `100` is a
+    /// conservative engineering default with no count-based prior art.
+    pub out_of_window_alert_threshold: u32,
 }
 
 impl Default for ReassemblyConfig {
     fn default() -> Self {
         ReassemblyConfig {
-            max_depth: 10 * 1024 * 1024,        // 10 MB per direction
-            memcap: 1024 * 1024 * 1024,         // 1 GB total
-            flow_timeout_secs: 300,             // 5 minutes
-            max_flows: 100_000,                 // 100K concurrent flows
-            max_segments_per_direction: 10_000, // 10K segments per direction
-            max_receive_window: 1_048_576,      // 1 MB forward window
+            max_depth: 10 * 1024 * 1024,         // 10 MB per direction
+            memcap: 1024 * 1024 * 1024,          // 1 GB total
+            flow_timeout_secs: 300,              // 5 minutes
+            max_flows: 100_000,                  // 100K concurrent flows
+            max_segments_per_direction: 10_000,  // 10K segments per direction
+            max_receive_window: 1_048_576,       // 1 MB forward window
+            overlap_alert_threshold: 50,         // see field doc (LESSON-P2.05)
+            small_segment_alert_threshold: 2048, // see field doc (LESSON-P2.05)
+            out_of_window_alert_threshold: 100,  // see field doc (LESSON-P2.05)
         }
     }
 }

--- a/src/reassembly/mod.rs
+++ b/src/reassembly/mod.rs
@@ -51,10 +51,12 @@ use crate::reassembly::flow::{FlowKey, FlowState, TcpFlow};
 use crate::reassembly::handler::{CloseReason, Direction, StreamHandler};
 use crate::reassembly::segment::InsertResult;
 
-const OVERLAP_ALERT_THRESHOLD: u32 = 50;
-const SMALL_SEGMENT_ALERT_THRESHOLD: u32 = 2048;
-const OUT_OF_WINDOW_ALERT_THRESHOLD: u32 = 100;
 const MAX_FINDINGS: usize = 10_000;
+
+// The overlap / small-segment / out-of-window anomaly thresholds were
+// module-level `const`s; they are now per-engine configuration fields
+// (`ReassemblyConfig::*_alert_threshold`, see `config.rs`) so they can
+// be tuned via the CLI — LESSON-P2.05.
 
 static FINALIZE_SKIPPED_WARNED: AtomicBool = AtomicBool::new(false);
 
@@ -375,10 +377,16 @@ impl TcpReassembler {
     /// than one) and lets the `dropped_findings` counter accurately
     /// reflect distinct anomalies lost to the cap.
     fn check_anomaly_thresholds(&mut self, packet: &ParsedPacket, key: &FlowKey, dir: Direction) {
+        // Snapshot the configured thresholds before borrowing the flow
+        // (LESSON-P2.05 — these are now `ReassemblyConfig` fields).
+        let overlap_threshold = self.config.overlap_alert_threshold;
+        let small_segment_threshold = self.config.small_segment_alert_threshold;
+        let out_of_window_threshold = self.config.out_of_window_alert_threshold;
+
         let flow = self.flows.get_mut(key).unwrap();
         let flow_dir = flow.get_direction_mut(dir);
 
-        if flow_dir.overlap_count > OVERLAP_ALERT_THRESHOLD && !flow_dir.overlap_alert_fired {
+        if flow_dir.overlap_count > overlap_threshold && !flow_dir.overlap_alert_fired {
             flow_dir.overlap_alert_fired = true;
             if self.findings.len() < MAX_FINDINGS {
                 self.findings.push(Finding {
@@ -399,7 +407,7 @@ impl TcpReassembler {
                 self.stats.dropped_findings += 1;
             }
         }
-        if flow_dir.small_segment_count > SMALL_SEGMENT_ALERT_THRESHOLD
+        if flow_dir.small_segment_count > small_segment_threshold
             && !flow_dir.small_segment_alert_fired
         {
             flow_dir.small_segment_alert_fired = true;
@@ -422,7 +430,7 @@ impl TcpReassembler {
                 self.stats.dropped_findings += 1;
             }
         }
-        if flow_dir.out_of_window_count > OUT_OF_WINDOW_ALERT_THRESHOLD
+        if flow_dir.out_of_window_count > out_of_window_threshold
             && !flow_dir.out_of_window_alert_fired
         {
             flow_dir.out_of_window_alert_fired = true;

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -127,6 +127,36 @@ fn test_summary_hosts_flag_defaults_false() {
     }
 }
 
+// ---- LESSON-P2.05: configurable reassembly anomaly thresholds ----
+
+#[test]
+fn test_threshold_flags_parse() {
+    let cli = Cli::parse_from([
+        "wirerust",
+        "--overlap-threshold",
+        "10",
+        "--small-segment-threshold",
+        "256",
+        "--out-of-window-threshold",
+        "25",
+        "analyze",
+        "capture.pcap",
+    ]);
+    assert_eq!(cli.overlap_threshold, Some(10));
+    assert_eq!(cli.small_segment_threshold, Some(256));
+    assert_eq!(cli.out_of_window_threshold, Some(25));
+}
+
+#[test]
+fn test_threshold_flags_default_to_none() {
+    // Absent flags must be None so main.rs leaves the
+    // ReassemblyConfig::default() value untouched.
+    let cli = Cli::parse_from(["wirerust", "analyze", "capture.pcap"]);
+    assert_eq!(cli.overlap_threshold, None);
+    assert_eq!(cli.small_segment_threshold, None);
+    assert_eq!(cli.out_of_window_threshold, None);
+}
+
 #[test]
 fn test_removed_unwired_flags_are_rejected() {
     // LESSON-P1.04: --threats, --verbose, --beacon, --filter, and

--- a/tests/reassembly_engine_tests.rs
+++ b/tests/reassembly_engine_tests.rs
@@ -1533,3 +1533,89 @@ fn test_dropped_findings_key_present_in_summarize() {
         "summarize() detail must always contain `dropped_findings` — LESSON-P1.01 regressed"
     );
 }
+
+// ---- LESSON-P2.05: configurable anomaly thresholds ----
+
+/// Drive a flow to `n` overlapping duplicate segments and return the
+/// reassembler, so a test can assert whether the overlap finding fired
+/// under a given `overlap_alert_threshold`.
+fn run_overlapping_flow(overlap_alert_threshold: u32, duplicates: u32) -> TcpReassembler {
+    let config = ReassemblyConfig {
+        overlap_alert_threshold,
+        ..ReassemblyConfig::default()
+    };
+    let mut reassembler = TcpReassembler::new(config);
+    let mut handler = RecordingHandler::new();
+    let client = [10, 0, 0, 1];
+    let server = [10, 0, 0, 2];
+
+    let syn = make_tcp_packet(
+        client,
+        12345,
+        server,
+        80,
+        1000,
+        &[],
+        true,
+        false,
+        false,
+        false,
+    );
+    reassembler.process_packet(&syn, 1, &mut handler);
+
+    // Out-of-order segment at offset 2 (gap at offset 1 keeps it buffered).
+    let original = make_tcp_packet(
+        client, 12345, server, 80, 1002, b"AAAA", false, false, false, false,
+    );
+    reassembler.process_packet(&original, 2, &mut handler);
+
+    for i in 0..duplicates {
+        let dup = make_tcp_packet(
+            client, 12345, server, 80, 1002, b"AAAA", false, false, false, false,
+        );
+        reassembler.process_packet(&dup, 3 + i, &mut handler);
+    }
+    reassembler
+}
+
+#[test]
+fn test_low_overlap_threshold_fires_earlier() {
+    // With a configured threshold of 5, just 6 overlapping duplicates
+    // (overlap_count = 6 > 5) must trigger the overlap anomaly — far
+    // below the default-50 trip point. Proves the engine reads the
+    // threshold from ReassemblyConfig, not a hard-coded const.
+    let reasm = run_overlapping_flow(5, 6);
+    assert!(
+        reasm
+            .findings()
+            .iter()
+            .any(|f| f.summary.contains("Excessive segment overlaps")),
+        "overlap finding must fire once overlap_count exceeds the configured threshold of 5"
+    );
+}
+
+#[test]
+fn test_default_overlap_threshold_silent_at_six_overlaps() {
+    // The same 6 overlaps under the default threshold (50) must NOT
+    // fire — confirms the low-threshold test above is exercising the
+    // config field, not some unrelated trigger.
+    let reasm = run_overlapping_flow(ReassemblyConfig::default().overlap_alert_threshold, 6);
+    assert!(
+        !reasm
+            .findings()
+            .iter()
+            .any(|f| f.summary.contains("Excessive segment overlaps")),
+        "6 overlaps must stay silent under the default threshold of 50"
+    );
+}
+
+#[test]
+fn test_default_config_threshold_values() {
+    // Pin the documented LESSON-P2.05 defaults so a silent change is
+    // caught. These are conservative engineering defaults (see
+    // config.rs field docs), not values endorsed by NIDS prior art.
+    let cfg = ReassemblyConfig::default();
+    assert_eq!(cfg.overlap_alert_threshold, 50);
+    assert_eq!(cfg.small_segment_alert_threshold, 2048);
+    assert_eq!(cfg.out_of_window_alert_threshold, 100);
+}


### PR DESCRIPTION
## Summary
LESSON-P2.05. The three reassembly anomaly thresholds (overlap, small-segment, out-of-window) were hard-coded module `const`s set by guesswork. This makes them per-engine configuration with research-cited documentation and CLI overrides.

## Research finding (research-agent, verified vs Suricata / Zeek / Snort sources)

**No production NIDS exposes a directly-comparable "count occurrences per flow direction and alert at N" threshold.** Suricata acts per-event with exponential backoff; Zeek bounds *byte volumes* and ships its overlap detector disabled; Snort's count-based knobs (`overlap_limit`, `small_segments`) both default to **0/disabled**. So the three values **cannot be "calibrated" against prior art** — they are conservative engineering defaults, now documented with the closest cited reference instead of presented as tuned values.

**One substantive finding:** the small-segment default `2048` is almost certainly Snort's `small_segments.count` knob *maximum* mistaken for a default (Snort's real default is 0). `2048` makes the check nearly inert — a fine-grained segmentation-evasion stream needs 2 KB+ of payload to trip it.

## Decision on the `2048` finding
The value is **retained as the default**. Cutting it 8× without false-positive data just swaps one guess for another and risks new false positives on benign small-segment-heavy traffic. Instead: the field doc records the finding plainly, and the new `--small-segment-threshold` flag lets operators lower it to the low hundreds where it actually catches evasion. A data-backed default change is a clean future follow-up.

## Changes
- `ReassemblyConfig` gains `overlap_alert_threshold` / `small_segment_alert_threshold` / `out_of_window_alert_threshold` (`u32`), each with a doc comment citing the P2.05 research. `Default` keeps 50 / 2048 / 100.
- The three module-level `const`s in `mod.rs` are removed; `check_anomaly_thresholds` snapshots the values from `self.config`.
- Three global CLI flags — `--overlap-threshold`, `--small-segment-threshold`, `--out-of-window-threshold` (`Option<u32>`). Absent flag → `ReassemblyConfig` default untouched (no clap/config default duplication).
- `main.rs::run_analyze` applies the flag overrides.

## Tests (5 new)
| Test | Asserts |
|---|---|
| `test_threshold_flags_parse` | the 3 flags parse to `Some(n)` |
| `test_threshold_flags_default_to_none` | absent flags → `None` |
| `test_low_overlap_threshold_fires_earlier` | threshold 5 → overlap finding fires at 6 overlaps |
| `test_default_overlap_threshold_silent_at_six_overlaps` | same 6 overlaps stay silent under default 50 (proves the engine reads config, not a const) |
| `test_default_config_threshold_values` | pins the documented 50 / 2048 / 100 defaults |

## Test plan
- [x] `cargo fmt --check` / `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo test --all-targets` — **265 passed, 0 failed** (was 260)

## P2 backlog status
**All 11 P2 lessons now closed** (P2.01–P2.11). This PR is the last one. The brownfield-ingest P0+P1+P2 tiers are complete.