### PR TITLE
docs: require research-agent validation for deferred findings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,10 @@ CI sets `RUSTFLAGS=-Dwarnings`. `rustfmt.toml` pins edition 2024, `max_width = 1
 - **Semantic PR titles enforced via CI** (`amannn/action-semantic-pull-request`). Allowed types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert`. Scope is optional.
 - No local commit hooks (no lefthook/husky/commitlint config) — enforcement is CI-side only.
 
+## Deferred Findings
+
+Deferred or open findings — STATE.md Drift Items, spec contradictions, and review/adversarial backlog items — MUST be validated by the research agent (`vsdd-factory:research-agent`) before being filed as GitHub issues. No issue is created from an unvalidated finding. The canonical, machine-enforced version of this rule is policy `DF-VALIDATION-001` in `.factory/policies.yaml`.
+
 ## Project References
 
 | Path | Purpose |


### PR DESCRIPTION
## Summary

- Adds a **Deferred Findings** section to `CLAUDE.md` (between "Git Workflow" and "Project References").
- The section states that all deferred or open findings (STATE.md Drift Items, spec contradictions, review/adversarial backlog items) must be validated by `vsdd-factory:research-agent` before a GitHub issue is created.
- This mirrors the machine-enforced policy `DF-VALIDATION-001` in `.factory/policies.yaml`, making the rule visible to every contributor who reads `CLAUDE.md`.

## Test plan

- [ ] Docs-only change — no source, test, or config files modified.
- [ ] CI fmt, clippy, and test jobs are unaffected.
- [ ] Verify the new section renders correctly in the GitHub UI.