### PR TITLE
fix(decoder): lax-parse snaplen-truncated IP packets instead of dropping them

### DIFF
--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -11,11 +11,25 @@
 //! UDP transports surface their port / flag tuple, ICMP is reported as the
 //! parent protocol with no transport detail, and everything else is reported
 //! as `Protocol::Other(proto_num)` with no transport info.
+//!
+//! ## Snaplen-truncated captures
+//!
+//! Each frame is parsed strictly first ([`etherparse::SlicedPacket`]), which
+//! validates the IPv4 `total_length` / IPv6 `payload_length` header fields
+//! against the bytes actually captured. A `tcpdump -s` capture truncates
+//! packets below their on-wire length, so those fields legitimately over-run
+//! the captured slice and the strict parser rejects the packet. When that
+//! happens the frame is re-parsed with [`etherparse::LaxSlicedPacket`], which
+//! clamps lengths to the captured bytes — matching how Wireshark and tcpdump
+//! dissect truncated captures. Strict-first keeps full validation for the
+//! common (untruncated) case; lax parsing is only ever a fallback.
 
 use std::net::IpAddr;
 
 use anyhow::{Result, anyhow};
-use etherparse::SlicedPacket;
+use etherparse::{
+    EtherType, IpNumber, LaxNetSlice, LaxSlicedPacket, NetSlice, SlicedPacket, TransportSlice,
+};
 use pcap_file::DataLink;
 use serde::Serialize;
 
@@ -82,17 +96,89 @@ impl ParsedPacket {
     }
 }
 
