### PR TITLE
ci: pin fuzz-build to nightly-2026-05-21 and cargo-fuzz 0.13.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,19 @@ jobs:
   fuzz-build:
     name: Fuzz build
     runs-on: ubuntu-latest
+    # Nightly toolchain and cargo-fuzz are pinned together to a known-good
+    # combination. The toolchain is pinned to nightly-2026-05-21
+    # (rustc 1.97.0-nightly, confirmed green on develop 2026-05-22).
+    # cargo-fuzz 0.13.1 requires rustix; older rustix (0.36.5) used a
+    # rustc_layout_scalar_valid_range_start attribute that was removed from
+    # nightly in early 2026, causing build failures (PR #110, runs
+    # 26296832804 and 26296980821). The version below resolves a new-enough
+    # rustix automatically via --no-locked, which is safe once the toolchain
+    # is fixed. To bump: pick a newer known-good nightly date, verify the
+    # fuzz build passes, then update the date here. Do NOT enable renovatebot
+    # or Dependabot auto-update for this pin — bumping is a deliberate,
+    # periodic maintenance action, not automatic.
+    timeout-minutes: 25
     env:
       # The fuzz sub-crate builds under nightly with libfuzzer-sys flags that
       # are incompatible with -Dwarnings. Override the workflow-level env for
@@ -82,21 +95,25 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@nightly
+        with:
+          # Pin to a specific, known-good dated nightly. See job comment above.
+          toolchain: nightly-2026-05-21
       - uses: Swatinem/rust-cache@v2
         with:
           # Use a separate cache key so the nightly fuzz build does not
           # pollute the stable-toolchain cache shared by test/clippy/fmt.
-          key: fuzz-nightly
+          key: fuzz-nightly-2026-05-21
       - name: Install cargo-fuzz
-        # Drop --locked: cargo-fuzz 0.13.1's transitive dep rustix 0.36.5
-        # uses rustc_layout_scalar_valid_range_start which was removed from
-        # current nightly. Without --locked cargo resolves a newer compatible
-        # rustix automatically against the current nightly toolchain.
-        run: cargo install cargo-fuzz
+        # Pin to 0.13.1 (the version validated against nightly-2026-05-21).
+        # Do NOT use --locked: cargo-fuzz 0.13.1's Cargo.lock pins
+        # rustix 0.36.5 which uses rustc_layout_scalar_valid_range_start, an
+        # attribute removed from nightly. Without --locked, cargo resolves a
+        # newer compatible rustix that compiles cleanly on this toolchain.
+        run: cargo install cargo-fuzz --version 0.13.1
       - name: Build fuzz harness (compile check only)
-        run: cargo +nightly fuzz build fuzz_decode_packet
+        run: cargo +nightly-2026-05-21 fuzz build fuzz_decode_packet
       - name: Verify fuzz target is listed (positive coverage assertion)
-        run: cargo +nightly fuzz list | grep -qx fuzz_decode_packet
+        run: cargo +nightly-2026-05-21 fuzz list | grep -qx fuzz_decode_packet
 
   # LESSON-P2.06: supply-chain scanning split into two complementary
   # jobs so a noisy advisory in one source does not block merges on


### PR DESCRIPTION
## Problem

`fuzz-build` has failed twice on PR #110 (CI runs 26296832804 and 26296980821). The root cause is a floating nightly toolchain combined with `cargo install cargo-fuzz --locked`:

- `cargo-fuzz 0.13.1` pins `rustix 0.36.5` in its `Cargo.lock`
- `rustix 0.36.5` uses `#[cfg_attr(rustc_attrs, rustc_layout_scalar_valid_range_start(...))]` — an internal compiler attribute removed from recent nightlies
- On a cold cache the install fails immediately with 4 compiler errors; on a warm cache the pre-built binary is reused and the job passes (explaining the intermittent pattern)

## Fix

- Pin the nightly toolchain to `nightly-2026-05-21` (rustc 1.97.0-nightly, confirmed green on develop run 26297370757 today)
- Pin `cargo install cargo-fuzz --version 0.13.1` explicitly (no `--locked`) so cargo resolves a newer, compatible `rustix` against the fixed toolchain
- Add `timeout-minutes: 25` (addresses W2.4 process-gap)
- Include the cache key suffix (`fuzz-nightly-2026-05-21`) so stale nightly caches from before the pin don't mask future breakage
- Document the pin and the deliberate-bump policy in comments

## Test plan

- [ ] `fuzz-build` job is green on this PR (cold cache, no pre-built binary)
- [ ] All other jobs (Test, Clippy, Format, Semantic PR, Deny) are green
- [ ] Audit job may be informational non-blocking (continue-on-error: true)