### PR TITLE
docs: ADR 0004, MITRE staged-techniques note, test-naming convention, GREASE rationale (P3 subset)

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,37 @@ impl ProtocolAnalyzer for MyAnalyzer {
 }
 ```
 
+### Test naming convention
+
+Tests use **prose-style names that state the asserted behavior**, not just
+the function under test. The name should read as a claim that is true when
+the test passes:
+
+```rust
+// good — states the behavior being asserted
+fn test_detect_empty_host_header() { ... }
+fn mitre_grouping_emits_tactic_headers_in_canonical_order() { ... }
+fn test_low_overlap_threshold_fires_earlier() { ... }
+
+// avoid — names the symbol, not the behavior
+fn test_host_header() { ... }
+fn test_mitre() { ... }
+```
+
+Guidelines:
+
+- Prefer `<subject>_<verb>_<expected outcome>` — e.g.
+  `test_drop_without_finalize_does_not_panic`.
+- A `test_` prefix is common but not required; an integration test whose
+  name already reads as a sentence (`mitre_grouping_emits_…`) may omit it.
+- One behavior per test. If the name needs an "and", it is probably two
+  tests.
+- When a test exists to guard a specific lesson or regression, reference it
+  in the test body comment (e.g. `// LESSON-P2.05: …`), not in the name.
+
+This is a documentation of existing practice — the test suite already
+follows it; new tests should match.
+
 ## Roadmap
 
 See [open issues](https://github.com/Zious11/wirerust/issues) for planned features:

--- a/docs/adr/0004-process-wide-warning-atomics.md
+++ b/docs/adr/0004-process-wide-warning-atomics.md
@@ -1,0 +1,137 @@
+# ADR 0004: Process-Wide Atomics for One-Shot Bug-Tripwire Warnings
+
+**Status:** Accepted
+**Date:** 2026-05-19
+**Context:** This is a retroactive ADR. The reassembly engine accumulated three
+`static AtomicBool` one-shot warning guards over several PRs (the
+`close_flow`-on-missing-key guard, the `ISN`-missing guard, and the
+`finalize`-not-called `Drop` tripwire added for LESSON-P0.03). The
+brownfield-ingest Phase C synthesis flagged that this recurring pattern was
+never written down (the "ADR 0004 for process-wide atomics" P3 lesson). This
+ADR codifies the existing decision so future contributors apply it
+consistently rather than re-deriving it.
+
+## Problem
+
+Several places in the reassembly engine detect a **programming error** — a
+control-flow bug that should never happen if the engine is driven correctly:
+
+- `close_flow` called for a `FlowKey` not present in the flow table
+  (`src/reassembly/lifecycle.rs`).
+- A segment insert reached with no ISN set for the direction
+  (`src/reassembly/segment.rs`).
+- A `TcpReassembler` dropped without `finalize()` having been called
+  (`src/reassembly/mod.rs`, the LESSON-P0.03 `Drop` tripwire).
+
+Each wants to emit a diagnostic to `stderr` so the bug is *loud* rather than
+silent. But a naive `eprintln!` at each site has two failure modes:
+
+1. **Flooding.** These sites sit on per-packet / per-flow paths. A bug that
+   trips one of them typically trips it on *every* packet or *every* flow —
+   thousands of identical lines that bury the signal and slow the run.
+2. **Per-instance repetition.** wirerust creates many `TcpReassembler`
+   instances within a single process — every integration test, and every
+   multi-file analysis run, constructs fresh engines. A warning latch stored
+   as a per-instance `bool` field would re-warn once *per instance*, so a
+   test suite would print the same bug warning dozens of times.
+
+The warning needs to fire **once per process**: enough to alert a developer,
+never enough to flood.
+
+## Decision
+
+**One-shot bug-tripwire warnings use a process-wide `static AtomicBool`
+guard, flipped with `AtomicBool::swap(true, Ordering::Relaxed)`.**
+
+The canonical shape:
+
+```rust
+static SOME_BUG_WARNED: AtomicBool = AtomicBool::new(false);
+
+// at the detection site:
+if !SOME_BUG_WARNED.swap(true, Ordering::Relaxed) {
+    eprintln!("wirerust: <description of the bug and its consequence>");
+}
+```
+
+`swap` returns the *previous* value, so the very first caller sees `false`
+and prints; every subsequent caller — in this instance or any other, on any
+thread — sees `true` and stays silent.
+
+This applies specifically to **programming-error tripwires**. It does NOT
+apply to normal operational counters or to per-capture findings (those are
+`ReassemblyStats` fields and `Finding`s respectively, and are per-instance by
+design).
+
+## Alternatives Considered
+
+### Per-instance `bool` field on `TcpReassembler`
+
+Rejected. It re-warns once per engine instance. A bug class is a property of
+the *code*, not of one engine; seeing the warning once anywhere is the
+signal. Per-instance state turns "once" into "once per test", which is the
+flooding problem in a slower disguise. It also cannot serve the `Drop`
+tripwire cleanly (see below) or the free-function ISN site in `segment.rs`,
+which has no `self`.
+
+### A logging framework (`log` + `env_logger`, `tracing`, etc.)
+
+Rejected. wirerust deliberately carries a small dependency set, and these
+warnings are rare bug tripwires, not an observability surface. A one-line
+`eprintln!` gated by an atomic needs no crate. If wirerust later grows a
+real logging story, these sites can migrate then.
+
+### `std::sync::Once`
+
+Workable — `Once::call_once` gives exactly-once semantics. Rejected as
+slightly heavier at the call site: it takes a closure and is conceptually a
+lazy-initialization primitive, whereas `AtomicBool::swap` keeps the call site
+a plain `if` that reads naturally as "warn unless we already did". Both are
+correct; the atomic is the simpler fit for a boolean latch.
+
+## Rationale
+
+- **`static`, not per-instance** — the latch tracks a *bug class*, and a bug
+  class is process-global. This is the crux of the decision.
+- **`swap` for the check-and-set** — a single atomic operation does
+  test-and-latch with no separate load/store race window. The first caller
+  is unambiguously the one that observed `false`.
+- **`Ordering::Relaxed`** — the flag is a best-effort de-duplication hint,
+  not a synchronization point. It guards no other memory. The only
+  observable cost of the weakest ordering is that, under a genuine data race
+  between two threads hitting the site for the first time simultaneously,
+  the warning could print twice. Two identical lines instead of one is
+  harmless; paying for `SeqCst` to prevent it would be cargo-culting.
+- **Works without `&mut self`** — `swap` takes `&self` on the `static`, so
+  the pattern works in `Drop::drop` (which the LESSON-P0.03 tripwire needs)
+  and in free functions (the `segment.rs` ISN site), neither of which can
+  rely on a mutable engine borrow.
+
+## Consequences
+
+- **Tests assert behavior, not warning text.** Because the latch is
+  process-wide, a test cannot reliably assert "this run warned" — an earlier
+  test in the same process may have already flipped the flag. Tests for
+  these sites therefore assert the *real* contract (no panic, correct
+  control flow, correct counters) and treat the `stderr` line as a
+  developer-facing side effect only. The LESSON-P0.03 `Drop` tests are
+  written exactly this way (`test_drop_without_finalize_does_not_panic`).
+- **The warning is genuinely once-per-process.** Re-running an analysis in a
+  long-lived process (e.g. a future daemon mode) would not re-warn for a
+  recurring bug after the first occurrence. This is acceptable: the warning's
+  job is to surface the bug to a developer once, not to provide ongoing
+  telemetry. A recurring operational signal would be a counter, not a
+  tripwire.
+- **New tripwires must follow the pattern.** Any future "this should never
+  happen" diagnostic on a hot path uses a new `static AtomicBool` named
+  `<SUBJECT>_WARNED`, flipped with `swap(true, Ordering::Relaxed)`. Three
+  guards currently follow it: `CLOSE_FLOW_MISSING_WARNED`,
+  `ISN_MISSING_WARNED`, `FINALIZE_SKIPPED_WARNED`.
+
+## Validation
+
+- All three existing guards (`grep -rn '_WARNED' src/`) use the identical
+  `static AtomicBool` + `swap(true, Relaxed)` shape.
+- The behavior is exercised indirectly by the reassembly engine tests, which
+  pass without warning floods, and directly by the LESSON-P0.03 `Drop` tests,
+  which confirm the un-finalized path does not panic.

--- a/src/analyzer/tls.rs
+++ b/src/analyzer/tls.rs
@@ -35,6 +35,18 @@ const MAX_RECORD_PAYLOAD: usize = 18_432;
 // ── helpers ──────────────────────────────────────────────────────────────────
 
 /// Returns true if `val` is a TLS GREASE value (RFC 8701).
+///
+/// This uses the well-known bitmask test `(val & 0x0F0F) == 0x0A0A`,
+/// which is **deliberately broader than RFC 8701's strict definition**.
+/// RFC 8701 reserves exactly 16 GREASE values — `0x0A0A`, `0x1A1A`, …,
+/// `0xFAFA` (both bytes equal, of the form `0xNANA`). The bitmask also
+/// matches the 240 non-canonical `0x_A_A` values (e.g. `0x0A1A`,
+/// `0xCABA`). This is intentional and harmless: IANA has assigned no
+/// real cipher-suite or extension ID of `0x_A_A` form outside the 16
+/// GREASE values, so the wider mask never filters a value that carries
+/// JA3-relevant signal. The cheaper single-mask test is preferred over
+/// an explicit 16-value membership check. The JA3 property tests in
+/// this module's `ja3_property_tests` submodule pin this contract.
 fn is_grease_u16(val: u16) -> bool {
     (val & 0x0F0F) == 0x0A0A
 }

--- a/src/mitre.rs
+++ b/src/mitre.rs
@@ -11,6 +11,30 @@
 //! separator, three-digit suffix — e.g., `T1071.001`). This format is used
 //! across ATT&CK matrices and STIX 2.1 bundles. Inputs that don't match a
 //! seeded ID return `None` from the lookup functions.
+//!
+//! ## Catalogued vs. emitted techniques (staged entries)
+//!
+//! [`technique_info`] is a *catalogue*: it seeds every technique ID that
+//! wirerust may attach to a [`crate::findings::Finding`]. Not every
+//! catalogued ID is currently produced by an analyzer.
+//!
+//! Some entries are **staged** — present in the lookup table ahead of the
+//! detection logic that will emit them. This is intentional:
+//!
+//! - The catalogue is the single place an ID's name and tactic are defined.
+//!   Seeding an ID here first means the analyzer PR that starts emitting it
+//!   only has to set `mitre_technique: Some("TXXXX")` — it does not also
+//!   have to touch this module, keeping that change small and focused.
+//! - The ICS techniques (`T0xxx`) in particular are seeded for the planned
+//!   Modbus / DNP3 analyzers (see the README roadmap) but are not emitted
+//!   until those analyzers land.
+//!
+//! A staged entry is therefore not dead code — it is a deliberate forward
+//! declaration. The set of *emitted* IDs is whatever the analyzers in
+//! `src/analyzer/` and `src/reassembly/` currently pass as
+//! `mitre_technique`; `grep -rn 'mitre_technique: Some' src/` is the
+//! authoritative way to see it. No invariant requires the catalogue and the
+//! emitted set to match — the catalogue is intentionally the superset.
 
 use std::fmt;
 


### PR DESCRIPTION
## Summary
The curated high-value subset of the P3 documentation tier, plus the `is_grease_u16` documentation follow-up surfaced by the P2.04 JA3 property tests. **All changes are documentation / comments** — no behavior, no test changes (265 tests unchanged).

## Contents

### ADR 0004 — process-wide warning atomics
`docs/adr/0004-process-wide-warning-atomics.md` (new). Retroactively codifies the existing pattern: one-shot bug-tripwire warnings use a process-wide `static AtomicBool` flipped with `swap(true, Ordering::Relaxed)`. Records:
- **why `static`** — the latch tracks a *bug class*, not an instance; a per-instance `bool` would re-warn once per `TcpReassembler` (i.e. once per test).
- **why `Relaxed`** — best-effort dedup, guards no other memory; a double-print under a race is harmless.
- **consequence** — tests assert behavior, not warning text (the latch is process-global).

Three guards follow it: `CLOSE_FLOW_MISSING_WARNED`, `ISN_MISSING_WARNED`, `FINALIZE_SKIPPED_WARNED`.

### MITRE staged-techniques note
`src/mitre.rs` module header gains a "Catalogued vs. emitted techniques" section: `technique_info` is a *catalogue*, and some IDs are intentionally **staged** — seeded ahead of the analyzer that emits them (notably the ICS `T0xxx` entries for the planned Modbus/DNP3 analyzers). A staged entry is a forward declaration, not dead code.

### Test-naming convention
`README.md` "Extending" section gains a "Test naming convention" subsection codifying the existing prose-style practice — names state the asserted behavior, one behavior per test, lesson references in body comments not names. Documents existing practice.

### `is_grease_u16` rationale (P2.04 follow-up)
`src/analyzer/tls.rs` — the `is_grease_u16` doc comment now explains the bitmask `(val & 0x0F0F) == 0x0A0A` is deliberately broader than RFC 8701's strict 16-value set (matches 240 non-canonical `0x_A_A` values too), why that's harmless (no real IANA ID is `0x_A_A` form), and why the cheap single-mask test is kept. Resolves the imprecision the P2.04 property test surfaced: **keep as-is, documented** (the Q3 decision).

## Test plan
- [x] `cargo fmt --check` / `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo test --all-targets` — **265 passed, 0 failed** (unchanged — docs only)

## Scope note
Per the agreed curation, the three trivial P3 items (pluralization helper extraction, branch-naming doc widening, services-taxonomy split doc) are intentionally **not** addressed.

## Backlog status
With this PR: **P0 (5) + P1 (7) + P2 (11) all closed; P3 high-value subset done.** The brownfield-ingest lesson backlog is effectively complete bar three deliberately-skipped cosmetic P3 items.