### PR TITLE
test(decoder): add BC-2.02.010..013 behavioral-contract tests (STORY-004)

### DIFF
--- a/tests/bc_2_02_story004_tests.rs
+++ b/tests/bc_2_02_story004_tests.rs
@@ -1,0 +1,706 @@
+//! STORY-004 Phase 3 TDD — Packet Decoding: ICMP, Protocol::Other, app_protocol_hint
+//!
+//! Formalizes behavioral contracts BC-2.02.010 through BC-2.02.013.
+//! Strategy: brownfield-formalization. Every test maps to an AC or edge-case
+//! from STORY-004.md and a clause from the named BC.
+//!
+//! On the first run these are expected to PASS because the implementation
+//! in `src/decoder.rs` already satisfies the BCs. Any failure indicates a
+//! real gap that the implementer must close.
+//!
+//! Test naming convention: test_BC_S_SS_NNN_<assertion>()
+//!
+//! The BC-based naming pattern uses uppercase letters (BC-S.SS.NNN) which
+//! violates Rust's snake_case convention. `#![allow(non_snake_case)]` is
+//! necessary to satisfy both the factory naming mandate and CI's `-D warnings`.
+#![allow(non_snake_case)]
+
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+
+use pcap_file::DataLink;
+use wirerust::decoder::{ParsedPacket, Protocol, TransportInfo, decode_packet};
+
+// ---------------------------------------------------------------------------
+// Frame-building helpers
+//
+// Each helper builds a minimal but legally-parseable frame at the Ethernet or
+// raw-IP layer. Checksums are zeroed (etherparse does not validate them by
+// default for the strict or lax slicers).
+// ---------------------------------------------------------------------------
+
+/// ICMPv4 echo-request frame over Ethernet with a non-empty echo data section.
+///
+/// Layout:
+///   Ethernet  (14 bytes): dst-mac, src-mac, EtherType=0x0800
+///   IPv4      (20 bytes): IHL=5, proto=0x01 (ICMP), total_length=36
+///   ICMPv4    (8 bytes):  type=8 (echo-request), code=0, checksum=0, id=1, seq=1
+///   echo data (8 bytes):  classic timestamp/pattern payload (0x01..0x08)
+///
+/// The 8-byte echo body is present so that `pkt.payload.is_empty()` genuinely
+/// tests BC-2.02.010 invariant 3 ("ICMP body bytes are NOT included in
+/// ParsedPacket.payload") rather than being vacuously true because the frame
+/// carried no body at all.
+fn make_icmpv4_echo_request_eth() -> Vec<u8> {
+    vec![
+        // Ethernet header (14 bytes)
+        0xff, 0xff, 0xff, 0xff, 0xff, 0xff, // dst mac (broadcast)
+        0x00, 0x11, 0x22, 0x33, 0x44, 0x55, // src mac
+        0x08, 0x00, // EtherType: IPv4
+        // IPv4 header (20 bytes)
+        0x45, // version=4, IHL=5
+        0x00, // DSCP / ECN
+        0x00, 0x24, // total_length = 36 (20 IP + 8 ICMP header + 8 echo data)
+        0x00, 0x01, // identification
+        0x00, 0x00, // flags / fragment offset
+        0x40, // TTL = 64
+        0x01, // protocol = 1 (ICMP)
+        0x00, 0x00, // header checksum (zeroed; not validated by etherparse)
+        0xc0, 0xa8, 0x01, 0x01, // src: 192.168.1.1
+        0xc0, 0xa8, 0x01, 0x02, // dst: 192.168.1.2
+        // ICMPv4 echo-request header (8 bytes): type=8, code=0
+        0x08, // type: echo-request
+        0x00, // code: 0
+        0x00, 0x00, // checksum (zeroed)
+        0x00, 0x01, // identifier = 1
+        0x00, 0x01, // sequence number = 1
+        // echo data (8 bytes): classic timestamp/pattern bytes
+        0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+    ]
+}
+
+/// Minimal ICMPv4 echo-reply frame over Ethernet.
+///
+/// Identical to the echo-request except ICMP type=0 (echo-reply).
+fn make_icmpv4_echo_reply_eth() -> Vec<u8> {
+    let mut pkt = make_icmpv4_echo_request_eth();
+    // ICMP type byte is at offset 34 (14 Ethernet + 20 IPv4)
+    pkt[34] = 0x00; // type: echo-reply
+    pkt
+}
+
+/// ICMPv6 echo-request frame as a raw IPv6 packet (DataLink::IPV6) with a
+/// non-empty echo data section.
+///
+/// Layout:
+///   IPv6      (40 bytes): next-header=0x3A (58 = ICMPv6), payload_length=16
+///   ICMPv6    (8 bytes):  type=128 (echo-request), code=0, checksum=0, id=1, seq=1
+///   echo data (8 bytes):  classic timestamp/pattern payload (0x01..0x08)
+///
+/// The 8-byte echo body is present so that `pkt.payload.is_empty()` genuinely
+/// tests BC-2.02.010 invariant 3 ("ICMP body bytes are NOT included in
+/// ParsedPacket.payload") rather than being vacuously true.
+fn make_icmpv6_echo_request_raw() -> Vec<u8> {
+    vec![
+        // IPv6 header (40 bytes)
+        0x60, 0x00, 0x00, 0x00, // version=6, traffic-class=0, flow-label=0
+        0x00, 0x10, // payload_length = 16 (8 ICMPv6 header + 8 echo data)
+        0x3a, // next_header = 58 (ICMPv6)
+        0x40, // hop_limit = 64
+        // src: 2001:db8::1
+        0x20, 0x01, 0x0d, 0xb8, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x01, // dst: 2001:db8::2
+        0x20, 0x01, 0x0d, 0xb8, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x02,
+        // ICMPv6 echo-request header (8 bytes): type=128, code=0
+        0x80, // type: 128 (echo-request)
+        0x00, // code: 0
+        0x00, 0x00, // checksum (zeroed)
+        0x00, 0x01, // identifier = 1
+        0x00, 0x01, // sequence number = 1
+        // echo data (8 bytes): classic timestamp/pattern bytes
+        0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+    ]
+}
+
+/// Minimal ICMPv6 neighbor-solicitation frame as a raw IPv6 packet (DataLink::IPV6).
+///
+/// Type=135 (neighbor solicitation), code=0.
+fn make_icmpv6_neighbor_solicitation_raw() -> Vec<u8> {
+    let mut pkt = make_icmpv6_echo_request_raw();
+    // ICMPv6 type is at offset 40 (40-byte IPv6 header)
+    pkt[40] = 0x87; // type: 135 (neighbor solicitation)
+    pkt
+}
+
+/// GRE (IP protocol 47) frame over Ethernet with a non-empty protocol body.
+///
+/// Layout:
+///   Ethernet    (14 bytes): EtherType=0x0800
+///   IPv4        (20 bytes): proto=0x2F (47 = GRE), total_length=28
+///   GRE header  (4 bytes):  minimal header (flags=0, protocol-type=0)
+///   GRE payload (4 bytes):  arbitrary encapsulated-protocol body bytes
+///
+/// The 4-byte body is present so that `pkt.payload.is_empty()` genuinely
+/// tests BC-2.02.011 PC3 ("payload is Vec::new()") rather than being
+/// vacuously true because the frame carried no body at all.
+fn make_gre_eth() -> Vec<u8> {
+    vec![
+        // Ethernet header (14 bytes)
+        0xff, 0xff, 0xff, 0xff, 0xff, 0xff, // dst mac
+        0x00, 0x11, 0x22, 0x33, 0x44, 0x55, // src mac
+        0x08, 0x00, // EtherType: IPv4
+        // IPv4 header (20 bytes)
+        0x45, // version=4, IHL=5
+        0x00, // DSCP / ECN
+        0x00, 0x1c, // total_length = 28 (20 IP + 4 GRE header + 4 body)
+        0x00, 0x02, // identification
+        0x00, 0x00, // flags / fragment offset
+        0x40, // TTL = 64
+        0x2f, // protocol = 47 (GRE)
+        0x00, 0x00, // header checksum (zeroed)
+        0x0a, 0x00, 0x00, 0x01, // src: 10.0.0.1
+        0x0a, 0x00, 0x00, 0x02, // dst: 10.0.0.2
+        // GRE header (4 bytes): flags=0, protocol-type=0
+        0x00, 0x00, // flags and version
+        0x00, 0x00, // protocol type
+        // GRE payload body (4 bytes): arbitrary encapsulated bytes
+        0xde, 0xad, 0xbe, 0xef,
+    ]
+}
+
+/// ESP (IP protocol 50) frame over Ethernet with a non-empty ciphertext body.
+///
+/// Layout:
+///   Ethernet      (14 bytes): EtherType=0x0800
+///   IPv4          (20 bytes): proto=0x32 (50 = ESP), total_length=28
+///   ESP SPI       (4 bytes):  Security Parameter Index
+///   ESP ciphertext (4 bytes): arbitrary encrypted-payload body bytes
+///
+/// The 4-byte ciphertext body is present so that `pkt.payload.is_empty()`
+/// genuinely tests BC-2.02.011 PC3 ("payload is Vec::new()") rather than
+/// being vacuously true because the frame carried no body at all.
+fn make_esp_eth() -> Vec<u8> {
+    vec![
+        // Ethernet header (14 bytes)
+        0xff, 0xff, 0xff, 0xff, 0xff, 0xff, // dst mac
+        0x00, 0x11, 0x22, 0x33, 0x44, 0x55, // src mac
+        0x08, 0x00, // EtherType: IPv4
+        // IPv4 header (20 bytes)
+        0x45, // version=4, IHL=5
+        0x00, // DSCP / ECN
+        0x00, 0x1c, // total_length = 28 (20 IP + 4 ESP SPI + 4 ciphertext)
+        0x00, 0x03, // identification
+        0x00, 0x00, // flags / fragment offset
+        0x40, // TTL = 64
+        0x32, // protocol = 50 (ESP)
+        0x00, 0x00, // header checksum (zeroed)
+        0x0a, 0x00, 0x00, 0x01, // src: 10.0.0.1
+        0x0a, 0x00, 0x00, 0x02, // dst: 10.0.0.2
+        // ESP SPI (4 bytes)
+        0x00, 0x00, 0x00, 0x01,
+        // ESP ciphertext body (4 bytes): arbitrary encrypted bytes
+        0xca, 0xfe, 0xba, 0xbe,
+    ]
+}
+
+/// Build a `ParsedPacket` directly with a TCP transport carrying the given
+/// src/dst ports. Used for app_protocol_hint port-table tests where we want
+/// to bypass the byte-level decode and exercise the hint logic in isolation.
+fn tcp_packet_with_ports(src_port: u16, dst_port: u16) -> ParsedPacket {
+    ParsedPacket {
+        src_ip: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+        dst_ip: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)),
+        protocol: Protocol::Tcp,
+        transport: TransportInfo::Tcp {
+            src_port,
+            dst_port,
+            seq_number: 0,
+            syn: false,
+            ack: false,
+            fin: false,
+            rst: false,
+        },
+        payload: Vec::new(),
+        packet_len: 54,
+    }
+}
+
+/// Build a `ParsedPacket` directly with a UDP transport carrying the given
+/// src/dst ports.
+fn udp_packet_with_ports(src_port: u16, dst_port: u16) -> ParsedPacket {
+    ParsedPacket {
+        src_ip: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+        dst_ip: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)),
+        protocol: Protocol::Udp,
+        transport: TransportInfo::Udp { src_port, dst_port },
+        payload: Vec::new(),
+        packet_len: 42,
+    }
+}
+
+/// Build a `ParsedPacket` with `TransportInfo::None` (ICMP / Other).
+fn none_transport_packet(protocol: Protocol) -> ParsedPacket {
+    ParsedPacket {
+        src_ip: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+        dst_ip: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)),
+        protocol,
+        transport: TransportInfo::None,
+        payload: Vec::new(),
+        packet_len: 42,
+    }
+}
+
+// ===========================================================================
+// AC-001 — BC-2.02.010 postcondition 1
+//
+// An IPv4 ICMP echo-request frame decoded via decode_packet produces
+// ParsedPacket { protocol: Protocol::Icmp, transport: TransportInfo::None, payload: [] }.
+// ===========================================================================
+#[test]
+fn test_BC_2_02_010_icmpv4_protocol_icmp() {
+    let data = make_icmpv4_echo_request_eth();
+    let pkt = decode_packet(&data, DataLink::ETHERNET)
+        .expect("ICMPv4 echo-request Ethernet frame must decode successfully");
+
+    assert_eq!(
+        pkt.protocol,
+        Protocol::Icmp,
+        "BC-2.02.010 PC1: ICMPv4 must produce Protocol::Icmp"
+    );
+    assert!(
+        matches!(pkt.transport, TransportInfo::None),
+        "BC-2.02.010 PC2: ICMPv4 must produce TransportInfo::None"
+    );
+    assert!(
+        pkt.payload.is_empty(),
+        "BC-2.02.010 PC3: ICMP payload must be empty Vec"
+    );
+    assert_eq!(
+        pkt.src_ip,
+        IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1)),
+        "src IP must be preserved"
+    );
+    assert_eq!(
+        pkt.dst_ip,
+        IpAddr::V4(Ipv4Addr::new(192, 168, 1, 2)),
+        "dst IP must be preserved"
+    );
+}
+
+// ===========================================================================
+// AC-002 — BC-2.02.010 invariant 1
+//
+// Both ICMPv4 (IP protocol 1) and ICMPv6 (IP protocol 58) produce
+// Protocol::Icmp — there is no Protocol::Icmpv6 variant.
+// ===========================================================================
+#[test]
+fn test_BC_2_02_010_icmpv4_and_icmpv6_both_produce_protocol_icmp() {
+    // ICMPv4 over Ethernet
+    let icmpv4_data = make_icmpv4_echo_request_eth();
+    let icmpv4_pkt =
+        decode_packet(&icmpv4_data, DataLink::ETHERNET).expect("ICMPv4 frame must decode");
+
+    assert_eq!(
+        icmpv4_pkt.protocol,
+        Protocol::Icmp,
+        "BC-2.02.010 invariant 1: ICMPv4 must map to Protocol::Icmp"
+    );
+    assert!(matches!(icmpv4_pkt.transport, TransportInfo::None));
+
+    // ICMPv6 over raw IPv6
+    let icmpv6_data = make_icmpv6_echo_request_raw();
+    let icmpv6_pkt = decode_packet(&icmpv6_data, DataLink::IPV6).expect("ICMPv6 frame must decode");
+
+    assert_eq!(
+        icmpv6_pkt.protocol,
+        Protocol::Icmp,
+        "BC-2.02.010 invariant 1: ICMPv6 must also map to Protocol::Icmp (no separate Icmpv6 variant)"
+    );
+    assert!(
+        matches!(icmpv6_pkt.transport, TransportInfo::None),
+        "ICMPv6 must also produce TransportInfo::None"
+    );
+
+    // Confirm both resolve to the same discriminant (compile-time evidence that
+    // Icmpv6 is not a separate variant)
+    assert_eq!(icmpv4_pkt.protocol, icmpv6_pkt.protocol);
+}
+
+// ===========================================================================
+// AC-003 — BC-2.02.010 postcondition 4
+//
+// app_protocol_hint() on an ICMP ParsedPacket (with TransportInfo::None)
+// returns None.
+// ===========================================================================
+#[test]
+fn test_BC_2_02_010_icmp_app_protocol_hint_none() {
+    let data = make_icmpv4_echo_request_eth();
+    let pkt = decode_packet(&data, DataLink::ETHERNET).expect("ICMPv4 frame must decode");
+
+    assert!(
+        matches!(pkt.transport, TransportInfo::None),
+        "pre-condition: ICMP packet must have TransportInfo::None"
+    );
+    assert_eq!(
+        pkt.app_protocol_hint(),
+        None,
+        "BC-2.02.010 PC4: app_protocol_hint must return None for ICMP"
+    );
+}
+
+// ===========================================================================
+// AC-004 — BC-2.02.011 postcondition 1
+//
+// A packet with IP protocol 47 (GRE) produces
+// ParsedPacket { protocol: Protocol::Other(47), transport: TransportInfo::None, payload: [] }.
+// ===========================================================================
+#[test]
+fn test_BC_2_02_011_gre_protocol_other() {
+    let data = make_gre_eth();
+    let pkt = decode_packet(&data, DataLink::ETHERNET)
+        .expect("GRE Ethernet frame must decode successfully");
+
+    assert_eq!(
+        pkt.protocol,
+        Protocol::Other(47),
+        "BC-2.02.011 PC1: GRE (IP proto 47) must produce Protocol::Other(47)"
+    );
+    assert!(
+        matches!(pkt.transport, TransportInfo::None),
+        "BC-2.02.011 PC2: GRE packet must produce TransportInfo::None"
+    );
+    assert!(
+        pkt.payload.is_empty(),
+        "BC-2.02.011 PC3: GRE packet payload must be empty Vec"
+    );
+    assert_eq!(
+        pkt.src_ip,
+        IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+        "BC-2.02.011 PC5: src IP must still be preserved for Other packets"
+    );
+    assert_eq!(
+        pkt.dst_ip,
+        IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)),
+        "BC-2.02.011 PC5: dst IP must still be preserved for Other packets"
+    );
+}
+
+// ===========================================================================
+// AC-005 — BC-2.02.011 invariant 1
+//
+// Protocol::Other(u8) preserves the raw IP protocol byte.
+// GRE (proto 47) => Other(47); ESP (proto 50) => Other(50).
+// ===========================================================================
+#[test]
+fn test_BC_2_02_011_protocol_other_preserves_byte() {
+    let gre_data = make_gre_eth();
+    let gre_pkt = decode_packet(&gre_data, DataLink::ETHERNET).expect("GRE frame must decode");
+    assert_eq!(
+        gre_pkt.protocol,
+        Protocol::Other(47),
+        "GRE (proto 47) must produce Other(47)"
+    );
+
+    let esp_data = make_esp_eth();
+    let esp_pkt = decode_packet(&esp_data, DataLink::ETHERNET).expect("ESP frame must decode");
+    assert_eq!(
+        esp_pkt.protocol,
+        Protocol::Other(50),
+        "ESP (proto 50) must produce Other(50)"
+    );
+}
+
+// ===========================================================================
+// AC-006 — BC-2.02.012 postcondition 3
+//
+// app_protocol_hint() returns the correct service string for all 7 recognized
+// ports (tested once as src-port and once as dst-port for each service).
+// ===========================================================================
+#[test]
+fn test_BC_2_02_012_app_protocol_hint_all_seven_ports() {
+    // Each entry: (src_port, dst_port, expected_hint)
+    // The "src wins" sub-case uses a well-known port as src and an unknown port
+    // as dst; the "dst wins" sub-case uses an unknown src and the known port as dst.
+    let cases: &[(u16, u16, &str)] = &[
+        // DNS (53)
+        (53, 9999, "DNS"),
+        (9999, 53, "DNS"),
+        // HTTP (80)
+        (80, 9999, "HTTP"),
+        (9999, 80, "HTTP"),
+        // TLS (443)
+        (443, 9999, "TLS"),
+        (9999, 443, "TLS"),
+        // SSH (22)
+        (22, 9999, "SSH"),
+        (9999, 22, "SSH"),
+        // SMB (445)
+        (445, 9999, "SMB"),
+        (9999, 445, "SMB"),
+        // Modbus (502)
+        (502, 9999, "Modbus"),
+        (9999, 502, "Modbus"),
+        // DNP3 (20000)
+        (20000, 9999, "DNP3"),
+        (9999, 20000, "DNP3"),
+    ];
+
+    for (src_port, dst_port, expected) in cases {
+        // TCP variant
+        let tcp_pkt = tcp_packet_with_ports(*src_port, *dst_port);
+        assert_eq!(
+            tcp_pkt.app_protocol_hint(),
+            Some(*expected),
+            "BC-2.02.012 PC3 [TCP src={src_port} dst={dst_port}]: expected Some({expected:?})"
+        );
+
+        // UDP variant — same port table must apply for UDP
+        let udp_pkt = udp_packet_with_ports(*src_port, *dst_port);
+        assert_eq!(
+            udp_pkt.app_protocol_hint(),
+            Some(*expected),
+            "BC-2.02.012 PC3 [UDP src={src_port} dst={dst_port}]: expected Some({expected:?})"
+        );
+    }
+}
+
+// ===========================================================================
+// AC-007 — BC-2.02.012 postcondition 2
+//
+// app_protocol_hint() returns None for any port not in the 7-entry table.
+// ===========================================================================
+#[test]
+fn test_BC_2_02_012_app_protocol_hint_unknown_port_returns_none() {
+    let pkt = tcp_packet_with_ports(9999, 8080);
+    assert_eq!(
+        pkt.app_protocol_hint(),
+        None,
+        "BC-2.02.012 PC2: unknown ports must return None"
+    );
+
+    // Also verify a UDP packet with unrecognized ports returns None
+    let udp_pkt = udp_packet_with_ports(5555, 5555);
+    assert_eq!(
+        udp_pkt.app_protocol_hint(),
+        None,
+        "BC-2.02.012 EC-004: src=5555, dst=5555 must return None"
+    );
+}
+
+// ===========================================================================
+// AC-008 — BC-2.02.012 postcondition 4
+//
+// When both src and dst ports are known but different (src=80, dst=443),
+// the first matching match arm wins: Some("HTTP") is returned (80 arm fires
+// before 443 arm).
+// ===========================================================================
+#[test]
+fn test_BC_2_02_012_app_protocol_hint_match_order() {
+    // src=80 (HTTP), dst=443 (TLS) — HTTP arm must win
+    let pkt = tcp_packet_with_ports(80, 443);
+    assert_eq!(
+        pkt.app_protocol_hint(),
+        Some("HTTP"),
+        "BC-2.02.012 PC4 / EC-003: src=80, dst=443 must return Some(\"HTTP\") \
+         because the 80 arm precedes the 443 arm in match order"
+    );
+}
+
+// ===========================================================================
+// BC-2.02.012 postcondition 4 — non-adjacent arm ordering (MINOR-1 pin)
+//
+// When src=53 (DNS, arm 1) and dst=502 (Modbus, arm 6) both match, the DNS
+// arm fires first and returns Some("DNS"). A regression that reordered the
+// Modbus arm above the DNS arm would flip this result to Some("Modbus") and
+// be caught here. This pins a second independent point of the match-order
+// ordering beyond the adjacent 80/443 pair exercised in AC-008.
+// ===========================================================================
+#[test]
+fn test_BC_2_02_012_app_protocol_hint_match_order_dns_beats_modbus() {
+    // src=53 (DNS, arm 1), dst=502 (Modbus, arm 6) — DNS arm must win
+    let pkt = tcp_packet_with_ports(53, 502);
+    assert_eq!(
+        pkt.app_protocol_hint(),
+        Some("DNS"),
+        "BC-2.02.012 PC4: src=53, dst=502 must return Some(\"DNS\") \
+         because the DNS arm (arm 1) precedes the Modbus arm (arm 6)"
+    );
+}
+
+// ===========================================================================
+// AC-009 — BC-2.02.013 postcondition 1
+//
+// app_protocol_hint() returns None immediately when transport = TransportInfo::None,
+// without consulting the port table.
+// ===========================================================================
+#[test]
+fn test_BC_2_02_013_transport_none_returns_none_hint() {
+    // Direct construction (BC-2.02.013 EC-003 canonical test vector)
+    let pkt = none_transport_packet(Protocol::Icmp);
+    assert_eq!(
+        pkt.app_protocol_hint(),
+        None,
+        "BC-2.02.013 PC1: TransportInfo::None must always return None from app_protocol_hint"
+    );
+
+    // Also verify for a Protocol::Other packet
+    let other_pkt = none_transport_packet(Protocol::Other(47));
+    assert_eq!(
+        other_pkt.app_protocol_hint(),
+        None,
+        "BC-2.02.013 PC1: Protocol::Other with TransportInfo::None must also return None"
+    );
+}
+
+// ===========================================================================
+// EC-001 — STORY-004 edge cases + BC-2.02.010 EC-002
+//
+// ICMPv4 echo reply (type 0) produces Protocol::Icmp, TransportInfo::None.
+// ===========================================================================
+#[test]
+fn test_BC_2_02_010_EC_001_icmpv4_echo_reply_protocol_icmp() {
+    let data = make_icmpv4_echo_reply_eth();
+    let pkt =
+        decode_packet(&data, DataLink::ETHERNET).expect("ICMPv4 echo-reply frame must decode");
+
+    assert_eq!(pkt.protocol, Protocol::Icmp);
+    assert!(matches!(pkt.transport, TransportInfo::None));
+    assert!(pkt.payload.is_empty());
+}
+
+// ===========================================================================
+// EC-002 — STORY-004 edge cases + BC-2.02.010 EC-003
+//
+// ICMPv6 neighbor solicitation (type 135) produces Protocol::Icmp,
+// TransportInfo::None. The src IP is IPv6.
+// ===========================================================================
+#[test]
+fn test_BC_2_02_010_EC_002_icmpv6_neighbor_solicitation_protocol_icmp() {
+    let data = make_icmpv6_neighbor_solicitation_raw();
+    let pkt = decode_packet(&data, DataLink::IPV6)
+        .expect("ICMPv6 neighbor-solicitation frame must decode");
+
+    assert_eq!(
+        pkt.protocol,
+        Protocol::Icmp,
+        "ICMPv6 type 135 must produce Protocol::Icmp"
+    );
+    assert!(matches!(pkt.transport, TransportInfo::None));
+    assert!(pkt.payload.is_empty());
+    // BC-2.02.010 EC-004: src IP is V6
+    assert!(
+        matches!(pkt.src_ip, IpAddr::V6(_)),
+        "ICMPv6 packet must carry IPv6 src address"
+    );
+    assert_eq!(
+        pkt.src_ip,
+        IpAddr::V6(Ipv6Addr::new(0x2001, 0x0db8, 0, 0, 0, 0, 0, 1))
+    );
+}
+
+// ===========================================================================
+// EC-003 — STORY-004 edge cases + BC-2.02.011 EC-001
+//
+// GRE (proto 47) produces Protocol::Other(47), TransportInfo::None.
+// (Duplicate of AC-004, here as a named edge-case anchor per the story spec.)
+// ===========================================================================
+#[test]
+fn test_BC_2_02_011_EC_003_gre_protocol_other_47() {
+    let data = make_gre_eth();
+    let pkt = decode_packet(&data, DataLink::ETHERNET).expect("GRE frame must decode");
+
+    assert_eq!(pkt.protocol, Protocol::Other(47));
+    assert!(matches!(pkt.transport, TransportInfo::None));
+}
+
+// ===========================================================================
+// EC-004 — STORY-004 edge cases + BC-2.02.011 EC-002
+//
+// ESP (proto 50) produces Protocol::Other(50), TransportInfo::None.
+// (Duplicate of AC-005's ESP sub-case, here as a named edge-case anchor.)
+// ===========================================================================
+#[test]
+fn test_BC_2_02_011_EC_004_esp_protocol_other_50() {
+    let data = make_esp_eth();
+    let pkt = decode_packet(&data, DataLink::ETHERNET).expect("ESP frame must decode");
+
+    assert_eq!(pkt.protocol, Protocol::Other(50));
+    assert!(matches!(pkt.transport, TransportInfo::None));
+}
+
+// ===========================================================================
+// EC-005 — STORY-004 edge cases + BC-2.02.012 EC-001
+//
+// src=53, dst=9999 => app_protocol_hint() returns Some("DNS").
+// ===========================================================================
+#[test]
+fn test_BC_2_02_012_EC_005_src_53_dst_unknown_returns_dns() {
+    let pkt = udp_packet_with_ports(53, 9999);
+    assert_eq!(
+        pkt.app_protocol_hint(),
+        Some("DNS"),
+        "BC-2.02.012 EC-001: src=53, dst=9999 must return Some(\"DNS\")"
+    );
+}
+
+// ===========================================================================
+// EC-006 — STORY-004 edge cases + BC-2.02.012 EC-002
+//
+// src=9999, dst=53 => app_protocol_hint() returns Some("DNS").
+// ===========================================================================
+#[test]
+fn test_BC_2_02_012_EC_006_src_unknown_dst_53_returns_dns() {
+    let pkt = udp_packet_with_ports(9999, 53);
+    assert_eq!(
+        pkt.app_protocol_hint(),
+        Some("DNS"),
+        "BC-2.02.012 EC-002: src=9999, dst=53 must return Some(\"DNS\")"
+    );
+}
+
+// ===========================================================================
+// EC-007 — STORY-004 edge cases + BC-2.02.012 EC-003 (complement direction)
+//
+// src=443, dst=80 => Some("HTTP").
+//
+// AC-008 already covers src=80, dst=443 (the (80, _) arm fires on src).
+// This test exercises the complement: src=443 (TLS), dst=80 (HTTP). The match
+// evaluates arm 2 as `(80, _) | (_, 80)`: the first alternative `(80, _)`
+// fails (src=443 ≠ 80), but the second `(_, 80)` succeeds (dst=80). So arm 2
+// still fires and returns Some("HTTP"), confirming that the 80 arm beats the
+// 443 arm regardless of which side carries which port number.
+// ===========================================================================
+#[test]
+fn test_BC_2_02_012_EC_007_src_443_dst_80_match_order_http_still_wins() {
+    let pkt = tcp_packet_with_ports(443, 80);
+    assert_eq!(
+        pkt.app_protocol_hint(),
+        Some("HTTP"),
+        "BC-2.02.012 EC-003 complement: src=443, dst=80 must return Some(\"HTTP\") \
+         because the (_, 80) alternative of the 80 arm fires before the 443 arm"
+    );
+}
+
+// ===========================================================================
+// EC-008 — STORY-004 edge cases + BC-2.02.013 invariant 1
+//
+// TransportInfo::None with any IP protocol => app_protocol_hint() always None.
+// ===========================================================================
+#[test]
+fn test_BC_2_02_013_EC_008_transport_none_always_none_for_any_protocol() {
+    let protocols = [
+        Protocol::Icmp,
+        Protocol::Other(47),
+        Protocol::Other(50),
+        Protocol::Other(0),
+        Protocol::Other(255),
+        // Defense-in-depth: Protocol::Tcp/Udp paired with TransportInfo::None is an
+        // unreachable synthetic state in the real decoder (a truncated TCP transport
+        // header decodes to Protocol::Other(6), not Protocol::Tcp — see BC-2.02.011
+        // EC-003). These entries confirm that app_protocol_hint reads only
+        // self.transport, so even a hypothetical Protocol/transport mismatch yields
+        // None rather than attempting a port lookup on a missing transport.
+        Protocol::Tcp,
+        Protocol::Udp,
+    ];
+
+    for proto in &protocols {
+        let pkt = none_transport_packet(*proto);
+        assert_eq!(
+            pkt.app_protocol_hint(),
+            None,
+            "BC-2.02.013 invariant 1: TransportInfo::None must always return None \
+             regardless of Protocol variant (got non-None for {proto:?})"
+        );
+    }
+}


