### PR TITLE
chore: close P3 divergence-doc lessons P3.01 and P3.02

### DIFF
--- a/src/reassembly/mod.rs
+++ b/src/reassembly/mod.rs
@@ -58,6 +58,15 @@ const MAX_FINDINGS: usize = 10_000;
 // (`ReassemblyConfig::*_alert_threshold`, see `config.rs`) so they can
 // be tuned via the CLI — LESSON-P2.05.
 
+/// Plural suffix for a count: `""` for exactly one, `"s"` otherwise.
+///
+/// LESSON-P3.02: extracted from the inline ternary that formatted the
+/// segment-limit summary finding, giving the pluralization form one
+/// named home for any future count-bearing message to reuse.
+fn plural_s(count: u64) -> &'static str {
+    if count == 1 { "" } else { "s" }
+}
+
 static FINALIZE_SKIPPED_WARNED: AtomicBool = AtomicBool::new(false);
 
 /// TCP header fields extracted from a packet.
@@ -566,9 +575,8 @@ impl TcpReassembler {
                 verdict: Verdict::Inconclusive,
                 confidence: Confidence::Medium,
                 summary: format!(
-                    "{} segment{} dropped due to per-flow segment count limit",
-                    count,
-                    if count == 1 { "" } else { "s" }
+                    "{count} segment{} dropped due to per-flow segment count limit",
+                    plural_s(count),
                 ),
                 evidence: vec![
                     "Segment count limit prevents BTreeMap overhead explosion".into(),

--- a/src/summary.rs
+++ b/src/summary.rs
@@ -22,6 +22,18 @@ pub struct Summary {
     pub skipped_packets: u64,
     hosts: HashSet<IpAddr>,
     protocols: HashMap<Protocol, u64>,
+    /// Inferred service distribution, keyed by service name.
+    ///
+    /// LESSON-P3.01 — known divergence: this map is **port-based**. It
+    /// is built from [`ParsedPacket::app_protocol_hint`], which infers a
+    /// service purely from the TCP/UDP port tuple (53→DNS, 80→HTTP,
+    /// 443→TLS, 22→SSH, ...). The stream dispatcher (ADR 0001) is, by
+    /// contrast, **content-first**: it identifies a protocol from the
+    /// reassembled bytes regardless of port. The two can therefore
+    /// disagree — e.g. HTTP served on port 8080 contributes nothing
+    /// here (8080 is not a known port hint) yet is dispatched as HTTP
+    /// by content. Treat `services` as a cheap port-based triage
+    /// estimate, not an authoritative classification.
     services: HashMap<String, u64>,
 }
 


### PR DESCRIPTION
## Summary
Two deferred P3 cosmetic lessons from the Phase C brownfield-ingest synthesis:

- **P3.01** — documented the known divergence on `Summary.services`: it is a *port-based* service estimate (built from `ParsedPacket::app_protocol_hint`, which keys purely on the TCP/UDP port tuple), whereas the stream dispatcher (ADR 0001) is *content-first*. The two can legitimately disagree — e.g. HTTP served on port 8080 contributes nothing to `services` but is dispatched as HTTP by content. The field doc now states this so the map isn't mistaken for an authoritative classification.
- **P3.02** — extracted the inline `if count == 1 { "" } else { "s" }` pluralization ternary (in the segment-limit summary finding) into a named `plural_s` helper, giving the pluralization form one documented home.

Docs + a behavior-preserving refactor only — covered by existing tests.

## P3.06 note
The third deferred P3 item (P3.06 — widen branch-naming patterns in `CLAUDE.md`) is **not** included: `CLAUDE.md` is currently untracked in the repo, so the change cannot land in version control without first deciding whether to commit `CLAUDE.md`. Flagged for a separate decision.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --all-targets` — all green (282 tests; no new tests — refactor is behavior-preserving and covered by the existing segment-limit finding tests).