### PR TITLE
fix(decoder): only lax-recover length errors, not malformed packets

### DIFF
--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -18,15 +18,20 @@
 //! validates the IPv4 `total_length` / IPv6 `payload_length` header fields
 //! against the bytes actually captured. A `tcpdump -s` capture truncates
 //! packets below their on-wire length, so those fields legitimately over-run
-//! the captured slice and the strict parser rejects the packet. When that
-//! happens the frame is re-parsed with [`etherparse::LaxSlicedPacket`], which
-//! clamps lengths to the captured bytes — matching how Wireshark and tcpdump
-//! dissect truncated captures. Strict-first keeps full validation for the
-//! common (untruncated) case; lax parsing is only ever a fallback.
+//! the captured slice and the strict parser fails with a *length* error
+//! ([`etherparse::err::packet::SliceError::Len`]). **Only that error class**
+//! triggers a re-parse with [`etherparse::LaxSlicedPacket`], which clamps
+//! lengths to the captured bytes — matching how Wireshark and tcpdump dissect
+//! truncated captures. Any other strict error (bad header version, bad IHL,
+//! bad TCP data-offset, ...) is genuine structural corruption and the packet
+//! is rejected, exactly as the strict parser intended — lax recovery is never
+//! applied to a malformed packet. Strict-first keeps full validation for the
+//! common (untruncated) case; lax parsing is only ever the truncation fallback.
 
 use std::net::IpAddr;
 
 use anyhow::{Result, anyhow};
+use etherparse::err::packet::SliceError;
 use etherparse::{
     EtherType, IpNumber, LaxNetSlice, LaxSlicedPacket, NetSlice, SlicedPacket, TransportSlice,
 };
