### PR TITLE
test: close adversarial-review test-quality gaps in the snaplen sub-cycle

### DIFF
--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -27,6 +27,14 @@
 //! is rejected, exactly as the strict parser intended — lax recovery is never
 //! applied to a malformed packet. Strict-first keeps full validation for the
 //! common (untruncated) case; lax parsing is only ever the truncation fallback.
+//!
+//! When the snaplen cut lands *inside* the transport header (not just the
+//! payload), the lax parser recovers the IP layer but not the transport
+//! layer: such a frame decodes with its IP addresses intact but as
+//! `Protocol::Other(ip_protocol)` with `TransportInfo::None` — the honest
+//! degraded result, since the ports / flags simply were not captured. The
+//! "TCP / UDP surface their port / flag tuple" statement above therefore
+//! holds only when the transport header itself was captured.
 
 use std::net::IpAddr;
 
@@ -171,6 +179,12 @@ fn lax_parse(data: &[u8], datalink: DataLink) -> Result<LaxSlicedPacket<'_>> {
             // SLL header is a fixed 16 bytes whose final two bytes hold the
             // protocol type (an `EtherType`); hand the remainder to the lax
             // ether-type slicer, which is infallible.
+            //
+            // The `.get(..)` guard below is defensive: in practice an SLL
+            // frame shorter than 16 bytes fails the *strict* parse with a
+            // non-`Len` error and is rejected before `lax_parse` is ever
+            // reached, so the truncated-header branch is not expected to
+            // fire — but bounding the slice keeps it panic-free regardless.
             let proto = data
                 .get(SLL_HEADER_LEN - 2..SLL_HEADER_LEN)
                 .ok_or_else(|| anyhow!("Parse error: SLL header truncated"))?;

--- a/src/reassembly/mod.rs
+++ b/src/reassembly/mod.rs
@@ -332,9 +332,14 @@ impl TcpReassembler {
         // Maintain the consecutive small-segment run for this direction
         // (LESSON-P2.05). "Small" is a pure property of the payload
         // size, so it is classified here rather than inside the segment
-        // buffer. Segments the buffer rejected outright — out-of-window,
-        // segment-limit, depth-exceeded — and pure ACKs (empty payload)
-        // are neutral: they neither extend nor reset the run. A
+        // buffer. The run reflects every segment that *reached the
+        // reassembly window* — including duplicates and overlaps
+        // (`Duplicate` / `PartialOverlap` / `ConflictingOverlap` /
+        // `Truncated`), which are real received segments even though
+        // they are not newly stored. Only segments turned away *before*
+        // the window — out-of-window, segment-limit, depth-exceeded — and
+        // the IsnMissing programming-error case are neutral, as are pure
+        // ACKs (empty payload): none extend or reset the run. A
         // normal-sized data segment resets it: segmentation-evasion
         // shows up as a long *unbroken* run of tiny segments, whereas
         // benign interactive traffic interleaves them with normal-sized

--- a/tests/decoder_tests.rs
+++ b/tests/decoder_tests.rs
@@ -303,6 +303,57 @@ fn test_decode_snaplen_truncated_clamps_payload_to_captured_bytes() {
     );
 }
 
+#[test]
+fn test_decode_snaplen_truncated_ipv6_recovers_via_lax_parsing() {
+    // The IPv6 `payload_length` field sits at frame offset 4..6 (no
+    // Ethernet header on a RAW capture). Inflating it past the captured
+    // bytes makes the strict parser fail with the same length error an
+    // IPv4 `total_length` over-run produces — this confirms the lax
+    // fallback covers IPv6 truncation too, not only IPv4.
+    let mut data = make_raw_ipv6_tcp_packet();
+    data[4] = 0x05;
+    data[5] = 0xdc; // payload_length = 1500, far past the captured bytes
+    let parsed = decode_packet(&data, DataLink::IPV6)
+        .expect("snaplen-truncated IPv6 frame must decode via the lax fallback");
+
+    assert_eq!(parsed.protocol, Protocol::Tcp);
+    match parsed.transport {
+        TransportInfo::Tcp {
+            src_port, dst_port, ..
+        } => {
+            assert_eq!(src_port, 49153);
+            assert_eq!(dst_port, 80);
+        }
+        _ => panic!("Expected TCP"),
+    }
+}
+
+#[test]
+fn test_decode_truncation_inside_tcp_header_degrades_to_other() {
+    // A frame physically cut *inside* the TCP header — only 10 of the
+    // 20 header bytes captured (44-byte buffer = Ethernet 14 + IPv4 20 +
+    // 10 TCP). The lax fallback recovers the IP layer but cannot recover
+    // the transport layer, so the packet decodes with its IP addresses
+    // intact but as `Protocol::Other(6)` with no transport detail. This
+    // pins the documented degraded-decode behavior for a snaplen cut
+    // that lands within the transport header rather than the payload.
+    let full = make_tcp_packet();
+    let truncated = &full[..44];
+    let parsed = decode_packet(truncated, DataLink::ETHERNET)
+        .expect("a frame truncated mid-TCP-header must still decode its IP layer");
+
+    assert_eq!(parsed.src_ip, IpAddr::V4(Ipv4Addr::new(192, 168, 1, 10)));
+    assert_eq!(
+        parsed.protocol,
+        Protocol::Other(6),
+        "a captured-but-incomplete TCP header must degrade to Other(<ip-proto>)"
+    );
+    assert!(
+        matches!(parsed.transport, TransportInfo::None),
+        "an incomplete TCP header yields no transport detail"
+    );
+}
+
 // --- Error-path discipline ----------------------------------------------
 //
 // The strict→lax fallback must apply lax recovery ONLY to snaplen

