### PR TITLE
feat(reassembly): exempt interactive ports from small-segment detection

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -91,6 +91,12 @@ pub struct Cli {
     #[arg(long, global = true)]
     pub small_segment_max_bytes: Option<usize>,
 
+    /// Override the ports exempt from small-segment detection
+    /// (default: 23,513 — telnet, rlogin). Comma-separated; a flow is
+    /// exempt if either endpoint port matches. See LESSON-P2.05.
+    #[arg(long, global = true, value_delimiter = ',')]
+    pub small_segment_ignore_ports: Option<Vec<u16>>,
+
     /// Override the out-of-window anomaly threshold (default: 100).
     /// Per flow direction; see LESSON-P2.05.
     #[arg(long, global = true)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -110,6 +110,9 @@ fn run_analyze(
         if let Some(v) = cli.small_segment_max_bytes {
             config.small_segment_max_bytes = v;
         }
+        if let Some(v) = cli.small_segment_ignore_ports.clone() {
+            config.small_segment_ignore_ports = v;
+        }
         if let Some(v) = cli.out_of_window_threshold {
             config.out_of_window_alert_threshold = v;
         }

--- a/src/reassembly/config.rs
+++ b/src/reassembly/config.rs
@@ -3,12 +3,12 @@
 //! [`ReassemblyConfig`] holds the resource ceilings that bound the
 //! [`crate::reassembly::TcpReassembler`] — per-direction depth, total
 //! memcap, idle timeout, concurrent-flow count, the forward receive
-//! window, and the four per-flow-direction anomaly-detection fields
-//! (LESSON-P2.05). Extracted from `mod.rs` for LESSON-P2.01.
+//! window, and the five anomaly-detection fields (LESSON-P2.05).
+//! Extracted from `mod.rs` for LESSON-P2.01.
 //!
 //! ## Anomaly thresholds (LESSON-P2.05)
 //!
-//! Four fields control the overlap / small-segment / out-of-window
+//! Five fields control the overlap / small-segment / out-of-window
 //! Anomaly findings. A research pass against Suricata, Zeek, and Snort
 //! established that **no production NIDS ships an enabled, directly-
 //! comparable detector**: Suricata reassembles and inspects the result
@@ -17,9 +17,10 @@
 //! `small_segments`) both default to 0/disabled. These values are
 //! therefore conservative engineering defaults, not values calibrated
 //! against prior art; each field's doc comment records the closest
-//! cited reference. All four are CLI-overridable (`--overlap-threshold`,
+//! cited reference. All five are CLI-overridable (`--overlap-threshold`,
 //! `--small-segment-threshold`, `--small-segment-max-bytes`,
-//! `--out-of-window-threshold`) so operators can tune per-network.
+//! `--small-segment-ignore-ports`, `--out-of-window-threshold`) so
+//! operators can tune per-network.
 
 /// Configuration for the TCP reassembly engine.
 #[derive(Debug, Clone)]
@@ -82,6 +83,21 @@ pub struct ReassemblyConfig {
     /// it to `0` disables small-segment detection entirely. Tune via
     /// `--small-segment-max-bytes`.
     pub small_segment_max_bytes: usize,
+    /// Ports on which small-segment detection is suppressed. A flow is
+    /// exempt when **either** endpoint port appears here — a small-segment
+    /// run on these ports is benign interactive traffic, not evasion.
+    ///
+    /// LESSON-P2.05: the analogue is the `ignore_ports` parameter of
+    /// Snort 2.9's `stream5` `small_segments` (a space-separated port
+    /// list). The default `[23, 513]` covers telnet and rlogin — both
+    /// send one 1-byte segment per keystroke and so produce long benign
+    /// runs of tiny segments. SSH (22) is deliberately **not** included:
+    /// its encrypted keystroke packets are ~28–96 bytes, above the
+    /// `small_segment_max_bytes` cutoff, so they never count as small —
+    /// excluding 22 would only create a detection blind spot. (If the
+    /// cutoff is ever raised above ~28, reconsider adding 22.) An empty
+    /// list disables the exemption. Tune via `--small-segment-ignore-ports`.
+    pub small_segment_ignore_ports: Vec<u16>,
     /// Out-of-window segment count, per flow direction, **above which**
     /// an out-of-window Anomaly finding is emitted.
     ///
@@ -96,16 +112,17 @@ pub struct ReassemblyConfig {
 impl Default for ReassemblyConfig {
     fn default() -> Self {
         ReassemblyConfig {
-            max_depth: 10 * 1024 * 1024,        // 10 MB per direction
-            memcap: 1024 * 1024 * 1024,         // 1 GB total
-            flow_timeout_secs: 300,             // 5 minutes
-            max_flows: 100_000,                 // 100K concurrent flows
-            max_segments_per_direction: 10_000, // 10K segments per direction
-            max_receive_window: 1_048_576,      // 1 MB forward window
-            overlap_alert_threshold: 50,        // see field doc (LESSON-P2.05)
-            small_segment_alert_threshold: 100, // see field doc (LESSON-P2.05)
-            small_segment_max_bytes: 16,        // see field doc (LESSON-P2.05)
-            out_of_window_alert_threshold: 100, // see field doc (LESSON-P2.05)
+            max_depth: 10 * 1024 * 1024,               // 10 MB per direction
+            memcap: 1024 * 1024 * 1024,                // 1 GB total
+            flow_timeout_secs: 300,                    // 5 minutes
+            max_flows: 100_000,                        // 100K concurrent flows
+            max_segments_per_direction: 10_000,        // 10K segments per direction
+            max_receive_window: 1_048_576,             // 1 MB forward window
+            overlap_alert_threshold: 50,               // see field doc (LESSON-P2.05)
+            small_segment_alert_threshold: 100,        // see field doc (LESSON-P2.05)
+            small_segment_max_bytes: 16,               // see field doc (LESSON-P2.05)
+            small_segment_ignore_ports: vec![23, 513], // telnet, rlogin (LESSON-P2.05)
+            out_of_window_alert_threshold: 100,        // see field doc (LESSON-P2.05)
         }
     }
 }

--- a/src/reassembly/mod.rs
+++ b/src/reassembly/mod.rs
@@ -408,6 +408,17 @@ impl TcpReassembler {
         let small_segment_threshold = self.config.small_segment_alert_threshold;
         let out_of_window_threshold = self.config.out_of_window_alert_threshold;
 
+        // LESSON-P2.05 follow-up: a flow is exempt from small-segment
+        // detection when EITHER endpoint port is in the configured
+        // interactive-port ignore list (telnet, rlogin, ...) — those
+        // protocols emit benign runs of tiny segments. See
+        // `ReassemblyConfig::small_segment_ignore_ports`.
+        let small_segment_ignored = self
+            .config
+            .small_segment_ignore_ports
+            .iter()
+            .any(|&p| p == key.lower_port() || p == key.upper_port());
+
         let flow = self.flows.get_mut(key).unwrap();
         let flow_dir = flow.get_direction_mut(dir);
 
@@ -434,6 +445,7 @@ impl TcpReassembler {
         }
         if flow_dir.small_segment_run > small_segment_threshold
             && !flow_dir.small_segment_alert_fired
+            && !small_segment_ignored
         {
             flow_dir.small_segment_alert_fired = true;
             if self.findings.len() < MAX_FINDINGS {

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -139,6 +139,8 @@ fn test_threshold_flags_parse() {
         "256",
         "--small-segment-max-bytes",
         "32",
+        "--small-segment-ignore-ports",
+        "23,513,9000",
         "--out-of-window-threshold",
         "25",
         "analyze",
@@ -147,6 +149,7 @@ fn test_threshold_flags_parse() {
     assert_eq!(cli.overlap_threshold, Some(10));
     assert_eq!(cli.small_segment_threshold, Some(256));
     assert_eq!(cli.small_segment_max_bytes, Some(32));
+    assert_eq!(cli.small_segment_ignore_ports, Some(vec![23, 513, 9000]));
     assert_eq!(cli.out_of_window_threshold, Some(25));
 }
 
@@ -158,6 +161,7 @@ fn test_threshold_flags_default_to_none() {
     assert_eq!(cli.overlap_threshold, None);
     assert_eq!(cli.small_segment_threshold, None);
     assert_eq!(cli.small_segment_max_bytes, None);
+    assert_eq!(cli.small_segment_ignore_ports, None);
     assert_eq!(cli.out_of_window_threshold, None);
 }
 

--- a/tests/reassembly_engine_tests.rs
+++ b/tests/reassembly_engine_tests.rs
@@ -1618,17 +1618,22 @@ fn test_default_config_threshold_values() {
     assert_eq!(cfg.overlap_alert_threshold, 50);
     assert_eq!(cfg.small_segment_alert_threshold, 100);
     assert_eq!(cfg.small_segment_max_bytes, 16);
+    assert_eq!(cfg.small_segment_ignore_ports, vec![23, 513]);
     assert_eq!(cfg.out_of_window_alert_threshold, 100);
 }
 
 /// Drive a flow of one-byte segments through the engine to exercise the
-/// consecutive small-segment run counter (LESSON-P2.05). When
-/// `break_after` is `Some(n)`, one normal-sized (29-byte) segment is
-/// inserted after the n-th small segment, which must reset the run.
+/// consecutive small-segment run counter (LESSON-P2.05). `server_port`
+/// is the flow's well-known port (use a non-ignored port such as 80 to
+/// observe the detector, or an ignored one such as 23 to observe
+/// suppression). When `break_after` is `Some(n)`, one normal-sized
+/// (29-byte) segment is inserted after the n-th small segment, which
+/// must reset the run.
 fn run_small_segment_flow(
     threshold: u32,
     small_count: u32,
     break_after: Option<u32>,
+    server_port: u16,
 ) -> TcpReassembler {
     let config = ReassemblyConfig {
         small_segment_alert_threshold: threshold,
@@ -1643,7 +1648,7 @@ fn run_small_segment_flow(
         client,
         12345,
         server,
-        80,
+        server_port,
         1000,
         &[],
         true,
@@ -1662,7 +1667,7 @@ fn run_small_segment_flow(
                 client,
                 12345,
                 server,
-                80,
+                server_port,
                 seq,
                 b"a-normal-sized-tcp-segment-xx",
                 false,
@@ -1675,7 +1680,16 @@ fn run_small_segment_flow(
             ts += 1;
         }
         let small = make_tcp_packet(
-            client, 12345, server, 80, seq, b"x", false, true, false, false,
+            client,
+            12345,
+            server,
+            server_port,
+            seq,
+            b"x",
+            false,
+            true,
+            false,
+            false,
         );
         reassembler.process_packet(&small, ts, &mut handler);
         seq += 1;
@@ -1688,7 +1702,7 @@ fn run_small_segment_flow(
 fn test_consecutive_small_segments_trip_anomaly() {
     // 11 one-byte segments form an unbroken run of 11, above the
     // configured threshold of 10 — the small-segment anomaly must fire.
-    let reasm = run_small_segment_flow(10, 11, None);
+    let reasm = run_small_segment_flow(10, 11, None, 80);
     assert!(
         reasm
             .findings()
@@ -1703,12 +1717,27 @@ fn test_normal_segment_resets_small_segment_run() {
     // The same 11 one-byte segments — but a normal-sized segment after
     // the 6th resets the consecutive run, so the two sub-runs (6, then
     // 5) never reach the threshold of 10 and the anomaly stays silent.
-    let reasm = run_small_segment_flow(10, 11, Some(6));
+    let reasm = run_small_segment_flow(10, 11, Some(6), 80);
     assert!(
         !reasm
             .findings()
             .iter()
             .any(|f| f.summary.contains("small segments")),
         "a normal-sized segment must reset the run and keep the anomaly silent"
+    );
+}
+
+#[test]
+fn test_small_segment_anomaly_suppressed_on_ignored_port() {
+    // The same unbroken 11-segment run that fires on port 80 must stay
+    // silent on telnet (port 23): it is in the default ignore list, as
+    // char-at-a-time interactive traffic there is benign, not evasion.
+    let reasm = run_small_segment_flow(10, 11, None, 23);
+    assert!(
+        !reasm
+            .findings()
+            .iter()
+            .any(|f| f.summary.contains("small segments")),
+        "small-segment detection must be suppressed on an ignored port"
     );
 }


### PR DESCRIPTION
## Summary
The small-segment evasion detector (#92) false-positives on benign plaintext interactive traffic: telnet and rlogin send one 1-byte TCP segment per keystroke — exactly the long consecutive run of tiny segments the detector flags. This adds a configurable port exemption, the analogue of Snort 2.9's `stream5 small_segments ... ignore_ports`.

- New `ReassemblyConfig::small_segment_ignore_ports` field. A flow is exempt when **either** endpoint port is in the list (the well-known port can be on either side of an unordered flow tuple).
- New `--small-segment-ignore-ports` CLI flag (comma-separated).
- Default `[23, 513]` — telnet, rlogin.

## Research-validated design decisions
A research pass against Snort/Suricata/Zeek settled four design points:

- **Default `{23, 513}`, not empty.** wirerust's detector is on by default, so the false positive ships with it — the mitigation must ship with it too. (Snort ships `small_segments` *disabled*, so its empty `ignore_ports` default is harmless there; wirerust doesn't have that luxury.)
- **SSH (22) deliberately excluded.** SSH encrypted keystroke packets are ~28–96 bytes — above the 16-byte "small" cutoff — so they never count as small. Adding 22 would only create a detection blind spot on the most security-sensitive port, for zero false-positive benefit.
- **RDP / IRC / BGP excluded** — TLS-framed (>16 B) / line-oriented / 19-byte messages respectively; none are genuine sub-16-byte-run sources.
- **Either-endpoint match** — wirerust cannot reliably identify the server port from an arbitrary PCAP; "either endpoint" is robust to the unordered tuple and subsumes the well-known-port case.

## Known limitation / follow-up
Port is a coarse proxy (over-excludes if an attacker reuses port 23; under-excludes interactive protocols on custom ports). A more robust, port-independent discriminator — **directional symmetry** (benign interactive traffic is bidirectionally tiny due to keystroke echo; evasion is a one-directional burst) — is recorded as a future improvement.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --all-targets` — all green (273 tests). New test: an unbroken run that fires on port 80 stays silent on telnet (23); config-default + CLI-parse coverage added.