@@ -107,11 +112,8 @@ type IpTriple = (IpAddr, IpAddr, IpNumber);
 
 pub fn decode_packet(data: &[u8], datalink: DataLink) -> Result<ParsedPacket> {
     // Strict parse first: it validates the IPv4 `total_length` / IPv6
-    // `payload_length` fields against the captured bytes, which catches
-    // genuinely malformed packets. A snaplen-truncated capture trips that
-    // same length check — there the length field legitimately describes
-    // the full on-wire packet — so a strict error is NOT fatal here; it
-    // falls through to the lax parser below.
+    // `payload_length` fields against the captured bytes and catches
+    // genuinely malformed packets.
     let strict = match datalink {
         DataLink::ETHERNET => SlicedPacket::from_ethernet(data),
         DataLink::RAW | DataLink::IPV4 | DataLink::IPV6 => SlicedPacket::from_ip(data),
@@ -119,31 +121,38 @@ pub fn decode_packet(data: &[u8], datalink: DataLink) -> Result<ParsedPacket> {
         other => return Err(anyhow!("Unsupported link type: {other:?}")),
     };
 
-    // Common path: the strict parse succeeded with a usable IP layer.
-    if let Ok(slice) = &strict
-        && let Some(net) = &slice.net
-    {
-        return Ok(build_parsed(
-            strict_ip_triple(net),
-            &slice.transport,
-            data.len(),
-        ));
-    }
-
-    // Otherwise strict parsing either errored on a length check (the
-    // signature of a snaplen-truncated capture) or produced no IP layer
-    // (a non-IP frame such as ARP). Re-parse with the lax slicer, which
-    // clamps header lengths to the captured slice instead of rejecting —
-    // the way Wireshark and tcpdump dissect truncated captures.
-    let lax = lax_parse(data, datalink)?;
-    if let Some(net) = &lax.net {
-        return Ok(build_parsed(lax_ip_triple(net), &lax.transport, data.len()));
-    }
-
-    // Neither parser found an IP layer: the frame is genuinely undecodable.
     match strict {
+        // Strict succeeded with a usable IP layer — the common path.
+        Ok(slice) => match &slice.net {
+            Some(net) => Ok(build_parsed(
+                strict_ip_triple(net),
+                &slice.transport,
+                data.len(),
+            )),
+            // Strict parsed cleanly but found no IP layer — a non-IP
+            // frame (e.g. ARP). Lax parsing cannot conjure an IP layer
+            // that is not present, so reject directly.
+            None => Err(anyhow!("No IP layer found")),
+        },
+        // Strict failed on a *length* error — the signature of a
+        // snaplen-truncated capture, where a header length field
+        // legitimately over-runs the captured bytes. ONLY this error
+        // class is retried with the lax slicer, which clamps lengths to
+        // the captured slice (as Wireshark and tcpdump do). A structural
+        // error is handled by the arm below.
+        Err(SliceError::Len(_)) => {
+            let lax = lax_parse(data, datalink)?;
+            match &lax.net {
+                Some(net) => Ok(build_parsed(lax_ip_triple(net), &lax.transport, data.len())),
+                // Truncated past the IP header itself — undecodable.
+                None => Err(anyhow!("No IP layer found")),
+            }
+        }
+        // Any other strict error is genuine structural corruption (bad
+        // header version, bad IHL, bad TCP data-offset, ...). Reject it,
+        // exactly as the strict parser intended — lax recovery here
+        // would admit malformed packets a forensics tool should drop.
         Err(e) => Err(anyhow!("Parse error: {e}")),
-        Ok(_) => Err(anyhow!("No IP layer found")),
     }
 }
 

--- a/src/reassembly/config.rs
+++ b/src/reassembly/config.rs
@@ -58,13 +58,17 @@ pub struct ReassemblyConfig {
     ///
     /// LESSON-P2.05: TCP segmentation-evasion (e.g. `fragroute tcp_seg
     /// 1`) shows up as a long *unbroken* run of tiny segments, whereas
-    /// benign interactive traffic (telnet / SSH keystrokes) interleaves
-    /// tiny segments with normal-sized ones. A consecutive-run counter
-    /// — which Snort's `stream_tcp.small_segments` also uses, resetting
-    /// on a non-small segment — separates the two far better than the
-    /// cumulative count this field previously held. No NIDS publishes a
-    /// recommended value (Snort ships the feature disabled); `100` is a
-    /// conservative engineering default: low enough to catch a
+    /// benign interactive traffic (telnet / rlogin keystrokes)
+    /// interleaves tiny segments with normal-sized ones. A
+    /// consecutive-run counter — in the spirit of Snort's
+    /// `stream_tcp.small_segments` — separates the two far better than
+    /// the cumulative count this field previously held. The run resets
+    /// on *any single* normal-sized segment, so an attacker who splices
+    /// one `>= small_segment_max_bytes` segment into the run evades the
+    /// detector; a port-independent directional-symmetry discriminator
+    /// (tracked as a follow-up) would be more robust. No NIDS publishes
+    /// a recommended value (Snort ships the feature disabled); `100` is
+    /// a conservative engineering default: low enough to catch a
     /// 1-byte-segmented exploit payload (typically 300–900 segments),
     /// high enough to tolerate ordinary interactive bursts. Tune via
     /// `--small-segment-threshold`.

--- a/src/reassembly/flow.rs
+++ b/src/reassembly/flow.rs
@@ -94,6 +94,10 @@ pub struct FlowDirection {
     /// Length of the *current consecutive run* of small (undersized)
     /// segments. Incremented per small segment and reset to zero by any
     /// normal-sized one — see `ReassemblyConfig::small_segment_alert_threshold`.
+    /// Maintained for every flow regardless of the small-segment port
+    /// exemption: the exemption is applied when the finding would be
+    /// emitted, not when segments are counted, so this stays a raw
+    /// measurement.
     pub small_segment_run: u32,
     pub small_segment_alert_fired: bool,
     pub out_of_window_count: u32,

--- a/src/reassembly/mod.rs
+++ b/src/reassembly/mod.rs
@@ -332,17 +332,19 @@ impl TcpReassembler {
         // Maintain the consecutive small-segment run for this direction
         // (LESSON-P2.05). "Small" is a pure property of the payload
         // size, so it is classified here rather than inside the segment
-        // buffer. Segments the buffer rejected outright (out-of-window,
-        // segment-limit) and pure ACKs (empty payload) are neutral —
-        // they neither extend nor reset the run. A normal-sized data
-        // segment resets it: segmentation-evasion shows up as a long
-        // *unbroken* run of tiny segments, whereas benign interactive
-        // traffic interleaves them with normal-sized segments.
+        // buffer. Segments the buffer rejected outright — out-of-window,
+        // segment-limit, depth-exceeded — and pure ACKs (empty payload)
+        // are neutral: they neither extend nor reset the run. A
+        // normal-sized data segment resets it: segmentation-evasion
+        // shows up as a long *unbroken* run of tiny segments, whereas
+        // benign interactive traffic interleaves them with normal-sized
+        // segments.
         if !payload.is_empty()
             && !matches!(
                 result,
                 InsertResult::OutOfWindow
                     | InsertResult::SegmentLimitReached
+                    | InsertResult::DepthExceeded
                     | InsertResult::IsnMissing
             )
         {
@@ -408,17 +410,6 @@ impl TcpReassembler {
         let small_segment_threshold = self.config.small_segment_alert_threshold;
         let out_of_window_threshold = self.config.out_of_window_alert_threshold;
 
-        // LESSON-P2.05 follow-up: a flow is exempt from small-segment
-        // detection when EITHER endpoint port is in the configured
-        // interactive-port ignore list (telnet, rlogin, ...) — those
-        // protocols emit benign runs of tiny segments. See
-        // `ReassemblyConfig::small_segment_ignore_ports`.
-        let small_segment_ignored = self
-            .config
-            .small_segment_ignore_ports
-            .iter()
-            .any(|&p| p == key.lower_port() || p == key.upper_port());
-
         let flow = self.flows.get_mut(key).unwrap();
         let flow_dir = flow.get_direction_mut(dir);
 
@@ -443,9 +434,19 @@ impl TcpReassembler {
                 self.stats.dropped_findings += 1;
             }
         }
+        // LESSON-P2.05 follow-up: a flow is exempt from small-segment
+        // detection when EITHER endpoint port is in the configured
+        // interactive-port ignore list (telnet, rlogin, ...) — those
+        // protocols emit benign runs of tiny segments. The list scan is
+        // the last `&&` term, so it runs only once the run has actually
+        // crossed the threshold, not on every packet.
         if flow_dir.small_segment_run > small_segment_threshold
             && !flow_dir.small_segment_alert_fired
-            && !small_segment_ignored
+            && !self
+                .config
+                .small_segment_ignore_ports
+                .iter()
+                .any(|&p| p == key.lower_port() || p == key.upper_port())
         {
             flow_dir.small_segment_alert_fired = true;
             if self.findings.len() < MAX_FINDINGS {

--- a/tests/decoder_tests.rs
+++ b/tests/decoder_tests.rs
@@ -302,3 +302,52 @@ fn test_decode_snaplen_truncated_clamps_payload_to_captured_bytes() {
          not to the inflated IPv4 total_length"
     );
 }
+
+// --- Error-path discipline ----------------------------------------------
+//
+// The strict→lax fallback must apply lax recovery ONLY to snaplen
+// truncation (a strict *length* error), never to structural corruption.
+// These tests pin both the non-IP-frame branch and the
+// corruption-is-rejected branch.
+
+#[test]
+fn test_decode_arp_frame_reports_no_ip_layer() {
+    // An ARP frame (ethertype 0x0806) parses cleanly at the link layer
+    // but has no IP layer. `decode_packet` must reject it with
+    // "No IP layer found" — not attempt a lax recovery.
+    let mut frame = vec![
+        0xff, 0xff, 0xff, 0xff, 0xff, 0xff, // dst mac (broadcast)
+        0x00, 0x11, 0x22, 0x33, 0x44, 0x55, // src mac
+        0x08, 0x06, // ethertype: ARP
+    ];
+    frame.extend_from_slice(&[
+        0x00, 0x01, 0x08, 0x00, 0x06, 0x04, 0x00, 0x01, // htype/ptype/hlen/plen/oper
+        0x00, 0x11, 0x22, 0x33, 0x44, 0x55, // sender mac
+        0xc0, 0xa8, 0x01, 0x0a, // sender ip
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // target mac
+        0xc0, 0xa8, 0x01, 0x01, // target ip
+    ]);
+    let err = decode_packet(&frame, DataLink::ETHERNET).unwrap_err();
+    assert!(
+        err.to_string().contains("No IP layer found"),
+        "an ARP frame must report 'No IP layer found'; got: {err}"
+    );
+}
+
+#[test]
+fn test_decode_structurally_corrupt_packet_is_rejected_not_lax_recovered() {
+    // A frame with a valid IPv4 header but an invalid TCP data-offset
+    // (0, below the minimum of 5) is structural corruption, not snaplen
+    // truncation. The strict parser rejects it with a non-length error;
+    // `decode_packet` must NOT fall back to lax recovery (which would
+    // admit the malformed packet) — it must reject with "Parse error".
+    let mut frame = make_tcp_packet();
+    // TCP data-offset/reserved byte is at frame offset 14 + 20 + 12 = 46.
+    frame[46] = 0x00; // data offset 0 — structurally invalid
+    let err = decode_packet(&frame, DataLink::ETHERNET).unwrap_err();
+    assert!(
+        err.to_string().contains("Parse error"),
+        "a structurally-corrupt packet must be rejected as a parse error, \
+         not lax-recovered; got: {err}"
+    );
+}

--- a/tests/fixtures/README.md
+++ b/tests/fixtures/README.md
@@ -55,10 +55,13 @@ them end-to-end:
   `Invalid field value: PacketHeader orig_len > snap_len`, so the reader
   takes the unvalidated raw-record path instead.
 - **Decoder.** `etherparse`'s strict parser rejects an IP header whose
-  `total_length` / `payload_length` overshoots the captured bytes, so
-  the decoder falls back to `etherparse`'s lax parser, which clamps
-  lengths to the captured slice. This matches how Wireshark and tcpdump
-  dissect truncated captures rather than dropping them.
+  `total_length` / `payload_length` overshoots the captured bytes — a
+  *length* error. On that error class only, the decoder falls back to
+  `etherparse`'s lax parser, which clamps lengths to the captured slice
+  (matching how Wireshark and tcpdump dissect truncated captures rather
+  than dropping them). A structural error — bad header version, bad
+  IHL, bad TCP data-offset — is genuine corruption and is still
+  rejected; lax recovery never admits a malformed packet.
 
 `nfs_bad_stalls.cap` is the end-to-end regression fixture for both. All
 7037 of its IPv4 packets decode (the single non-IP ARP frame is dropped,

--- a/tests/reassembly_engine_tests.rs
+++ b/tests/reassembly_engine_tests.rs
@@ -1623,16 +1623,16 @@ fn test_default_config_threshold_values() {
 }
 
 /// Drive a flow of one-byte segments through the engine to exercise the
-/// consecutive small-segment run counter (LESSON-P2.05). `server_port`
-/// is the flow's well-known port (use a non-ignored port such as 80 to
-/// observe the detector, or an ignored one such as 23 to observe
-/// suppression). When `break_after` is `Some(n)`, one normal-sized
-/// (29-byte) segment is inserted after the n-th small segment, which
-/// must reset the run.
+/// consecutive small-segment run counter (LESSON-P2.05). `client_port`
+/// and `server_port` are the flow's two endpoint ports — vary them to
+/// land an ignored port on either side and observe the port exemption.
+/// When `break_after` is `Some(n)`, one normal-sized (29-byte) segment
+/// is inserted after the n-th small segment, which must reset the run.
 fn run_small_segment_flow(
     threshold: u32,
     small_count: u32,
     break_after: Option<u32>,
+    client_port: u16,
     server_port: u16,
 ) -> TcpReassembler {
     let config = ReassemblyConfig {
@@ -1646,7 +1646,7 @@ fn run_small_segment_flow(
 
     let syn = make_tcp_packet(
         client,
-        12345,
+        client_port,
         server,
         server_port,
         1000,
@@ -1665,7 +1665,7 @@ fn run_small_segment_flow(
             // 29 bytes: well above the 16-byte cutoff, so it resets the run.
             let normal = make_tcp_packet(
                 client,
-                12345,
+                client_port,
                 server,
                 server_port,
                 seq,
@@ -1681,7 +1681,7 @@ fn run_small_segment_flow(
         }
         let small = make_tcp_packet(
             client,
-            12345,
+            client_port,
             server,
             server_port,
             seq,
@@ -1698,46 +1698,69 @@ fn run_small_segment_flow(
     reassembler
 }
 
+/// True if any finding's summary names the small-segment anomaly.
+fn fired_small_segment(reasm: &TcpReassembler) -> bool {
+    reasm
+        .findings()
+        .iter()
+        .any(|f| f.summary.contains("small segments"))
+}
+
 #[test]
 fn test_consecutive_small_segments_trip_anomaly() {
     // 11 one-byte segments form an unbroken run of 11, above the
     // configured threshold of 10 — the small-segment anomaly must fire.
-    let reasm = run_small_segment_flow(10, 11, None, 80);
+    let reasm = run_small_segment_flow(10, 11, None, 12345, 80);
     assert!(
-        reasm
-            .findings()
-            .iter()
-            .any(|f| f.summary.contains("small segments")),
+        fired_small_segment(&reasm),
         "an unbroken run past the threshold must fire the small-segment anomaly"
     );
 }
 
 #[test]
 fn test_normal_segment_resets_small_segment_run() {
+    // Positive control: 11 one-byte segments with no break trip the
+    // threshold of 10. Without this the negative assertion below would
+    // pass even if small-segment detection were entirely broken.
+    let control = run_small_segment_flow(10, 11, None, 12345, 80);
+    assert!(
+        fired_small_segment(&control),
+        "control: an unbroken 11-segment run must fire the anomaly"
+    );
     // The same 11 one-byte segments — but a normal-sized segment after
     // the 6th resets the consecutive run, so the two sub-runs (6, then
     // 5) never reach the threshold of 10 and the anomaly stays silent.
-    let reasm = run_small_segment_flow(10, 11, Some(6), 80);
+    let reset = run_small_segment_flow(10, 11, Some(6), 12345, 80);
     assert!(
-        !reasm
-            .findings()
-            .iter()
-            .any(|f| f.summary.contains("small segments")),
+        !fired_small_segment(&reset),
         "a normal-sized segment must reset the run and keep the anomaly silent"
     );
 }
 
 #[test]
-fn test_small_segment_anomaly_suppressed_on_ignored_port() {
-    // The same unbroken 11-segment run that fires on port 80 must stay
-    // silent on telnet (port 23): it is in the default ignore list, as
-    // char-at-a-time interactive traffic there is benign, not evasion.
-    let reasm = run_small_segment_flow(10, 11, None, 23);
+fn test_small_segment_anomaly_suppressed_on_server_side_ignored_port() {
+    // The same unbroken 11-segment run that fires on port 80 (see
+    // `test_consecutive_small_segments_trip_anomaly`) must stay silent
+    // when the server port is telnet (23) — in the default ignore list.
+    // The only difference between the two flows is the server port, so
+    // this proves the port is the discriminator.
+    let reasm = run_small_segment_flow(10, 11, None, 12345, 23);
     assert!(
-        !reasm
-            .findings()
-            .iter()
-            .any(|f| f.summary.contains("small segments")),
-        "small-segment detection must be suppressed on an ignored port"
+        !fired_small_segment(&reasm),
+        "small-segment detection must be suppressed when the server port is ignored"
+    );
+}
+
+#[test]
+fn test_small_segment_anomaly_suppressed_on_client_side_ignored_port() {
+    // The exemption matches EITHER endpoint: here the ignored port (23)
+    // is the *client* port and the server port (80) is not ignored.
+    // The run must still be suppressed — exercises the `lower_port()`
+    // arm of the either-endpoint check, the complement of the test
+    // above.
+    let reasm = run_small_segment_flow(10, 11, None, 23, 80);
+    assert!(
+        !fired_small_segment(&reasm),
+        "small-segment detection must be suppressed when the client port is ignored"
     );
 }


### PR DESCRIPTION
## Summary
A fresh-context **adversarial review** of this session's snaplen / small-segment sub-cycle (#90–#93) found the sub-cycle was not converged. This PR is the convergence-fix pass.

**Headline finding (H1):** the strict→lax decoder fallback (#91) fired on *any* strict parse error. So genuinely-malformed packets that the strict parser correctly rejected — bad header version, bad IHL, bad TCP data-offset — were being lax-recovered and fed to the reassembly engine. For a forensics tool that is a real detection-behavior change, and the module docs mis-described the fallback as "snaplen-truncation recovery" when it was "lax-on-any-error".

## Fixes by review finding
- **H1** — `decode_packet` now falls back to lax parsing **only** on `SliceError::Len` (the length error a snaplen-truncated capture produces, confirmed against etherparse 0.16 source). Structural errors are rejected as "Parse error", as strict intended.
- **H2** — added the two missing error-branch tests: ARP frame → "No IP layer found"; structurally-corrupt packet (invalid TCP data-offset) → rejected, not lax-recovered.
- **M2** — `DepthExceeded` segments excluded from the small-segment run, consistent with the "rejected-outright is neutral" rule the comment already stated.
- **M3** — the ignore-port scan is now the last `&&` term, evaluated only once a run crosses the threshold rather than per-packet.
- **M5** — `test_normal_segment_resets_small_segment_run` gained a positive control so its negative assertion can't pass vacuously.
- **M6** — the small-segment flow helper takes both endpoint ports; added a client-side-ignored-port test, so both arms of the either-endpoint exemption are exercised.
- **M1/M4/L3/L4** — doc accuracy: the threshold doc no longer over-claims Snort parity and states the one-normal-segment evasion; `small_segment_run` documented as exemption-agnostic; module doc + fixtures README match the length-error-only fallback.

## Deferred (recorded as follow-ups, not in scope here)
- A port-independent **directional-symmetry** discriminator for small-segment detection.
- `--small-segment-max-bytes` has no sane-range validation (operator footgun).

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --all-targets` — all green; new ARP/corrupt-packet/client-port tests pass; `nfs_bad_stalls.cap` still decodes (truncation path unaffected).