### PR TITLE
fix(reassembly): count consecutive small segments, not cumulative

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -79,11 +79,17 @@ pub struct Cli {
     #[arg(long, global = true)]
     pub overlap_threshold: Option<u32>,
 
-    /// Override the small-segment anomaly threshold (default: 2048).
-    /// The default is permissive — lower it (low hundreds) to catch
-    /// fine-grained segmentation evasion. See LESSON-P2.05.
+    /// Override the small-segment anomaly threshold (default: 100).
+    /// Length of a consecutive run of undersized segments, per flow
+    /// direction, above which the anomaly fires. See LESSON-P2.05.
     #[arg(long, global = true)]
     pub small_segment_threshold: Option<u32>,
+
+    /// Override the small-segment payload-size cutoff in bytes
+    /// (default: 16). A segment shorter than this counts as "small";
+    /// 0 disables small-segment detection. See LESSON-P2.05.
+    #[arg(long, global = true)]
+    pub small_segment_max_bytes: Option<usize>,
 
     /// Override the out-of-window anomaly threshold (default: 100).
     /// Per flow direction; see LESSON-P2.05.

--- a/src/main.rs
+++ b/src/main.rs
@@ -107,6 +107,9 @@ fn run_analyze(
         if let Some(v) = cli.small_segment_threshold {
             config.small_segment_alert_threshold = v;
         }
+        if let Some(v) = cli.small_segment_max_bytes {
+            config.small_segment_max_bytes = v;
+        }
         if let Some(v) = cli.out_of_window_threshold {
             config.out_of_window_alert_threshold = v;
         }

--- a/src/reassembly/config.rs
+++ b/src/reassembly/config.rs
@@ -3,23 +3,22 @@
 //! [`ReassemblyConfig`] holds the resource ceilings that bound the
 //! [`crate::reassembly::TcpReassembler`] — per-direction depth, total
 //! memcap, idle timeout, concurrent-flow count, the forward receive
-//! window, and the three per-flow-direction anomaly-alert thresholds
+//! window, and the four per-flow-direction anomaly-detection fields
 //! (LESSON-P2.05). Extracted from `mod.rs` for LESSON-P2.01.
 //!
 //! ## Anomaly thresholds (LESSON-P2.05)
 //!
-//! The three `*_alert_threshold` fields control when the engine emits
-//! overlap / small-segment / out-of-window Anomaly findings. A research
-//! pass against Suricata, Zeek, and Snort established that **no
-//! production NIDS exposes a directly-comparable "count occurrences per
-//! flow direction and alert at N" threshold** — Suricata acts
-//! per-event with exponential backoff, Zeek bounds byte volumes and
-//! ships its overlap detector disabled, and Snort's count-based knobs
-//! (`overlap_limit`, `small_segments`) both default to 0/disabled.
-//! These three values therefore cannot be "calibrated" against prior
-//! art; they are conservative engineering defaults, and each field's
-//! doc comment records the closest cited reference. They are also CLI-
-//! overridable (`--overlap-threshold`, `--small-segment-threshold`,
+//! Four fields control the overlap / small-segment / out-of-window
+//! Anomaly findings. A research pass against Suricata, Zeek, and Snort
+//! established that **no production NIDS ships an enabled, directly-
+//! comparable detector**: Suricata reassembles and inspects the result
+//! rather than alerting on segment-size distribution, Zeek ships no
+//! small-segment notice, and Snort's count-based knobs (`overlap_limit`,
+//! `small_segments`) both default to 0/disabled. These values are
+//! therefore conservative engineering defaults, not values calibrated
+//! against prior art; each field's doc comment records the closest
+//! cited reference. All four are CLI-overridable (`--overlap-threshold`,
+//! `--small-segment-threshold`, `--small-segment-max-bytes`,
 //! `--out-of-window-threshold`) so operators can tune per-network.
 
 /// Configuration for the TCP reassembly engine.
@@ -50,19 +49,39 @@ pub struct ReassemblyConfig {
     /// engineering choice inside that sanctioned range — not a value
     /// any source endorses.
     pub overlap_alert_threshold: u32,
-    /// Small (undersized) segment count, per flow direction, **above
-    /// which** a small-segment Anomaly finding is emitted.
+    /// Length of a *consecutive run* of small (undersized) segments, per
+    /// flow direction, **above which** a small-segment Anomaly finding
+    /// is emitted. A segment counts as small when its payload is shorter
+    /// than [`Self::small_segment_max_bytes`]; a normal-sized segment
+    /// resets the run to zero.
     ///
-    /// LESSON-P2.05: research flagged this default as likely too
-    /// permissive. `2048` is the **maximum** of Snort's
-    /// `stream_tcp.small_segments.count` knob — whose actual default is
-    /// `0`/disabled — not a recommended detection value. A fine-grained
-    /// segmentation-evasion stream would need 2 KB+ of payload to trip
-    /// it. The value is retained as the default to avoid a behavior
-    /// change without false-positive data; operators tuning for evasion
-    /// detection should lower it via `--small-segment-threshold` (the
-    /// low hundreds is a reasonable starting point).
+    /// LESSON-P2.05: TCP segmentation-evasion (e.g. `fragroute tcp_seg
+    /// 1`) shows up as a long *unbroken* run of tiny segments, whereas
+    /// benign interactive traffic (telnet / SSH keystrokes) interleaves
+    /// tiny segments with normal-sized ones. A consecutive-run counter
+    /// — which Snort's `stream_tcp.small_segments` also uses, resetting
+    /// on a non-small segment — separates the two far better than the
+    /// cumulative count this field previously held. No NIDS publishes a
+    /// recommended value (Snort ships the feature disabled); `100` is a
+    /// conservative engineering default: low enough to catch a
+    /// 1-byte-segmented exploit payload (typically 300–900 segments),
+    /// high enough to tolerate ordinary interactive bursts. Tune via
+    /// `--small-segment-threshold`.
     pub small_segment_alert_threshold: u32,
+    /// Payload-size cutoff: a TCP segment carrying fewer than this many
+    /// payload bytes is classified as "small" for the
+    /// [`Self::small_segment_alert_threshold`] run counter. Empty
+    /// segments (pure ACKs) are never counted either way.
+    ///
+    /// LESSON-P2.05: the closest prior art is the size parameter of
+    /// Snort's `stream_tcp.small_segments`, operator-chosen in the range
+    /// 1–2048 (the documentation examples use `15`). `16` is a
+    /// conservative default — small enough to flag deliberate
+    /// fragmentation, large enough to also catch an attacker who splits
+    /// into 8–15 byte segments rather than literal 1-byte ones. Setting
+    /// it to `0` disables small-segment detection entirely. Tune via
+    /// `--small-segment-max-bytes`.
+    pub small_segment_max_bytes: usize,
     /// Out-of-window segment count, per flow direction, **above which**
     /// an out-of-window Anomaly finding is emitted.
     ///
@@ -77,15 +96,16 @@ pub struct ReassemblyConfig {
 impl Default for ReassemblyConfig {
     fn default() -> Self {
         ReassemblyConfig {
-            max_depth: 10 * 1024 * 1024,         // 10 MB per direction
-            memcap: 1024 * 1024 * 1024,          // 1 GB total
-            flow_timeout_secs: 300,              // 5 minutes
-            max_flows: 100_000,                  // 100K concurrent flows
-            max_segments_per_direction: 10_000,  // 10K segments per direction
-            max_receive_window: 1_048_576,       // 1 MB forward window
-            overlap_alert_threshold: 50,         // see field doc (LESSON-P2.05)
-            small_segment_alert_threshold: 2048, // see field doc (LESSON-P2.05)
-            out_of_window_alert_threshold: 100,  // see field doc (LESSON-P2.05)
+            max_depth: 10 * 1024 * 1024,        // 10 MB per direction
+            memcap: 1024 * 1024 * 1024,         // 1 GB total
+            flow_timeout_secs: 300,             // 5 minutes
+            max_flows: 100_000,                 // 100K concurrent flows
+            max_segments_per_direction: 10_000, // 10K segments per direction
+            max_receive_window: 1_048_576,      // 1 MB forward window
+            overlap_alert_threshold: 50,        // see field doc (LESSON-P2.05)
+            small_segment_alert_threshold: 100, // see field doc (LESSON-P2.05)
+            small_segment_max_bytes: 16,        // see field doc (LESSON-P2.05)
+            out_of_window_alert_threshold: 100, // see field doc (LESSON-P2.05)
         }
     }
 }

--- a/src/reassembly/flow.rs
+++ b/src/reassembly/flow.rs
@@ -8,8 +8,9 @@
 //! → `Closed`).
 //!
 //! Memory accounting (`memory_used`) is consulted by the reassembler's
-//! memcap eviction strategy; per-direction `overlap_count`, `small_segment_count`,
-//! and `out_of_window_count` feed the threshold-based Anomaly findings.
+//! memcap eviction strategy; per-direction `overlap_count`,
+//! `small_segment_run`, and `out_of_window_count` feed the
+//! threshold-based Anomaly findings.
 
 use std::collections::BTreeMap;
 use std::net::IpAddr;
@@ -90,7 +91,10 @@ pub struct FlowDirection {
     pub reassembled_bytes: usize,
     pub overlap_count: u32,
     pub overlap_alert_fired: bool,
-    pub small_segment_count: u32,
+    /// Length of the *current consecutive run* of small (undersized)
+    /// segments. Incremented per small segment and reset to zero by any
+    /// normal-sized one — see `ReassemblyConfig::small_segment_alert_threshold`.
+    pub small_segment_run: u32,
     pub small_segment_alert_fired: bool,
     pub out_of_window_count: u32,
     pub out_of_window_alert_fired: bool,
@@ -115,7 +119,7 @@ impl FlowDirection {
             reassembled_bytes: 0,
             overlap_count: 0,
             overlap_alert_fired: false,
-            small_segment_count: 0,
+            small_segment_run: 0,
             small_segment_alert_fired: false,
             out_of_window_count: 0,
             out_of_window_alert_fired: false,

--- a/src/reassembly/mod.rs
+++ b/src/reassembly/mod.rs
@@ -310,6 +310,7 @@ impl TcpReassembler {
             flow.get_direction_mut(dir).infer_isn(tcp.seq);
         }
 
+        let small_segment_max_bytes = self.config.small_segment_max_bytes;
         let flow_dir = flow.get_direction_mut(dir);
         let before_insert = flow_dir.buffered_bytes;
         let result = flow_dir.insert_segment(
@@ -327,6 +328,30 @@ impl TcpReassembler {
         );
         let bytes_added = flow_dir.buffered_bytes.saturating_sub(before_insert);
         self.total_memory += bytes_added;
+
+        // Maintain the consecutive small-segment run for this direction
+        // (LESSON-P2.05). "Small" is a pure property of the payload
+        // size, so it is classified here rather than inside the segment
+        // buffer. Segments the buffer rejected outright (out-of-window,
+        // segment-limit) and pure ACKs (empty payload) are neutral —
+        // they neither extend nor reset the run. A normal-sized data
+        // segment resets it: segmentation-evasion shows up as a long
+        // *unbroken* run of tiny segments, whereas benign interactive
+        // traffic interleaves them with normal-sized segments.
+        if !payload.is_empty()
+            && !matches!(
+                result,
+                InsertResult::OutOfWindow
+                    | InsertResult::SegmentLimitReached
+                    | InsertResult::IsnMissing
+            )
+        {
+            if payload.len() < small_segment_max_bytes {
+                flow_dir.small_segment_run = flow_dir.small_segment_run.saturating_add(1);
+            } else {
+                flow_dir.small_segment_run = 0;
+            }
+        }
 
         match result {
             InsertResult::Inserted => self.stats.segments_inserted += 1,
@@ -407,7 +432,7 @@ impl TcpReassembler {
                 self.stats.dropped_findings += 1;
             }
         }
-        if flow_dir.small_segment_count > small_segment_threshold
+        if flow_dir.small_segment_run > small_segment_threshold
             && !flow_dir.small_segment_alert_fired
         {
             flow_dir.small_segment_alert_fired = true;
@@ -417,10 +442,14 @@ impl TcpReassembler {
                     verdict: Verdict::Inconclusive,
                     confidence: Confidence::Medium,
                     summary: format!(
-                        "Excessive small segments ({}) on flow {}",
-                        flow_dir.small_segment_count, key
+                        "Excessive consecutive small segments ({}) on flow {}",
+                        flow_dir.small_segment_run, key
                     ),
-                    evidence: vec!["Possible IDS evasion".into()],
+                    evidence: vec![
+                        "Long unbroken run of undersized TCP segments; possible \
+                         segmentation-based IDS evasion"
+                            .into(),
+                    ],
                     mitre_technique: None,
                     source_ip: Some(packet.src_ip),
                     timestamp: None,

--- a/src/reassembly/segment.rs
+++ b/src/reassembly/segment.rs
@@ -71,10 +71,10 @@ impl FlowDirection {
             return InsertResult::SegmentLimitReached;
         }
 
-        // Track small segments (cumulative, not consecutive)
-        if data.len() < 8 {
-            self.small_segment_count += 1;
-        }
+        // Note: the small-segment run counter is maintained by the
+        // caller (`insert_payload_segment`), not here — "small" is a
+        // pure property of the payload size and needs no buffer state,
+        // unlike the overlap and out-of-window counters below.
 
         // Check depth limit
         let remaining_depth = max_depth.saturating_sub(self.reassembled_bytes);

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -137,6 +137,8 @@ fn test_threshold_flags_parse() {
         "10",
         "--small-segment-threshold",
         "256",
+        "--small-segment-max-bytes",
+        "32",
         "--out-of-window-threshold",
         "25",
         "analyze",
@@ -144,6 +146,7 @@ fn test_threshold_flags_parse() {
     ]);
     assert_eq!(cli.overlap_threshold, Some(10));
     assert_eq!(cli.small_segment_threshold, Some(256));
+    assert_eq!(cli.small_segment_max_bytes, Some(32));
     assert_eq!(cli.out_of_window_threshold, Some(25));
 }
 
@@ -154,6 +157,7 @@ fn test_threshold_flags_default_to_none() {
     let cli = Cli::parse_from(["wirerust", "analyze", "capture.pcap"]);
     assert_eq!(cli.overlap_threshold, None);
     assert_eq!(cli.small_segment_threshold, None);
+    assert_eq!(cli.small_segment_max_bytes, None);
     assert_eq!(cli.out_of_window_threshold, None);
 }
 

--- a/tests/reassembly_engine_tests.rs
+++ b/tests/reassembly_engine_tests.rs
@@ -1616,6 +1616,99 @@ fn test_default_config_threshold_values() {
     // config.rs field docs), not values endorsed by NIDS prior art.
     let cfg = ReassemblyConfig::default();
     assert_eq!(cfg.overlap_alert_threshold, 50);
-    assert_eq!(cfg.small_segment_alert_threshold, 2048);
+    assert_eq!(cfg.small_segment_alert_threshold, 100);
+    assert_eq!(cfg.small_segment_max_bytes, 16);
     assert_eq!(cfg.out_of_window_alert_threshold, 100);
+}
+
+/// Drive a flow of one-byte segments through the engine to exercise the
+/// consecutive small-segment run counter (LESSON-P2.05). When
+/// `break_after` is `Some(n)`, one normal-sized (29-byte) segment is
+/// inserted after the n-th small segment, which must reset the run.
+fn run_small_segment_flow(
+    threshold: u32,
+    small_count: u32,
+    break_after: Option<u32>,
+) -> TcpReassembler {
+    let config = ReassemblyConfig {
+        small_segment_alert_threshold: threshold,
+        ..ReassemblyConfig::default()
+    };
+    let mut reassembler = TcpReassembler::new(config);
+    let mut handler = RecordingHandler::new();
+    let client = [10, 0, 0, 1];
+    let server = [10, 0, 0, 2];
+
+    let syn = make_tcp_packet(
+        client,
+        12345,
+        server,
+        80,
+        1000,
+        &[],
+        true,
+        false,
+        false,
+        false,
+    );
+    reassembler.process_packet(&syn, 1, &mut handler);
+
+    let mut seq: u32 = 1001;
+    let mut ts: u32 = 2;
+    for i in 0..small_count {
+        if break_after == Some(i) {
+            // 29 bytes: well above the 16-byte cutoff, so it resets the run.
+            let normal = make_tcp_packet(
+                client,
+                12345,
+                server,
+                80,
+                seq,
+                b"a-normal-sized-tcp-segment-xx",
+                false,
+                true,
+                false,
+                false,
+            );
+            reassembler.process_packet(&normal, ts, &mut handler);
+            seq += 29;
+            ts += 1;
+        }
+        let small = make_tcp_packet(
+            client, 12345, server, 80, seq, b"x", false, true, false, false,
+        );
+        reassembler.process_packet(&small, ts, &mut handler);
+        seq += 1;
+        ts += 1;
+    }
+    reassembler
+}
+
+#[test]
+fn test_consecutive_small_segments_trip_anomaly() {
+    // 11 one-byte segments form an unbroken run of 11, above the
+    // configured threshold of 10 — the small-segment anomaly must fire.
+    let reasm = run_small_segment_flow(10, 11, None);
+    assert!(
+        reasm
+            .findings()
+            .iter()
+            .any(|f| f.summary.contains("small segments")),
+        "an unbroken run past the threshold must fire the small-segment anomaly"
+    );
+}
+
+#[test]
+fn test_normal_segment_resets_small_segment_run() {
+    // The same 11 one-byte segments — but a normal-sized segment after
+    // the 6th resets the consecutive run, so the two sub-runs (6, then
+    // 5) never reach the threshold of 10 and the anomaly stays silent.
+    let reasm = run_small_segment_flow(10, 11, Some(6));
+    assert!(
+        !reasm
+            .findings()
+            .iter()
+            .any(|f| f.summary.contains("small segments")),
+        "a normal-sized segment must reset the run and keep the anomaly silent"
+    );
 }

--- a/tests/reassembly_segment_tests.rs
+++ b/tests/reassembly_segment_tests.rs
@@ -135,19 +135,12 @@ fn test_sequence_wraparound() {
     assert_eq!(&all_bytes, b"beforewraparound");
 }
 
-#[test]
-fn test_small_segment_tracking() {
-    let mut dir = FlowDirection::new();
-    dir.set_isn(1000);
-
-    // Insert small segments
-    for i in 0..5u32 {
-        let seq = 1001 + i;
-        dir.insert_segment(seq, b"a", 10_485_760, 10_000, 10_485_760);
-    }
-
-    assert_eq!(dir.small_segment_count, 5);
-}
+// `test_small_segment_tracking` was removed in the LESSON-P2.05
+// consecutive-run change: small-segment classification moved out of the
+// segment buffer into the engine (`insert_payload_segment`), so it is
+// now covered by the engine-level tests in `reassembly_engine_tests.rs`
+// (`test_consecutive_small_segments_trip_anomaly` and
+// `test_normal_segment_resets_small_segment_run`).
 
 #[test]
 fn test_buffered_bytes_after_insert() {


### PR DESCRIPTION
## Summary
The small-segment evasion detector counted **cumulative** sub-8-byte segments per flow direction and alerted above **2048**. A research pass against Snort, Suricata and Zeek found this is the wrong design:

- **Wrong counting semantic.** Snort's `stream_tcp.small_segments` — the only comparable NIDS detector — counts *consecutive* small segments and resets the run on any normal-sized segment. Segmentation-evasion (`fragroute tcp_seg 1`) is a long *unbroken* run of tiny segments; benign interactive traffic (telnet/SSH keystrokes) interleaves tiny and normal segments. A cumulative counter conflates the two.
- **Indefensible default.** `2048` is the *maximum* of Snort's range, not a recommendation. A 1-byte-segmented exploit payload is typically only 300–900 segments, so a cumulative-2048 threshold could never fire on a real attack — the detector was effectively dead.

## Changes
- Switch to a **consecutive-run counter** (`small_segment_run`), reset by any normal-sized segment — mirrors Snort's semantics.
- Lower the count default **2048 → 100** (meaningful only with run semantics).
- Make the "small" size cutoff configurable: new `small_segment_max_bytes` config field + `--small-segment-max-bytes` flag, default raised **8 → 16** (Snort's doc example uses 15); `0` disables the detector.
- Classify "small" in `insert_payload_segment`, not the segment buffer — segment size is a pure property of the payload and needs no buffer state (unlike overlap / out-of-window). This keeps `insert_segment`'s signature unchanged (no test-call churn).

## Honest framing
No NIDS publishes a recommended count/size pair — Snort ships the feature **disabled**, Suricata and Zeek have no equivalent. The new defaults are documented in the config field docs as conservative engineering choices, *not* calibrated values. Residual false-positive risk on plaintext interactive traffic remains; per-port exclusion (Snort's `ignore_ports` analogue) is a sensible follow-up.

## Tests
- 2 engine-level tests: an unbroken run past the threshold trips the anomaly; a normal-sized segment resets the run and keeps it silent.
- Buffer-level `test_small_segment_tracking` removed — the logic is no longer in the buffer.
- `--small-segment-max-bytes` parse coverage added.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --all-targets` — all green (272 tests); benign baseline fixtures still produce zero findings under the lower default.