### PR DESCRIPTION
# [STORY-004] Packet Decoding — ICMP, Protocol::Other, and app_protocol_hint Port Table

**Epic:** E-1 — Packet Decoding
**Mode:** brownfield-formalization
**Convergence:** CONVERGED after 6 adversarial passes (3 consecutive clean: passes 4, 5, 6)

![Tests](https://img.shields.io/badge/tests-18%2F18-brightgreen)
![Coverage](https://img.shields.io/badge/coverage-100%25_new_paths-brightgreen)
![Adversarial](https://img.shields.io/badge/adversarial-6_passes_3_clean-green)
![Demo](https://img.shields.io/badge/demo-9%2F9_ACs-blue)

This PR formalizes the behavioral contracts for three decoder subsystems that existed but
lacked regression tests: ICMP classification (BC-2.02.010), unknown-protocol passthrough via
`Protocol::Other(u8)` (BC-2.02.011), and the `app_protocol_hint` port-table lookup
(BC-2.02.012/013). The sole code change is a new test file — no `src/` files are modified.
The 18 tests serve as a permanent regression barrier, pinning match-order behavior (HTTP arm
before TLS arm, DNS arm before Modbus arm) and the early-return invariant for
`TransportInfo::None`.

---

## Architecture Changes

```mermaid
graph TD
    TestFile["tests/bc_2_02_story004_tests.rs<br/>(NEW — test only)"]
    Decoder["src/decoder.rs<br/>(existing, unchanged)"]
    TestFile -.->|verifies| Decoder
    style TestFile fill:#90EE90
```

<details>
<summary><strong>Architecture Decision Record</strong></summary>

### ADR: Brownfield Formalization — Test-Only PR

**Context:** The `decode_packet` function already handled ICMP, GRE, ESP and other unknown IP
protocols correctly, but no test exercised these paths. The `app_protocol_hint` port table was
similarly untested for match-order invariants.

**Decision:** Add a single integration test file (`tests/bc_2_02_story004_tests.rs`) with 18
tests. Do not modify `src/decoder.rs`.

**Rationale:** The implementation already satisfies all BCs. Touching src/ would risk
introducing regressions; a test-only PR achieves BC coverage with zero blast radius.

**Alternatives Considered:**
1. Refactor decoder to expose helpers for testing — rejected: unnecessary churn; decoder is
   already pure and testable as-is.
2. Doctest-based coverage — rejected: doctests cannot easily build multi-byte raw frames.

**Consequences:**
- 18 new regression guards with zero production risk.
- Match-order behavior is now pinned; any reordering of port-table arms will be caught
  immediately.

</details>

---

## Story Dependencies

```mermaid
graph LR
    STORY001["STORY-001<br/>merged"] --> STORY004["STORY-004<br/>this PR"]
    STORY004 --> STORY005["STORY-005<br/>blocked — pending"]
    style STORY001 fill:#90EE90
    style STORY004 fill:#FFD700
    style STORY005 fill:#FFCCCC
```

STORY-004 depends on STORY-001 (merged as PR #106). STORY-005 is blocked on this PR.

---

## Spec Traceability

```mermaid
flowchart LR
    BC010["BC-2.02.010<br/>ICMP Classification"] --> AC001["AC-001<br/>ICMPv4 echo-request"]
    BC010 --> AC002["AC-002<br/>ICMPv4 and ICMPv6 both Icmp"]
    BC010 --> AC003["AC-003<br/>app_protocol_hint None for ICMP"]
    BC011["BC-2.02.011<br/>Protocol::Other"] --> AC004["AC-004<br/>GRE -> Other(47)"]
    BC011 --> AC005["AC-005<br/>byte preserved (47, 50)"]
    BC012["BC-2.02.012<br/>port table"] --> AC006["AC-006<br/>all 7 ports correct"]
    BC012 --> AC007["AC-007<br/>unknown port -> None"]
    BC012 --> AC008["AC-008<br/>match order: HTTP beats TLS"]
    BC013["BC-2.02.013<br/>None transport"] --> AC009["AC-009<br/>None -> None hint"]
    AC001 --> T["tests/bc_2_02_story004_tests.rs"]
    AC002 --> T
    AC003 --> T
    AC004 --> T
    AC005 --> T
    AC006 --> T
    AC007 --> T
    AC008 --> T
    AC009 --> T
    T --> D["src/decoder.rs (verified, unchanged)"]
```

---

## Test Evidence

### Coverage Summary

| Metric | Value | Threshold | Status |
|--------|-------|-----------|--------|
| STORY-004 tests | 18/18 pass | 100% | PASS |
| Full suite | 18/18 (bc_2_02) + all others | 100% | PASS |
| New tests added | 18 | — | — |
| Holdout satisfaction | N/A — evaluated at wave gate | >= 0.85 | N/A |

### Test Flow

```mermaid
graph LR
    BC010Tests["BC-2.02.010 Tests<br/>5 tests: AC-001,002,003 + EC-001,002"]
    BC011Tests["BC-2.02.011 Tests<br/>4 tests: AC-004,005 + EC-003,004"]
    BC012Tests["BC-2.02.012 Tests<br/>7 tests: AC-006,007,008 + EC-005,006,007 + match-order pin"]
    BC013Tests["BC-2.02.013 Tests<br/>2 tests: AC-009 + EC-008"]

    BC010Tests -->|18/18 PASS| Result["ALL PASS 0.00s"]
    BC011Tests --> Result
    BC012Tests --> Result
    BC013Tests --> Result

    style Result fill:#90EE90
```

| Metric | Value |
|--------|-------|
| **New tests** | 18 added, 0 modified |
| **Total suite** | 18 tests PASS in 0.00s (bc_2_02); full suite clean |
| **Coverage delta** | 0 src lines changed; 706 test lines added |
| **Mutation kill rate** | N/A — test-only PR; no src changes |
| **Regressions** | 0 |

<details>
<summary><strong>Detailed Test Results</strong></summary>

### New Tests (This PR)

| Test | AC / EC | Result |
|------|---------|--------|
| `test_BC_2_02_010_icmpv4_protocol_icmp()` | AC-001 | PASS |
| `test_BC_2_02_010_icmpv4_and_icmpv6_both_produce_protocol_icmp()` | AC-002 | PASS |
| `test_BC_2_02_010_icmp_app_protocol_hint_none()` | AC-003 | PASS |
| `test_BC_2_02_011_gre_protocol_other()` | AC-004 | PASS |
| `test_BC_2_02_011_protocol_other_preserves_byte()` | AC-005 | PASS |
| `test_BC_2_02_012_app_protocol_hint_all_seven_ports()` | AC-006 | PASS |
| `test_BC_2_02_012_app_protocol_hint_unknown_port_returns_none()` | AC-007 | PASS |
| `test_BC_2_02_012_app_protocol_hint_match_order()` | AC-008 | PASS |
| `test_BC_2_02_013_transport_none_returns_none_hint()` | AC-009 | PASS |
| `test_BC_2_02_010_EC_001_icmpv4_echo_reply_protocol_icmp()` | EC-001 | PASS |
| `test_BC_2_02_010_EC_002_icmpv6_neighbor_solicitation_protocol_icmp()` | EC-002 | PASS |
| `test_BC_2_02_011_EC_003_gre_protocol_other_47()` | EC-003 | PASS |
| `test_BC_2_02_011_EC_004_esp_protocol_other_50()` | EC-004 | PASS |
| `test_BC_2_02_012_EC_005_src_53_dst_unknown_returns_dns()` | EC-005 | PASS |
| `test_BC_2_02_012_EC_006_src_unknown_dst_53_returns_dns()` | EC-006 | PASS |
| `test_BC_2_02_012_EC_007_src_443_dst_80_match_order_http_still_wins()` | EC-007 | PASS |
| `test_BC_2_02_012_app_protocol_hint_match_order_dns_beats_modbus()` | match-order pin | PASS |
| `test_BC_2_02_013_EC_008_transport_none_always_none_for_any_protocol()` | EC-008 | PASS |

</details>

---

## Holdout Evaluation

N/A — evaluated at wave gate per factory policy.

---

## Adversarial Review

| Pass | Findings | Critical | High | Medium | Status |
|------|----------|----------|------|--------|--------|
| 1 | Multiple | 0 | 0 | several | Fixed |
| 2 | Some | 0 | 0 | minor | Fixed |
| 3 | Some | 0 | 0 | minor | Fixed |
| 4 | 0 | 0 | 0 | 0 | CLEAN |
| 5 | 0 | 0 | 0 | 0 | CLEAN |
| 6 | 0 | 0 | 0 | 0 | CLEAN |

**Convergence:** 3 consecutive clean passes (4, 5, 6). Adversary exhausted all plausible
attack vectors. Story spec advanced to v1.3 to incorporate adversarial fixes (stale line
anchors corrected in Task 7 and Architecture Compliance Rules).

<details>
<summary><strong>Key Adversarial Findings Fixed (Passes 1-3)</strong></summary>

- Test helpers now build frames with non-empty ICMP/GRE/ESP bodies so that `payload.is_empty()`
  is non-vacuous (payload is empty because the decoder sets it to `Vec::new()`, not because the
  frame had no body).
- Added `test_BC_2_02_012_app_protocol_hint_match_order_dns_beats_modbus()` to pin a
  non-adjacent match-order point (arm 1 vs arm 6).
- Added `test_BC_2_02_012_EC_007_src_443_dst_80_match_order_http_still_wins()` to verify the
  complement direction (src=TLS dst=HTTP) of the match-order claim.
- Added `test_BC_2_02_013_EC_008_transport_none_always_none_for_any_protocol()` with a
  defense-in-depth loop over Protocol::Tcp/Udp paired with TransportInfo::None.
- Story spec Task 7 / Architecture Compliance Rule corrected: stale anchor "decoder.rs:98-99"
  replaced with "src/decoder.rs:98 and :103".

</details>

---

## Security Review

```mermaid
graph LR
    Critical["Critical: 0"]
    High["High: 0"]
    Medium["Medium: 0"]
    Low["Low: 0"]

    style Critical fill:#90EE90
    style High fill:#90EE90
    style Medium fill:#90EE90
    style Low fill:#87CEEB
```

Test-only PR. No new src/ code, no I/O, no network, no unsafe, no dependencies added.
The test file constructs static byte slices in-memory. Security surface: zero.

<details>
<summary><strong>Security Scan Details</strong></summary>

- No `unsafe` blocks introduced.
- No new dependencies in Cargo.toml.
- No I/O, no file access, no network in test code.
- `cargo audit` / `cargo deny`: no new advisories (baseline was clean).

</details>

---

## Risk Assessment & Deployment

### Blast Radius
- **Systems affected:** test suite only
- **User impact:** none (no src/ changes)
- **Data impact:** none
- **Risk Level:** LOW

### Performance Impact

| Metric | Before | After | Delta | Status |
|--------|--------|-------|-------|--------|
| CI test time | baseline | +0.00s (18 tests) | negligible | OK |
| Binary size | unchanged | unchanged | 0 | OK |

<details>
<summary><strong>Rollback Instructions</strong></summary>

```bash
git revert 10cab1c
git push origin develop
```

Rollback risk: none — reverting simply removes the 18 tests; no runtime behavior changes.

</details>

### Feature Flags
None. Test-only change.

---

## Traceability

| BC | AC | Test | Status |
|----|----|------|--------|
| BC-2.02.010 | AC-001 | `test_BC_2_02_010_icmpv4_protocol_icmp()` | PASS |
| BC-2.02.010 | AC-002 | `test_BC_2_02_010_icmpv4_and_icmpv6_both_produce_protocol_icmp()` | PASS |
| BC-2.02.010 | AC-003 | `test_BC_2_02_010_icmp_app_protocol_hint_none()` | PASS |
| BC-2.02.011 | AC-004 | `test_BC_2_02_011_gre_protocol_other()` | PASS |
| BC-2.02.011 | AC-005 | `test_BC_2_02_011_protocol_other_preserves_byte()` | PASS |
| BC-2.02.012 | AC-006 | `test_BC_2_02_012_app_protocol_hint_all_seven_ports()` | PASS |
| BC-2.02.012 | AC-007 | `test_BC_2_02_012_app_protocol_hint_unknown_port_returns_none()` | PASS |
| BC-2.02.012 | AC-008 | `test_BC_2_02_012_app_protocol_hint_match_order()` | PASS |
| BC-2.02.013 | AC-009 | `test_BC_2_02_013_transport_none_returns_none_hint()` | PASS |

<details>
<summary><strong>Full VSDD Contract Chain</strong></summary>

```
BC-2.02.010 -> AC-001/002/003 -> tests/bc_2_02_story004_tests.rs -> src/decoder.rs:282-284 -> ADV-PASS-6-CLEAN
BC-2.02.011 -> AC-004/005     -> tests/bc_2_02_story004_tests.rs -> src/decoder.rs:285     -> ADV-PASS-6-CLEAN
BC-2.02.012 -> AC-006/007/008 -> tests/bc_2_02_story004_tests.rs -> src/decoder.rs:94-116  -> ADV-PASS-6-CLEAN
BC-2.02.013 -> AC-009         -> tests/bc_2_02_story004_tests.rs -> src/decoder.rs:98,103  -> ADV-PASS-6-CLEAN
```

Demo evidence: 9/9 ACs recorded as GIF+WebM via VHS 0.11.0.
Evidence root: `.factory/cycles/v0.1.0-greenfield-spec/STORY-004/demos/demo-summary.md`

</details>

---

## AI Pipeline Metadata

<details>
<summary><strong>Pipeline Details</strong></summary>

```yaml
ai-generated: true
pipeline-mode: brownfield-formalization
factory-version: 1.0.0-rc.18
pipeline-stages:
  spec-crystallization: completed (v1.3)
  story-decomposition: completed
  tdd-implementation: completed (test-only)
  holdout-evaluation: N/A (wave gate)
  adversarial-review: completed
  formal-verification: skipped (test-only PR)
  convergence: achieved
convergence-metrics:
  adversarial-passes: 6
  consecutive-clean: 3
  test-kill-rate: N/A (no src changes)
  implementation-ci: 1.0
models-used:
  builder: claude-sonnet-4-6
generated-at: "2026-05-22T00:00:00Z"
```

</details>

---

## Pre-Merge Checklist

- [ ] All CI status checks passing
- [x] No src/ changes — coverage delta is neutral by construction
- [x] No critical/high security findings (test-only, no unsafe)
- [x] Rollback: single `git revert` of one commit
- [x] No feature flags needed
- [x] Adversarial review converged (6 passes, 3 clean)
- [x] Demo evidence: 9/9 ACs recorded