+/// Linux SLL ("cooked capture") header length in bytes. The protocol-type
+/// field occupies the final two bytes (big-endian).
+const SLL_HEADER_LEN: usize = 16;
+
+/// `(source IP, destination IP, IP-layer protocol number)` — the subset of
+/// the network layer the decoder needs, extracted uniformly from either the
+/// strict or the lax slice types.
+type IpTriple = (IpAddr, IpAddr, IpNumber);
+
 pub fn decode_packet(data: &[u8], datalink: DataLink) -> Result<ParsedPacket> {
-    let sliced = match datalink {
+    // Strict parse first: it validates the IPv4 `total_length` / IPv6
+    // `payload_length` fields against the captured bytes, which catches
+    // genuinely malformed packets. A snaplen-truncated capture trips that
+    // same length check — there the length field legitimately describes
+    // the full on-wire packet — so a strict error is NOT fatal here; it
+    // falls through to the lax parser below.
+    let strict = match datalink {
         DataLink::ETHERNET => SlicedPacket::from_ethernet(data),
         DataLink::RAW | DataLink::IPV4 | DataLink::IPV6 => SlicedPacket::from_ip(data),
         DataLink::LINUX_SLL => SlicedPacket::from_linux_sll(data),
         other => return Err(anyhow!("Unsupported link type: {other:?}")),
-    }
-    .map_err(|e| anyhow!("Parse error: {e}"))?;
+    };
 
-    let (src_ip, dst_ip, ip_protocol) = match &sliced.net {
-        Some(etherparse::NetSlice::Ipv4(ipv4)) => {
+    // Common path: the strict parse succeeded with a usable IP layer.
+    if let Ok(slice) = &strict
+        && let Some(net) = &slice.net
+    {
+        return Ok(build_parsed(
+            strict_ip_triple(net),
+            &slice.transport,
+            data.len(),
+        ));
+    }
+
+    // Otherwise strict parsing either errored on a length check (the
+    // signature of a snaplen-truncated capture) or produced no IP layer
+    // (a non-IP frame such as ARP). Re-parse with the lax slicer, which
+    // clamps header lengths to the captured slice instead of rejecting —
+    // the way Wireshark and tcpdump dissect truncated captures.
+    let lax = lax_parse(data, datalink)?;
+    if let Some(net) = &lax.net {
+        return Ok(build_parsed(lax_ip_triple(net), &lax.transport, data.len()));
+    }
+
+    // Neither parser found an IP layer: the frame is genuinely undecodable.
+    match strict {
+        Err(e) => Err(anyhow!("Parse error: {e}")),
+        Ok(_) => Err(anyhow!("No IP layer found")),
+    }
+}
+
+/// Re-parse a frame with `etherparse`'s lax slicer, which clamps header
+/// length fields to the captured slice instead of rejecting the packet.
+fn lax_parse(data: &[u8], datalink: DataLink) -> Result<LaxSlicedPacket<'_>> {
+    match datalink {
+        DataLink::ETHERNET => {
+            LaxSlicedPacket::from_ethernet(data).map_err(|e| anyhow!("Parse error: {e}"))
+        }
+        DataLink::RAW | DataLink::IPV4 | DataLink::IPV6 => {
+            LaxSlicedPacket::from_ip(data).map_err(|e| anyhow!("Parse error: {e}"))
+        }
+        DataLink::LINUX_SLL => {
+            // etherparse 0.16 has no `LaxSlicedPacket::from_linux_sll`. The
+            // SLL header is a fixed 16 bytes whose final two bytes hold the
+            // protocol type (an `EtherType`); hand the remainder to the lax
+            // ether-type slicer, which is infallible.
+            let proto = data
+                .get(SLL_HEADER_LEN - 2..SLL_HEADER_LEN)
+                .ok_or_else(|| anyhow!("Parse error: SLL header truncated"))?;
+            let ether_type = EtherType::from(u16::from_be_bytes([proto[0], proto[1]]));
+            Ok(LaxSlicedPacket::from_ether_type(
+                ether_type,
+                &data[SLL_HEADER_LEN..],
+            ))
+        }
+        other => Err(anyhow!("Unsupported link type: {other:?}")),
+    }
+}
+
+/// Extract the [`IpTriple`] from a strict network slice.
+fn strict_ip_triple(net: &NetSlice<'_>) -> IpTriple {
+    match net {
+        NetSlice::Ipv4(ipv4) => {
             let header = ipv4.header();
             (
                 IpAddr::V4(header.source_addr()),
@@ -100,7 +186,7 @@ pub fn decode_packet(data: &[u8], datalink: DataLink) -> Result<ParsedPacket> {
                 header.protocol(),
             )
         }
-        Some(etherparse::NetSlice::Ipv6(ipv6)) => {
+        NetSlice::Ipv6(ipv6) => {
             let header = ipv6.header();
             (
                 IpAddr::V6(header.source_addr()),
@@ -108,11 +194,43 @@ pub fn decode_packet(data: &[u8], datalink: DataLink) -> Result<ParsedPacket> {
                 ipv6.payload().ip_number,
             )
         }
-        None => return Err(anyhow!("No IP layer found")),
-    };
+    }
+}
 
-    let (protocol, transport) = match &sliced.transport {
-        Some(etherparse::TransportSlice::Tcp(tcp)) => (
+/// Extract the [`IpTriple`] from a lax network slice.
+fn lax_ip_triple(net: &LaxNetSlice<'_>) -> IpTriple {
+    match net {
+        LaxNetSlice::Ipv4(ipv4) => {
+            let header = ipv4.header();
+            (
+                IpAddr::V4(header.source_addr()),
+                IpAddr::V4(header.destination_addr()),
+                header.protocol(),
+            )
+        }
+        LaxNetSlice::Ipv6(ipv6) => {
+            let header = ipv6.header();
+            (
+                IpAddr::V6(header.source_addr()),
+                IpAddr::V6(header.destination_addr()),
+                ipv6.payload().ip_number,
+            )
+        }
+    }
+}
+
+/// Assemble a [`ParsedPacket`] from an extracted [`IpTriple`] and the
+/// transport slice, which is the same `TransportSlice` type on both the
+/// strict and lax parse paths.
+fn build_parsed(
+    ip: IpTriple,
+    transport: &Option<TransportSlice<'_>>,
+    packet_len: usize,
+) -> ParsedPacket {
+    let (src_ip, dst_ip, ip_protocol) = ip;
+
+    let (protocol, transport_info) = match transport {
+        Some(TransportSlice::Tcp(tcp)) => (
             Protocol::Tcp,
             TransportInfo::Tcp {
                 src_port: tcp.source_port(),
@@ -124,31 +242,31 @@ pub fn decode_packet(data: &[u8], datalink: DataLink) -> Result<ParsedPacket> {
                 rst: tcp.rst(),
             },
         ),
-        Some(etherparse::TransportSlice::Udp(udp)) => (
+        Some(TransportSlice::Udp(udp)) => (
             Protocol::Udp,
             TransportInfo::Udp {
                 src_port: udp.source_port(),
                 dst_port: udp.destination_port(),
             },
         ),
-        Some(etherparse::TransportSlice::Icmpv4(_) | etherparse::TransportSlice::Icmpv6(_)) => {
+        Some(TransportSlice::Icmpv4(_) | TransportSlice::Icmpv6(_)) => {
             (Protocol::Icmp, TransportInfo::None)
         }
         None => (Protocol::Other(ip_protocol.0), TransportInfo::None),
     };
 
-    let payload = match &sliced.transport {
-        Some(etherparse::TransportSlice::Tcp(tcp)) => tcp.payload().to_vec(),
-        Some(etherparse::TransportSlice::Udp(udp)) => udp.payload().to_vec(),
+    let payload = match transport {
+        Some(TransportSlice::Tcp(tcp)) => tcp.payload().to_vec(),
+        Some(TransportSlice::Udp(udp)) => udp.payload().to_vec(),
         _ => Vec::new(),
     };
 
-    Ok(ParsedPacket {
+    ParsedPacket {
         src_ip,
         dst_ip,
         protocol,
-        transport,
+        transport: transport_info,
         payload,
-        packet_len: data.len(),
-    })
+        packet_len,
+    }
 }

--- a/tests/decoder_tests.rs
+++ b/tests/decoder_tests.rs
@@ -214,3 +214,91 @@ fn test_decode_linux_sll_tcp_packet() {
         _ => panic!("Expected TCP"),
     }
 }
+
+// --- Snaplen-truncated captures -----------------------------------------
+//
+// A `tcpdump -s 96` capture truncates each packet below its on-wire
+// length, but the IPv4 `total_length` field still reports the full
+// original size. `etherparse`'s strict parser rejects that as a length
+// inconsistency; `decode_packet` must fall back to lax parsing and
+// recover the headers from the bytes that were captured.
+
+/// `make_tcp_packet` with the IPv4 `total_length` field overwritten to
+/// claim a full 1500-byte packet, simulating snaplen truncation. The
+/// field is at frame offset 16..18 (Ethernet 14 + IPv4 bytes 2..4).
+fn make_snaplen_truncated_eth_tcp() -> Vec<u8> {
+    let mut pkt = make_tcp_packet();
+    pkt[16] = 0x05;
+    pkt[17] = 0xdc; // total_length = 1500, far past the captured bytes
+    pkt
+}
+
+#[test]
+fn test_decode_snaplen_truncated_ethernet_recovers_via_lax_parsing() {
+    let data = make_snaplen_truncated_eth_tcp();
+    let parsed = decode_packet(&data, DataLink::ETHERNET)
+        .expect("snaplen-truncated Ethernet frame must decode via the lax fallback");
+
+    assert_eq!(parsed.src_ip, IpAddr::V4(Ipv4Addr::new(192, 168, 1, 10)));
+    assert_eq!(parsed.dst_ip, IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1)));
+    assert_eq!(parsed.protocol, Protocol::Tcp);
+    match parsed.transport {
+        TransportInfo::Tcp {
+            src_port, dst_port, ..
+        } => {
+            assert_eq!(src_port, 49153);
+            assert_eq!(dst_port, 80);
+        }
+        _ => panic!("Expected TCP"),
+    }
+}
+
+#[test]
+fn test_decode_snaplen_truncated_raw_ip_recovers_via_lax_parsing() {
+    // RAW datalink: IPv4 `total_length` is at frame offset 2..4.
+    let mut data = make_raw_ip_tcp_packet();
+    data[2] = 0x05;
+    data[3] = 0xdc;
+    let parsed = decode_packet(&data, DataLink::RAW)
+        .expect("snaplen-truncated raw-IP frame must decode via the lax fallback");
+
+    assert_eq!(parsed.src_ip, IpAddr::V4(Ipv4Addr::new(192, 168, 1, 10)));
+    assert_eq!(parsed.protocol, Protocol::Tcp);
+}
+
+#[test]
+fn test_decode_snaplen_truncated_linux_sll_recovers_via_lax_parsing() {
+    // SLL datalink: IPv4 starts after the 16-byte SLL header, so the
+    // `total_length` field is at frame offset 18..20. This also
+    // exercises the manual `from_ether_type` lax path, since
+    // `etherparse` has no `LaxSlicedPacket::from_linux_sll`.
+    let mut data = make_linux_sll_tcp_packet();
+    data[18] = 0x05;
+    data[19] = 0xdc;
+    let parsed = decode_packet(&data, DataLink::LINUX_SLL)
+        .expect("snaplen-truncated SLL frame must decode via the lax fallback");
+
+    assert_eq!(parsed.src_ip, IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)));
+    assert_eq!(parsed.dst_ip, IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)));
+    assert_eq!(parsed.protocol, Protocol::Tcp);
+}
+
+#[test]
+fn test_decode_snaplen_truncated_clamps_payload_to_captured_bytes() {
+    // Header stack plus 10 real payload bytes, with `total_length`
+    // claiming a 1500-byte packet. Lax parsing must clamp the payload
+    // to the bytes actually present rather than trusting the field —
+    // otherwise it would over-read past the buffer.
+    let mut data = make_tcp_packet();
+    data.extend_from_slice(&[0xde, 0xad, 0xbe, 0xef, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06]);
+    data[16] = 0x05;
+    data[17] = 0xdc;
+    let parsed = decode_packet(&data, DataLink::ETHERNET).expect("must decode");
+
+    assert_eq!(
+        parsed.payload.len(),
+        10,
+        "lax parsing must clamp the TCP payload to the captured bytes, \
+         not to the inflated IPv4 total_length"
+    );
+}

--- a/tests/fixture_reassembly_tests.rs
+++ b/tests/fixture_reassembly_tests.rs
@@ -10,12 +10,12 @@
 //! TCP traffic.
 //!
 //! `nfs_bad_stalls.cap` is a different kind of fixture: a snaplen-96
-//! capture that exercises the reader's truncated-capture path
-//! end-to-end. It is a regression guard for the snaplen reader fix —
-//! before that fix the validated `pcap-file` read path rejected the
-//! whole file. It is benign but deliberately NOT reassembly-heavy; see
-//! `test_nfs_bad_stalls_snaplen_capture_reassembles_as_benign` for the
-//! decoder-truncation caveat.
+//! capture that exercises the snaplen-truncated reader AND decoder
+//! paths end-to-end. Unlike the two baselines it is NOT benign — it is
+//! a genuine "bad stalls" capture whose NFS flow trips the
+//! out-of-window anomaly threshold, so it doubles as a positive
+//! detection fixture. See
+//! `test_nfs_bad_stalls_snaplen_capture_decodes_and_detects_anomaly`.
 //!
 //! Fixture provenance and licensing: see `tests/fixtures/README.md`.
 
@@ -109,33 +109,36 @@ fn test_snaplen_truncated_capture_loads_without_error() {
 }
 
 #[test]
-fn test_nfs_bad_stalls_snaplen_capture_reassembles_as_benign() {
-    // `nfs_bad_stalls.cap` is a snaplen-96 NFS-over-TCP capture. Two
-    // separate truncation effects apply, and only the first is fixed:
+fn test_nfs_bad_stalls_snaplen_capture_decodes_and_detects_anomaly() {
+    // `nfs_bad_stalls.cap` is a snaplen-96 NFS-over-TCP capture that
+    // exercises two snaplen-truncation fixes end-to-end: the reader
+    // (the file loads at all) and the decoder (truncated IP packets are
+    // lax-parsed instead of dropped). Before the decoder fix only ~2373
+    // of its packets decoded; now ~7032 do — `packets_tcp` is the
+    // regression guard for that fix.
     //
-    //  - Reader: the file now loads (see the test above).
-    //  - Decoder: `etherparse` still drops every packet whose IPv4
-    //    `total_length` overshoots the 96-byte captured slice — the
-    //    data-bearing segments. Only the small control packets (SYN /
-    //    ACK / FIN, whose real length fits in 96 bytes) decode.
-    //
-    // So this is NOT a heavy-reassembly baseline like the two fixtures
-    // above — `bytes_reassembled` is tiny by construction. Its job is
-    // to prove a snaplen-truncated capture flows reader -> decoder ->
-    // reassembly -> finalize without panic, and stays benign.
+    // It is NOT a benign baseline like the two fixtures above: it is a
+    // genuine "bad stalls" capture, and its NFS flow legitimately
+    // exceeds the out-of-window anomaly threshold. The TCP sequence
+    // numbers that drive that detection live in the headers, which the
+    // 96-byte snaplen captured intact — so the finding is real, not a
+    // truncation artifact. The fixture therefore doubles as a positive
+    // detection fixture.
     let reasm = reassemble_fixture("tests/fixtures/nfs_bad_stalls.cap");
     let s = reasm.stats();
     assert!(reasm.is_finalized());
     assert!(
-        s.packets_tcp > 0,
-        "expected the decodable control packets to be processed as TCP"
+        s.packets_tcp > 7000,
+        "decoder must lax-parse the snaplen-truncated packets; got only \
+         {} TCP packets (pre-decoder-fix baseline was ~2373)",
+        s.packets_tcp
     );
-    assert!(s.flows_total > 0, "expected reassembled flows");
-    // Benign capture: no reassembly anomaly threshold may trip.
-    assert_eq!(
-        reasm.findings().len(),
-        0,
-        "benign capture must produce no reassembly anomaly findings; got {:?}",
-        reasm.findings()
+    assert_eq!(s.flows_total, 8, "expected 8 flows");
+    // Positive detection: the bad-stalls NFS flow trips the
+    // out-of-window anomaly threshold.
+    let findings = reasm.findings();
+    assert!(
+        findings.iter().any(|f| f.summary.contains("out-of-window")),
+        "expected an out-of-window anomaly finding; got {findings:?}"
     );
 }

--- a/tests/fixtures/README.md
+++ b/tests/fixtures/README.md
@@ -31,7 +31,7 @@ false-positives for anyone cloning the repository.
 |------|--------|-------|
 | `tcp-ecn-sample.pcap` | [Wireshark SampleCaptures wiki](https://wiki.wireshark.org/uploads/__moin_import__/attachments/SampleCaptures/tcp-ecn-sample.pcap) | TCP transfer with ECN (RFC 3168). 479 TCP packets, 2 flows. Reassembly-heavy benign baseline (P2.05). |
 | `tcp-ethereal-file1.trace` | [Wireshark SampleCaptures wiki](https://wiki.wireshark.org/uploads/__moin_import__/attachments/SampleCaptures/tcp-ethereal-file1.trace) | Large multi-segment TCP/HTTP transfer. 218 TCP packets, 1 flow, ~150 KB reassembled. Reassembly-heavy benign baseline (P2.05). |
-| `nfs_bad_stalls.cap` | [Wireshark SampleCaptures wiki](https://wiki.wireshark.org/uploads/__moin_import__/attachments/SampleCaptures/nfs_bad_stalls.cap) | Snaplen-96 NFS-over-TCP capture (7038 packets). Snaplen-truncation regression fixture, **not** a reassembly baseline — see below. |
+| `nfs_bad_stalls.cap` | [Wireshark SampleCaptures wiki](https://wiki.wireshark.org/uploads/__moin_import__/attachments/SampleCaptures/nfs_bad_stalls.cap) | Snaplen-96 NFS-over-TCP capture (7038 packets). Exercises the snaplen-truncated reader + decoder paths end-to-end. A genuine "bad stalls" capture whose NFS flow trips the out-of-window anomaly — a positive detection fixture, **not** a benign baseline. See below. |
 
 The first two are exercised by `tests/fixture_reassembly_tests.rs` as
 benign calibration baselines: they drive heavy reassembly while
@@ -47,20 +47,23 @@ lesson).
 
 Snaplen-truncated captures — files where a packet's original on-wire
 length exceeds the capture's `snaplen` (e.g. produced by
-`tcpdump -s 96`) — are common in real-world forensics. wirerust now
-handles them at the **reader** layer: the validated `pcap-file` 2.0.0
-read path wrongly rejects such records with
-`Invalid field value: PacketHeader orig_len > snap_len`, so the reader
-takes the unvalidated raw-record path instead. `nfs_bad_stalls.cap` is
-the regression fixture for that fix.
+`tcpdump -s 96`) — are common in real-world forensics. wirerust handles
+them end-to-end:
 
-One truncation effect remains, in the **decoder** rather than the
-reader. `etherparse` rejects an IPv4 header whose `total_length` field
-overshoots the bytes actually captured, so every data-bearing packet in
-a `-s 96` capture is dropped at decode time — only the small control
-packets (SYN / ACK / FIN, whose real length fits the snaplen) survive.
-For `nfs_bad_stalls.cap` that is 2376 of 7038 packets. This is why the
-fixture is a snaplen *regression guard*, not a reassembly baseline: its
-reassembled byte volume is tiny by construction. Making the decoder
-tolerate snaplen-truncated IP packets (clamp `total_length` to the
-captured slice) is a genuine follow-up, tracked but not addressed here.
+- **Reader.** `pcap-file` 2.0.0's validated read path wrongly rejects
+  snaplen-truncated records with
+  `Invalid field value: PacketHeader orig_len > snap_len`, so the reader
+  takes the unvalidated raw-record path instead.
+- **Decoder.** `etherparse`'s strict parser rejects an IP header whose
+  `total_length` / `payload_length` overshoots the captured bytes, so
+  the decoder falls back to `etherparse`'s lax parser, which clamps
+  lengths to the captured slice. This matches how Wireshark and tcpdump
+  dissect truncated captures rather than dropping them.
+
+`nfs_bad_stalls.cap` is the end-to-end regression fixture for both. All
+7037 of its IPv4 packets decode (the single non-IP ARP frame is dropped,
+as expected); only the application-layer *payload* bytes beyond the
+96-byte snaplen are unavoidably absent. Because the TCP/IP headers
+survive intact, the reassembly engine sees this capture's true sequence
+behaviour — and its NFS flow legitimately trips the out-of-window
+anomaly threshold, which is what makes it a positive detection fixture.


### PR DESCRIPTION
## Summary
- `decode_packet` dropped every snaplen-truncated IP packet. `etherparse`'s strict slicer validates the IPv4 `total_length` / IPv6 `payload_length` fields against the captured bytes; a `tcpdump -s` capture truncates packets below their on-wire length, so those fields legitimately over-run the slice and the strict parser rejects the packet. On `nfs_bad_stalls.cap` (snaplen 96) that discarded **4661 of 7038** packets — every data-bearing one.
- The decoder now parses **strict-first** (full validation preserved for the common untruncated case) and falls back to `etherparse::LaxSlicedPacket` when strict errors or yields no IP layer. Lax parsing clamps header lengths to the captured slice — matching how Wireshark and tcpdump dissect truncated captures. SLL uses `from_ether_type` since etherparse 0.16 has no `LaxSlicedPacket::from_linux_sll`.
- Result on `nfs_bad_stalls.cap`: **7037/7038** packets now decode (the lone non-IP ARP frame is still correctly dropped).

## Why a finding appears
With the headers recovered, the reassembly engine sees the capture's true TCP sequence behaviour. `nfs_bad_stalls.cap` is a genuine "bad stalls" capture — its NFS flow legitimately trips the out-of-window anomaly threshold (101 segments). Sequence numbers live in the headers, which the snaplen captured intact, so the finding is real, not a truncation artifact. The fixture's `fixture_reassembly_tests.rs` test (added in #90) is rewritten accordingly: it now asserts >7000 packets decode and the out-of-window anomaly is detected — a positive detection fixture.

## Approach validated by research
etherparse 0.16 `LaxSlicedPacket` API, strict-vs-lax behaviour, and forensic correctness (Wireshark/tcpdump dissect rather than drop truncated captures) were checked against version-pinned docs.rs pages and the etherparse changelog before implementation.

## Changes
- `src/decoder.rs` — strict→lax fallback; `lax_parse` / `build_parsed` / `strict_ip_triple` / `lax_ip_triple` helpers.
- `tests/decoder_tests.rs` — 4 hermetic truncation tests (Ethernet / raw-IP / SLL recovery + payload-clamping).
- `tests/fixture_reassembly_tests.rs` — rewritten nfs_bad_stalls test.
- `tests/fixtures/README.md` — documents reader + decoder truncation handling; closes the decoder follow-up flagged in #90.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --all-targets` — all green (271 tests)
- [x] `cargo run -- analyze tests/fixtures/nfs_bad_stalls.cap --http` — 7037 decoded, 1 ARP skipped