--- a/tests/fixture_reassembly_tests.rs
+++ b/tests/fixture_reassembly_tests.rs
@@ -113,9 +113,11 @@ fn test_nfs_bad_stalls_snaplen_capture_decodes_and_detects_anomaly() {
     // `nfs_bad_stalls.cap` is a snaplen-96 NFS-over-TCP capture that
     // exercises two snaplen-truncation fixes end-to-end: the reader
     // (the file loads at all) and the decoder (truncated IP packets are
-    // lax-parsed instead of dropped). Before the decoder fix only ~2373
-    // of its packets decoded; now ~7032 do — `packets_tcp` is the
-    // regression guard for that fix.
+    // lax-parsed instead of dropped). Before the decoder fix only 2373
+    // of its packets decoded; now exactly 7032 of its 7038 packets are
+    // TCP and decode — `packets_tcp` is the regression guard for that
+    // fix, and the exact count is pinned so a decoder regression fails
+    // here rather than drifting silently.
     //
     // It is NOT a benign baseline like the two fixtures above: it is a
     // genuine "bad stalls" capture, and its NFS flow legitimately
@@ -127,11 +129,10 @@ fn test_nfs_bad_stalls_snaplen_capture_decodes_and_detects_anomaly() {
     let reasm = reassemble_fixture("tests/fixtures/nfs_bad_stalls.cap");
     let s = reasm.stats();
     assert!(reasm.is_finalized());
-    assert!(
-        s.packets_tcp > 7000,
-        "decoder must lax-parse the snaplen-truncated packets; got only \
-         {} TCP packets (pre-decoder-fix baseline was ~2373)",
-        s.packets_tcp
+    assert_eq!(
+        s.packets_tcp, 7032,
+        "decoder must lax-parse the snaplen-truncated packets into exactly \
+         7032 TCP packets (pre-decoder-fix baseline was 2373)"
     );
     assert_eq!(s.flows_total, 8, "expected 8 flows");
     // Positive detection: the bad-stalls NFS flow trips the

--- a/tests/fixtures/README.md
+++ b/tests/fixtures/README.md
@@ -64,9 +64,11 @@ them end-to-end:
   rejected; lax recovery never admits a malformed packet.
 
 `nfs_bad_stalls.cap` is the end-to-end regression fixture for both. All
-7037 of its IPv4 packets decode (the single non-IP ARP frame is dropped,
-as expected); only the application-layer *payload* bytes beyond the
-96-byte snaplen are unavoidably absent. Because the TCP/IP headers
-survive intact, the reassembly engine sees this capture's true sequence
+but one of its 7038 packets decode — the lone non-IP ARP frame is
+dropped; `tests/fixture_reassembly_tests.rs` pins the exact 7032 TCP
+packets the decoder recovers (the rest are a handful of UDP / other-IP
+packets). Only the application-layer *payload* bytes beyond the 96-byte
+snaplen are unavoidably absent. Because the TCP/IP headers survive
+intact, the reassembly engine sees this capture's true sequence
 behaviour — and its NFS flow legitimately trips the out-of-window
 anomaly threshold, which is what makes it a positive detection fixture.

--- a/tests/reassembly_engine_tests.rs
+++ b/tests/reassembly_engine_tests.rs
@@ -1718,22 +1718,42 @@ fn test_consecutive_small_segments_trip_anomaly() {
 }
 
 #[test]
-fn test_normal_segment_resets_small_segment_run() {
-    // Positive control: 11 one-byte segments with no break trip the
-    // threshold of 10. Without this the negative assertion below would
-    // pass even if small-segment detection were entirely broken.
-    let control = run_small_segment_flow(10, 11, None, 12345, 80);
+fn test_small_segment_run_at_exactly_threshold_stays_silent() {
+    // The alert fires on `run > threshold`, strictly. A run of exactly
+    // the threshold (10 small segments, threshold 10) must NOT fire —
+    // this pins the boundary, so a regression from `>` to `>=` is
+    // caught (`test_consecutive_small_segments_trip_anomaly` covers the
+    // threshold + 1 side).
+    let reasm = run_small_segment_flow(10, 10, None, 12345, 80);
     assert!(
-        fired_small_segment(&control),
-        "control: an unbroken 11-segment run must fire the anomaly"
+        !fired_small_segment(&reasm),
+        "a run of exactly the threshold must stay silent (the test is `>`, not `>=`)"
     );
-    // The same 11 one-byte segments — but a normal-sized segment after
-    // the 6th resets the consecutive run, so the two sub-runs (6, then
-    // 5) never reach the threshold of 10 and the anomaly stays silent.
-    let reset = run_small_segment_flow(10, 11, Some(6), 12345, 80);
+}
+
+#[test]
+fn test_normal_segment_resets_small_segment_run() {
+    // Two flows of 11 one-byte segments against a threshold of 8,
+    // differing only in where the run-breaking normal segment lands.
+    // Both the *threshold boundary* and the *reset position* are made
+    // load-bearing — a wrong answer flips the assertion.
+    //
+    // Break after the 9th small segment: the first sub-run is exactly 9
+    // (> 8) so the anomaly MUST fire. This proves the run is not reset
+    // before the break — a too-early reset would keep the sub-run <= 8.
+    let fires = run_small_segment_flow(8, 11, Some(9), 12345, 80);
     assert!(
-        !fired_small_segment(&reset),
-        "a normal-sized segment must reset the run and keep the anomaly silent"
+        fired_small_segment(&fires),
+        "the pre-break sub-run of 9 must trip the threshold of 8"
+    );
+    // Move the break one segment earlier: the first sub-run is now
+    // exactly 8 (not > 8) and the second is 3, so the anomaly MUST stay
+    // silent. Were the reset absent the run would reach 11 and fire —
+    // so this proves the reset actually happens, and at the break.
+    let silent = run_small_segment_flow(8, 11, Some(8), 12345, 80);
+    assert!(
+        !fired_small_segment(&silent),
+        "a normal-sized segment must reset the run at the break"
     );
 }
 


### PR DESCRIPTION
## Summary
A second fresh-context **adversarial review** of the snaplen / small-segment sub-cycle confirmed the production code is sound, but found the new tests under-constrained the behavior the commits claimed (several passed vacuously). This PR closes those gaps. **No behavior change** — tests, comments, and docs only.

## By review finding
- **H1** — added `test_decode_truncation_inside_tcp_header_degrades_to_other`: a frame physically cut inside the TCP header decodes (via lax) with its IP layer intact but as `Protocol::Other(<proto>)` with no transport detail. The decoder module doc now documents this degraded-decode case.
- **M1** — that test physically truncates the buffer; the earlier truncation tests only inflated the length field while keeping the full header stack present, so lax clamping was never actually exercised.
- **L2** — added an IPv6 snaplen-truncation test; the lax fallback was only covered for IPv4.
- **M2** — corrected the small-segment-run comment: the real rule is "segments turned away *before the reassembly window* are neutral" — the prior "rejected outright" wording wrongly implied `ConflictingOverlap` / `Duplicate` should not count.
- **M3** — added `test_small_segment_run_at_exactly_threshold_stays_silent`: pins the `>` boundary so a regression to `>=` is caught.
- **M4** — rewrote `test_normal_segment_resets_small_segment_run` as a load-bearing pair (threshold 8, break after the 9th vs the 8th small segment) so the threshold boundary *and* the reset position both flip the assertion — the previous negative-only test passed even if the reset were mispositioned or absent.
- **M5** — the fixture test now pins the exact decoded TCP count (`packets_tcp == 7032`, was `> 7000`); the README states the same test-pinned figure instead of unverified prose.
- **L1** — documented the SLL truncated-header branch in `lax_parse` as defensive-only (unreachable in practice).

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --all-targets` — all green; new IPv6 / mid-TCP-header / boundary / reset-pair tests pass; `packets_tcp == 7032` confirms the exact decode count.