### PR TITLE
ci: replace rustsec/audit-check with cargo audit shell step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,13 +124,36 @@ jobs:
     # Advisory database may surface new findings between code changes,
     # so this job is informational on PRs (continue-on-error: true)
     # and run on a schedule against develop to catch zero-days.
+    #
+    # Implementation note: rustsec/audit-check@v2.0.0 was replaced with
+    # a direct `cargo audit` shell invocation. The action required
+    # `checks: write` permission to post GitHub Checks API annotations,
+    # which the default GITHUB_TOKEN does not provide, causing:
+    #   "Resource not accessible by integration" (exit 1)
+    # on every push run even when no vulnerabilities were found.
+    # Using plain cargo audit avoids the API call entirely.
     continue-on-error: true
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Install cargo-audit
+        run: cargo install cargo-audit --locked
       - name: Run cargo audit
-        uses: rustsec/audit-check@v2.0.0
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+        # --ignore flags suppress informational (non-vulnerability) advisories
+        # that are blocked by transitive dependency constraints:
+        #   RUSTSEC-2025-0119: number_prefix unmaintained (via indicatif 0.17.x
+        #     — no newer release fixes this; indicatif is a dev/progress dep)
+        #   RUSTSEC-2026-0097: rand 0.8.5 unsound (via phf_generator -> tls-parser
+        #     — rand upgrade is tls-parser upstream's responsibility; not a direct
+        #     dep and the unsound path requires a custom logger + reseed race)
+        # Both are informational findings, not CVE-severity vulnerabilities.
+        # Revisit when indicatif or tls-parser releases a fix.
+        run: |
+          cargo audit \
+            --ignore RUSTSEC-2025-0119 \
+            --ignore RUSTSEC-2026-0097
 
   deny:
     name: Deny


### PR DESCRIPTION
## Summary

- **Root cause:** `rustsec/audit-check@v2.0.0` requires `checks: write` permission to post GitHub Checks API annotations. The default `GITHUB_TOKEN` only has `contents: read` and `metadata: read`, so every push run failed with `Resource not accessible by integration` (exit 1), marking the Audit job red even when zero vulnerabilities were found.
- **Fix:** Replace the action with a plain `cargo audit` shell invocation — no Checks API calls, no Node.js 20 deprecation warning. Two transitive informational advisories (RUSTSEC-2025-0119 `number_prefix` unmaintained, RUSTSEC-2026-0097 `rand 0.8.5` unsound) are suppressed via `--ignore` with documented rationale. Both are non-CVE findings blocked by upstream transitive constraints.
- `continue-on-error: true` is retained — the Audit job remains advisory-only and non-blocking.

## Failing run diagnosed
- Run ID: 26298573735 (develop HEAD 7c1ab2c)
- Failing job: Audit (ID 77417546653)
- Exact error: `##[error]Resource not accessible by integration - https://docs.github.com/rest/checks/runs#create-a-check-run`
- No actual vulnerabilities found by cargo-audit itself — the failure was purely the API permission error from the action wrapper.

## Test plan

- [ ] PR CI: all jobs green (Test, Clippy, Format, Fuzz build, Audit, Deny)
- [ ] Audit job exits 0 (no vulnerabilities, two informational findings suppressed)
- [ ] No Node.js 20 deprecation annotation on Audit job
- [ ] Post-merge develop push run: all jobs green