### PR TITLE
fix(cli): enforce sane ranges on reassembly threshold flags

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,11 @@ httparse = "1"
 tls-parser = "0.12"
 md-5 = "0.11"
 clap = { version = "4", features = ["derive"] }
+# Pinned to the 0.16.x minor: the decoder's strict→lax truncation
+# fallback keys on the `SliceError::Len` variant, which is part of the
+# 0.16 API contract. A 0.17 bump must re-verify the error taxonomy
+# (see src/decoder.rs). `"0.16"` already excludes 0.17 via Cargo's
+# caret semantics for 0.x versions.
 etherparse = "0.16"
 pcap-file = "2"
 serde = { version = "1", features = ["derive"] }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -75,21 +75,24 @@ pub struct Cli {
     pub reassembly_memcap: usize,
 
     /// Override the overlapping-segment anomaly threshold (default: 50).
-    /// Per flow direction; see LESSON-P2.05 in the reassembly config.
-    #[arg(long, global = true)]
+    /// Per flow direction; accepted range 0–255 (Snort's
+    /// `overlap_limit` range). See LESSON-P2.05 in the reassembly config.
+    #[arg(long, global = true, value_parser = clap::value_parser!(u32).range(0..=255))]
     pub overlap_threshold: Option<u32>,
 
     /// Override the small-segment anomaly threshold (default: 100).
     /// Length of a consecutive run of undersized segments, per flow
-    /// direction, above which the anomaly fires. See LESSON-P2.05.
-    #[arg(long, global = true)]
+    /// direction, above which the anomaly fires. Accepted range 0–2048
+    /// (Snort's `small_segments` count range). See LESSON-P2.05.
+    #[arg(long, global = true, value_parser = clap::value_parser!(u32).range(0..=2048))]
     pub small_segment_threshold: Option<u32>,
 
     /// Override the small-segment payload-size cutoff in bytes
     /// (default: 16). A segment shorter than this counts as "small";
-    /// 0 disables small-segment detection. See LESSON-P2.05.
-    #[arg(long, global = true)]
-    pub small_segment_max_bytes: Option<usize>,
+    /// 0 disables small-segment detection. Accepted range 0–2048
+    /// (Snort's `small_segments` size range). See LESSON-P2.05.
+    #[arg(long, global = true, value_parser = clap::value_parser!(u16).range(0..=2048))]
+    pub small_segment_max_bytes: Option<u16>,
 
     /// Override the ports exempt from small-segment detection
     /// (default: 23,513 — telnet, rlogin). Comma-separated; a flow is

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -39,6 +39,13 @@
 use std::net::IpAddr;
 
 use anyhow::{Result, anyhow};
+// `SliceError::Len` is the strict-parser error class the truncation
+// fallback keys on (see `decode_packet`). That discrimination is part
+// of the etherparse 0.16 API contract; `Cargo.toml` constrains the
+// dependency to `0.16.x` accordingly. A future 0.17 bump must re-verify
+// the error taxonomy — `test_decode_snaplen_truncated_ipv6_recovers_via_lax_parsing`
+// and `test_decode_structurally_corrupt_packet_is_rejected_not_lax_recovered`
+// act as the contract tests for it.
 use etherparse::err::packet::SliceError;
 use etherparse::{
     EtherType, IpNumber, LaxNetSlice, LaxSlicedPacket, NetSlice, SlicedPacket, TransportSlice,

--- a/src/reassembly/config.rs
+++ b/src/reassembly/config.rs
@@ -84,9 +84,9 @@ pub struct ReassemblyConfig {
     /// conservative default — small enough to flag deliberate
     /// fragmentation, large enough to also catch an attacker who splits
     /// into 8–15 byte segments rather than literal 1-byte ones. Setting
-    /// it to `0` disables small-segment detection entirely. Tune via
-    /// `--small-segment-max-bytes`.
-    pub small_segment_max_bytes: usize,
+    /// it to `0` disables small-segment detection entirely. The
+    /// `--small-segment-max-bytes` flag enforces Snort's 0–2048 range.
+    pub small_segment_max_bytes: u16,
     /// Ports on which small-segment detection is suppressed. A flow is
     /// exempt when **either** endpoint port appears here — a small-segment
     /// run on these ports is benign interactive traffic, not evasion.

--- a/src/reassembly/mod.rs
+++ b/src/reassembly/mod.rs
@@ -353,7 +353,7 @@ impl TcpReassembler {
                     | InsertResult::IsnMissing
             )
         {
-            if payload.len() < small_segment_max_bytes {
+            if payload.len() < usize::from(small_segment_max_bytes) {
                 flow_dir.small_segment_run = flow_dir.small_segment_run.saturating_add(1);
             } else {
                 flow_dir.small_segment_run = 0;

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -166,6 +166,25 @@ fn test_threshold_flags_default_to_none() {
 }
 
 #[test]
+fn test_reassembly_threshold_flags_reject_out_of_range_values() {
+    // LESSON-P2.05 adversarial-review follow-up: the reassembly
+    // threshold flags enforce their documented sane ranges, so an
+    // out-of-range value is rejected at parse time rather than silently
+    // producing a nonsensical detector configuration.
+    for (flag, bad) in [
+        ("--overlap-threshold", "300"),        // range 0..=255
+        ("--small-segment-threshold", "5000"), // range 0..=2048
+        ("--small-segment-max-bytes", "5000"), // range 0..=2048
+    ] {
+        let result = Cli::try_parse_from(["wirerust", flag, bad, "analyze", "x.pcap"]);
+        assert!(
+            result.is_err(),
+            "`{flag} {bad}` is out of range and must be rejected"
+        );
+    }
+}
+
+#[test]
 fn test_removed_unwired_flags_are_rejected() {
     // LESSON-P1.04: --threats, --verbose, --beacon, --filter, and
     // --services were removed in the "no unwired CLI flags" sweep

--- a/tests/reassembly_engine_tests.rs
+++ b/tests/reassembly_engine_tests.rs
@@ -1131,6 +1131,55 @@ fn test_out_of_window_threshold_alert() {
 }
 
 #[test]
+fn test_out_of_window_threshold_silent_at_exactly_threshold() {
+    // The out-of-window alert fires on `count > threshold`, strictly.
+    // With the threshold configured to 5, exactly 5 out-of-window
+    // segments must NOT fire — pins the boundary so a regression from
+    // `>` to `>=` is caught (`test_out_of_window_threshold_alert`
+    // covers the threshold + 1 side).
+    let config = ReassemblyConfig {
+        max_receive_window: 1000,
+        out_of_window_alert_threshold: 5,
+        ..ReassemblyConfig::default()
+    };
+    let mut reassembler = TcpReassembler::new(config);
+    let mut handler = RecordingHandler::new();
+    let client = [10, 0, 0, 1];
+    let server = [10, 0, 0, 2];
+
+    let syn = make_tcp_packet(
+        client,
+        12345,
+        server,
+        80,
+        1000,
+        &[],
+        true,
+        false,
+        false,
+        false,
+    );
+    reassembler.process_packet(&syn, 1, &mut handler);
+
+    for i in 0..5 {
+        let seq = 1000 + 5000 + i; // beyond base_offset + the 1000-byte window
+        let pkt = make_tcp_packet(
+            client, 12345, server, 80, seq, b"x", false, false, false, false,
+        );
+        reassembler.process_packet(&pkt, 2, &mut handler);
+    }
+
+    assert_eq!(reassembler.stats().segments_out_of_window, 5);
+    assert!(
+        !reassembler
+            .findings()
+            .iter()
+            .any(|f| f.summary.contains("out-of-window segments")),
+        "exactly the threshold count must stay silent (the test is `>`, not `>=`)"
+    );
+}
+
+#[test]
 fn test_out_of_window_alert_fires_only_once() {
     let config = ReassemblyConfig {
         max_receive_window: 1000,
@@ -1606,6 +1655,23 @@ fn test_default_overlap_threshold_silent_at_six_overlaps() {
             .iter()
             .any(|f| f.summary.contains("Excessive segment overlaps")),
         "6 overlaps must stay silent under the default threshold of 50"
+    );
+}
+
+#[test]
+fn test_overlap_threshold_silent_at_exactly_threshold() {
+    // The overlap alert fires on `overlap_count > threshold`, strictly.
+    // With the threshold configured to 5, exactly 5 overlaps must NOT
+    // fire — pins the boundary so a regression from `>` to `>=` is
+    // caught (`test_low_overlap_threshold_fires_earlier` covers the
+    // threshold + 1 side).
+    let reasm = run_overlapping_flow(5, 5);
+    assert!(
+        !reasm
+            .findings()
+            .iter()
+            .any(|f| f.summary.contains("Excessive segment overlaps")),
+        "exactly the threshold count must stay silent (the test is `>`, not `>=`)"
     );
 }
 


### PR DESCRIPTION
## Summary
Closes the three process-gap deferrals the 3-pass adversarial review of the snaplen / small-segment sub-cycle logged in STATE.md (drift items 6–8).

- **Drift 6** — the reassembly threshold flags accepted any value, so an operator could silently configure a nonsensical detector (`--small-segment-max-bytes 100000` makes *every* TCP segment "small"). The flags now carry clap `value_parser` ranges enforced at parse time, matching the Snort ranges the config field docs already cite: `--overlap-threshold` 0–255, `--small-segment-threshold` 0–2048, `--small-segment-max-bytes` 0–2048. `small_segment_max_bytes` is now `u16`. `--out-of-window-threshold` stays unbounded — no NIDS prior art gives it a defensible ceiling.
- **Drift 7** — the threshold-boundary test pattern existed only for the small-segment detector. Added exactly-threshold negative tests for the overlap and out-of-window detectors, so a `>` → `>=` regression is caught for all three.
- **Drift 8** — documented (in `Cargo.toml` and `src/decoder.rs`) that the decoder's strict→lax `SliceError::Len` discrimination is coupled to the etherparse 0.16 API. `"0.16"` already excludes 0.17 via Cargo's caret semantics; the IPv6 / corrupt-packet tests act as contract tests for a future bump.

The Snort range values (overlap_limit 0–255, small_segments 0–2048) were established by the earlier P2.05 research dispatches and are already cited in the config field docs — this PR enforces what the docs already document.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --all-targets` — all green. New: out-of-range threshold flag values are rejected at parse time; overlap and out-of-window exactly-threshold runs stay silent.