### PR TITLE
test: formalize DNS traffic-statistics behavioral contracts (STORY-066)

### DIFF
--- a/src/analyzer/dns.rs
+++ b/src/analyzer/dns.rs
@@ -1,10 +1,18 @@
-//! DNS query/response analyzer.
+//! Statistics-only DNS analyzer (BC-2.08.004).
 //!
-//! Operates on raw UDP/53 packets directly (not via TCP reassembly), parsing
-//! the question section to extract qnames and tracking suspicious patterns:
-//! DGA-class entropy on labels, unusually long subdomains, NXDOMAIN spikes,
-//! and rare-TLD lookups. Findings carry confidence levels reflecting how
-//! noisy each pattern is in benign traffic.
+//! Matches port-53 traffic on both TCP and UDP. For each packet it inspects
+//! the DNS header QR bit (byte 2, bit 7) to classify the packet as a query
+//! (QR = 0) or a response (QR = 1), then increments the corresponding
+//! counter. Payloads shorter than 12 bytes (the minimum DNS header length)
+//! are classified as responses via the length guard in `is_query`.
+//!
+//! `summarize()` reports two counters — `dns_queries` and `dns_responses` —
+//! in the [`AnalysisSummary`] detail map.
+//!
+//! `analyze()` unconditionally returns an empty `Vec<Finding>`. DNS anomaly
+//! detection (qname parsing, DGA-class entropy, NXDOMAIN spike detection,
+//! confidence-leveled findings) does not exist in this implementation and is
+//! explicitly out of scope (see BC-2.08.004).
 
 use std::collections::BTreeMap;
 

--- a/tests/dns_tests.rs
+++ b/tests/dns_tests.rs
@@ -1,0 +1,277 @@
+//! Behavioral-contract test suite for STORY-066: DNS Traffic Statistics.
+//!
+//! Covers BC-2.08.001 (port-53 dispatch), BC-2.08.002 (QR-bit counting),
+//! BC-2.08.003 (summarize output), and BC-2.08.004 (never-emit contract).
+//!
+//! Test naming follows the factory convention: test_BC_S_SS_NNN_xxx or the
+//! story-spec-prescribed verbatim names (W1.4 decision).
+
+use std::collections::BTreeMap;
+use std::net::IpAddr;
+
+use wirerust::analyzer::dns::DnsAnalyzer;
+use wirerust::analyzer::{AnalysisSummary, ProtocolAnalyzer};
+use wirerust::decoder::{ParsedPacket, Protocol, TransportInfo};
+
+// ---------------------------------------------------------------------------
+// Helper: build a minimal ParsedPacket
+// ---------------------------------------------------------------------------
+
+fn make_packet(transport: TransportInfo, payload: Vec<u8>) -> ParsedPacket {
+    ParsedPacket {
+        src_ip: IpAddr::V4("127.0.0.1".parse().unwrap()),
+        dst_ip: IpAddr::V4("127.0.0.2".parse().unwrap()),
+        protocol: match &transport {
+            TransportInfo::Udp { .. } => Protocol::Udp,
+            TransportInfo::Tcp { .. } => Protocol::Tcp,
+            TransportInfo::None => Protocol::Icmp,
+        },
+        transport,
+        payload,
+        packet_len: 64,
+    }
+}
+
+/// A 12-byte DNS query payload (QR=0: payload[2] & 0x80 == 0).
+fn dns_query_payload() -> Vec<u8> {
+    let mut p = vec![0u8; 12];
+    p[2] = 0x00; // QR=0, standard query
+    p
+}
+
+/// A 12-byte DNS response payload (QR=1: payload[2] & 0x80 != 0).
+fn dns_response_payload() -> Vec<u8> {
+    let mut p = vec![0u8; 12];
+    p[2] = 0x80; // QR=1, standard response
+    p
+}
+
+fn udp_dns_query_packet() -> ParsedPacket {
+    make_packet(TransportInfo::Udp { src_port: 12345, dst_port: 53 }, dns_query_payload())
+}
+
+fn udp_dns_response_packet() -> ParsedPacket {
+    make_packet(TransportInfo::Udp { src_port: 53, dst_port: 12345 }, dns_response_payload())
+}
+
+// ---------------------------------------------------------------------------
+// AC-001 (BC-2.08.001 postcondition 1)
+// DnsAnalyzer::can_decode returns true for port-53 traffic over TCP or UDP.
+// ---------------------------------------------------------------------------
+
+/// AC-001 / BC-2.08.001 postcondition 1:
+/// can_decode returns true for src_port==53 or dst_port==53, for both TCP and UDP.
+#[test]
+fn test_dns_can_decode_port_53_tcp_and_udp() {
+    panic!("RED GATE: AC-001 not yet verified")
+}
+
+// ---------------------------------------------------------------------------
+// AC-002 (BC-2.08.001 postcondition 2)
+// can_decode returns false for TransportInfo::None (ICMP / unknown).
+// ---------------------------------------------------------------------------
+
+/// AC-002 / BC-2.08.001 postcondition 2:
+/// can_decode returns false for TransportInfo::None.
+#[test]
+fn test_dns_can_decode_false_for_icmp() {
+    panic!("RED GATE: AC-002 not yet verified")
+}
+
+// ---------------------------------------------------------------------------
+// AC-003 (BC-2.08.001 postcondition 3)
+// can_decode returns false when neither port is 53.
+// ---------------------------------------------------------------------------
+
+/// AC-003 / BC-2.08.001 postcondition 3:
+/// can_decode returns false for UDP src=54, dst=54 (neither port is 53).
+#[test]
+fn test_dns_can_decode_false_for_non_dns_port() {
+    panic!("RED GATE: AC-003 not yet verified")
+}
+
+// ---------------------------------------------------------------------------
+// AC-004 (BC-2.08.002 postcondition 1)
+// analyze increments query_count when QR=0 and payload.len() >= 12.
+// ---------------------------------------------------------------------------
+
+/// AC-004 / BC-2.08.002 postcondition 1:
+/// When payload[2] & 0x80 == 0 (QR=0) and len >= 12, query_count increments by 1.
+#[test]
+fn test_dns_analyzer_counts_queries() {
+    panic!("RED GATE: AC-004 not yet verified")
+}
+
+// ---------------------------------------------------------------------------
+// AC-005 (BC-2.08.002 postcondition 2)
+// analyze increments response_count when QR=1 and payload.len() >= 12.
+// ---------------------------------------------------------------------------
+
+/// AC-005 / BC-2.08.002 postcondition 2:
+/// When payload[2] & 0x80 != 0 (QR=1) and len >= 12, response_count increments by 1.
+#[test]
+fn test_dns_analyzer_counts_responses() {
+    panic!("RED GATE: AC-005 not yet verified")
+}
+
+// ---------------------------------------------------------------------------
+// AC-006 (BC-2.08.002 postcondition 3)
+// Short payload (<12 bytes): is_query returns false, response_count increments.
+// ---------------------------------------------------------------------------
+
+/// AC-006 / BC-2.08.002 postcondition 3:
+/// When payload.len() < 12, is_query returns false and response_count (not query_count)
+/// is incremented.
+#[test]
+fn test_dns_short_payload_counted_as_response() {
+    panic!("RED GATE: AC-006 not yet verified")
+}
+
+// ---------------------------------------------------------------------------
+// AC-007 (BC-2.08.002 invariant 1)
+// Exactly one counter incremented per analyze call.
+// ---------------------------------------------------------------------------
+
+/// AC-007 / BC-2.08.002 invariant 1:
+/// Exactly one of query_count or response_count is incremented per analyze() call —
+/// their sum always equals the number of analyze() calls made.
+#[test]
+fn test_dns_analyze_increments_exactly_one_counter() {
+    panic!("RED GATE: AC-007 not yet verified")
+}
+
+// ---------------------------------------------------------------------------
+// AC-008 (BC-2.08.003 postcondition 1)
+// summarize().analyzer_name == "DNS".
+// ---------------------------------------------------------------------------
+
+/// AC-008 / BC-2.08.003 postcondition 1:
+/// summarize() returns an AnalysisSummary with analyzer_name == "DNS".
+#[test]
+fn test_dns_summarize_analyzer_name() {
+    panic!("RED GATE: AC-008 not yet verified")
+}
+
+// ---------------------------------------------------------------------------
+// AC-009 (BC-2.08.003 postcondition 5)
+// summarize().packets_analyzed == query_count + response_count.
+// ---------------------------------------------------------------------------
+
+/// AC-009 / BC-2.08.003 postcondition 5:
+/// packets_analyzed equals the total number of analyze() calls (query_count +
+/// response_count).
+#[test]
+fn test_dns_summarize_packets_analyzed_is_sum() {
+    panic!("RED GATE: AC-009 not yet verified")
+}
+
+// ---------------------------------------------------------------------------
+// AC-010 + AC-011 (BC-2.08.003 postconditions 2 and 3)
+// detail["dns_queries"] == query_count and detail["dns_responses"] == response_count.
+// ---------------------------------------------------------------------------
+
+/// AC-010 / BC-2.08.003 postcondition 2:
+/// detail["dns_queries"] is a JSON number equal to query_count.
+/// AC-011 / BC-2.08.003 postcondition 3:
+/// detail["dns_responses"] is a JSON number equal to response_count.
+/// (Both ACs share this single test per W1.4 decision in the story spec.)
+#[test]
+fn test_dns_summarize_detail_keys() {
+    panic!("RED GATE: AC-010/AC-011 not yet verified")
+}
+
+// ---------------------------------------------------------------------------
+// AC-012 (BC-2.08.003 postcondition 4)
+// detail BTreeMap has exactly two keys.
+// ---------------------------------------------------------------------------
+
+/// AC-012 / BC-2.08.003 postcondition 4:
+/// The detail BTreeMap contains exactly two keys: "dns_queries" and "dns_responses".
+#[test]
+fn test_dns_summarize_exactly_two_detail_keys() {
+    panic!("RED GATE: AC-012 not yet verified")
+}
+
+// ---------------------------------------------------------------------------
+// AC-013 (BC-2.08.004 postcondition 1)
+// analyze() always returns empty Vec<Finding>.
+// ---------------------------------------------------------------------------
+
+/// AC-013 / BC-2.08.004 postcondition 1:
+/// analyze() unconditionally returns an empty Vec<Finding> — no DNS condition
+/// causes a Finding to be emitted.
+#[test]
+fn test_dns_analyze_always_returns_empty_findings() {
+    panic!("RED GATE: AC-013 not yet verified")
+}
+
+// ---------------------------------------------------------------------------
+// AC-014 (BC-2.08.004 invariant 1)
+// Even 1000 packets produce zero findings.
+// ---------------------------------------------------------------------------
+
+/// AC-014 / BC-2.08.004 invariant 1:
+/// The never-emit contract holds under high volume: 1000 analyze() calls all
+/// return vec![].
+#[test]
+fn test_dns_high_volume_no_findings() {
+    panic!("RED GATE: AC-014 not yet verified")
+}
+
+// ---------------------------------------------------------------------------
+// EC-001 (BC-2.08.001 edge case): UDP src=53 dst=12345 — can_decode true
+// ---------------------------------------------------------------------------
+
+/// EC-001 / BC-2.08.001:
+/// UDP src=53, dst=12345 (DNS response to client): can_decode returns true.
+#[test]
+fn test_dns_ec001_udp_src53_can_decode() {
+    panic!("RED GATE: EC-001 not yet verified")
+}
+
+// ---------------------------------------------------------------------------
+// EC-002 (BC-2.08.001 edge case): TCP dst=53 — can_decode true
+// ---------------------------------------------------------------------------
+
+/// EC-002 / BC-2.08.001:
+/// TCP dst=53 (DNS-over-TCP query): can_decode returns true.
+#[test]
+fn test_dns_ec002_tcp_dst53_can_decode() {
+    panic!("RED GATE: EC-002 not yet verified")
+}
+
+// ---------------------------------------------------------------------------
+// EC-003 (BC-2.08.002 edge case): payload.len() == 0 — response_count++
+// ---------------------------------------------------------------------------
+
+/// EC-003 / BC-2.08.002:
+/// payload.len() == 0: is_query returns false; response_count is incremented.
+#[test]
+fn test_dns_ec003_empty_payload_counted_as_response() {
+    panic!("RED GATE: EC-003 not yet verified")
+}
+
+// ---------------------------------------------------------------------------
+// EC-004 (BC-2.08.002 edge case): payload[2] == 0xFF — response_count++
+// ---------------------------------------------------------------------------
+
+/// EC-004 / BC-2.08.002:
+/// payload[2] == 0xFF (QR=1 plus all other flag bits set): response_count is
+/// incremented because the QR bit is set.
+#[test]
+fn test_dns_ec004_all_flags_set_counted_as_response() {
+    panic!("RED GATE: EC-004 not yet verified")
+}
+
+// ---------------------------------------------------------------------------
+// EC-005 (BC-2.08.003 edge case): zero analyze() calls — all counts == 0
+// ---------------------------------------------------------------------------
+
+/// EC-005 / BC-2.08.003 postcondition 1 + invariant 4:
+/// With no calls to analyze(), summarize() returns packets_analyzed=0,
+/// dns_queries=0, dns_responses=0. Also verifies summarize does not reset
+/// counters (call twice; both return same values).
+#[test]
+fn test_dns_ec005_zero_packets_summarize() {
+    panic!("RED GATE: EC-005 not yet verified")
+}

--- a/tests/dns_tests.rs
+++ b/tests/dns_tests.rs
@@ -245,10 +245,11 @@ fn test_dns_analyzer_counts_responses() {
 // Short payload (<12 bytes): is_query returns false, response_count increments.
 // ---------------------------------------------------------------------------
 
-/// AC-006 / BC-2.08.002 postcondition 3 / invariant 2:
+/// AC-006 / BC-2.08.002 postcondition 3 / EC-003:
 /// When `payload.len() < 12`, `is_query` returns `false` (length guard fires
 /// before the QR-bit test), and `response_count` (not `query_count`) is
-/// incremented. Canonical test vector: 6-byte payload.
+/// incremented. Canonical test vector: 11-byte payload (one byte below the
+/// 12-byte DNS-header minimum).
 #[test]
 fn test_dns_short_payload_counted_as_response() {
     let mut a = DnsAnalyzer::new();

--- a/tests/dns_tests.rs
+++ b/tests/dns_tests.rs
@@ -6,15 +6,14 @@
 //! Test naming follows the factory convention: test_BC_S_SS_NNN_xxx or the
 //! story-spec-prescribed verbatim names (W1.4 decision).
 
-use std::collections::BTreeMap;
 use std::net::IpAddr;
 
+use wirerust::analyzer::ProtocolAnalyzer;
 use wirerust::analyzer::dns::DnsAnalyzer;
-use wirerust::analyzer::{AnalysisSummary, ProtocolAnalyzer};
 use wirerust::decoder::{ParsedPacket, Protocol, TransportInfo};
 
 // ---------------------------------------------------------------------------
-// Helper: build a minimal ParsedPacket
+// Helpers
 // ---------------------------------------------------------------------------
 
 fn make_packet(transport: TransportInfo, payload: Vec<u8>) -> ParsedPacket {
@@ -32,50 +31,105 @@ fn make_packet(transport: TransportInfo, payload: Vec<u8>) -> ParsedPacket {
     }
 }
 
-/// A 12-byte DNS query payload (QR=0: payload[2] & 0x80 == 0).
+fn make_tcp(src_port: u16, dst_port: u16) -> TransportInfo {
+    TransportInfo::Tcp {
+        src_port,
+        dst_port,
+        seq_number: 0,
+        syn: false,
+        ack: false,
+        fin: false,
+        rst: false,
+    }
+}
+
+/// 12-byte DNS query payload (QR=0: payload[2] & 0x80 == 0).
 fn dns_query_payload() -> Vec<u8> {
     let mut p = vec![0u8; 12];
     p[2] = 0x00; // QR=0, standard query
     p
 }
 
-/// A 12-byte DNS response payload (QR=1: payload[2] & 0x80 != 0).
+/// 12-byte DNS response payload (QR=1: payload[2] & 0x80 != 0).
 fn dns_response_payload() -> Vec<u8> {
     let mut p = vec![0u8; 12];
     p[2] = 0x80; // QR=1, standard response
     p
 }
 
-fn udp_dns_query_packet() -> ParsedPacket {
-    make_packet(TransportInfo::Udp { src_port: 12345, dst_port: 53 }, dns_query_payload())
+fn udp_dst53_query_packet() -> ParsedPacket {
+    make_packet(
+        TransportInfo::Udp {
+            src_port: 12345,
+            dst_port: 53,
+        },
+        dns_query_payload(),
+    )
 }
 
-fn udp_dns_response_packet() -> ParsedPacket {
-    make_packet(TransportInfo::Udp { src_port: 53, dst_port: 12345 }, dns_response_payload())
+fn udp_src53_response_packet() -> ParsedPacket {
+    make_packet(
+        TransportInfo::Udp {
+            src_port: 53,
+            dst_port: 12345,
+        },
+        dns_response_payload(),
+    )
 }
 
 // ---------------------------------------------------------------------------
 // AC-001 (BC-2.08.001 postcondition 1)
-// DnsAnalyzer::can_decode returns true for port-53 traffic over TCP or UDP.
+// can_decode returns true for src==53 or dst==53, TCP or UDP.
 // ---------------------------------------------------------------------------
 
 /// AC-001 / BC-2.08.001 postcondition 1:
-/// can_decode returns true for src_port==53 or dst_port==53, for both TCP and UDP.
+/// `DnsAnalyzer::can_decode` returns `true` for any packet where `src_port==53`
+/// OR `dst_port==53`, regardless of whether the transport is TCP or UDP.
 #[test]
 fn test_dns_can_decode_port_53_tcp_and_udp() {
-    panic!("RED GATE: AC-001 not yet verified")
+    let a = DnsAnalyzer::new();
+
+    // UDP src=12345, dst=53 (query from client to server)
+    let pkt = make_packet(
+        TransportInfo::Udp {
+            src_port: 12345,
+            dst_port: 53,
+        },
+        vec![],
+    );
+    assert!(a.can_decode(&pkt), "UDP dst=53 must decode");
+
+    // UDP src=53, dst=12345 (response from server to client)
+    let pkt = make_packet(
+        TransportInfo::Udp {
+            src_port: 53,
+            dst_port: 12345,
+        },
+        vec![],
+    );
+    assert!(a.can_decode(&pkt), "UDP src=53 must decode");
+
+    // TCP dst=53 (DNS-over-TCP query)
+    let pkt = make_packet(make_tcp(54321, 53), vec![]);
+    assert!(a.can_decode(&pkt), "TCP dst=53 must decode");
+
+    // TCP src=53 (DNS-over-TCP response)
+    let pkt = make_packet(make_tcp(53, 54321), vec![]);
+    assert!(a.can_decode(&pkt), "TCP src=53 must decode");
 }
 
 // ---------------------------------------------------------------------------
 // AC-002 (BC-2.08.001 postcondition 2)
-// can_decode returns false for TransportInfo::None (ICMP / unknown).
+// can_decode returns false for TransportInfo::None.
 // ---------------------------------------------------------------------------
 
 /// AC-002 / BC-2.08.001 postcondition 2:
-/// can_decode returns false for TransportInfo::None.
+/// `can_decode` returns `false` for `TransportInfo::None` (ICMP / unknown transport).
 #[test]
 fn test_dns_can_decode_false_for_icmp() {
-    panic!("RED GATE: AC-002 not yet verified")
+    let a = DnsAnalyzer::new();
+    let pkt = make_packet(TransportInfo::None, vec![]);
+    assert!(!a.can_decode(&pkt), "TransportInfo::None must not decode");
 }
 
 // ---------------------------------------------------------------------------
@@ -84,10 +138,41 @@ fn test_dns_can_decode_false_for_icmp() {
 // ---------------------------------------------------------------------------
 
 /// AC-003 / BC-2.08.001 postcondition 3:
-/// can_decode returns false for UDP src=54, dst=54 (neither port is 53).
+/// `can_decode` returns `false` when neither src_port nor dst_port is 53.
+/// Canonical test vector: UDP src=54, dst=54.
 #[test]
 fn test_dns_can_decode_false_for_non_dns_port() {
-    panic!("RED GATE: AC-003 not yet verified")
+    let a = DnsAnalyzer::new();
+
+    // UDP src=54, dst=54 (canonical test vector from BC-2.08.001)
+    let pkt = make_packet(
+        TransportInfo::Udp {
+            src_port: 54,
+            dst_port: 54,
+        },
+        vec![],
+    );
+    assert!(!a.can_decode(&pkt), "UDP port 54/54 must not decode");
+
+    // UDP src=9999, dst=9999 (canonical test vector from BC-2.08.001)
+    let pkt = make_packet(
+        TransportInfo::Udp {
+            src_port: 9999,
+            dst_port: 9999,
+        },
+        vec![],
+    );
+    assert!(!a.can_decode(&pkt), "UDP port 9999/9999 must not decode");
+
+    // UDP dst=443 (BC-2.08.001 edge case EC-006)
+    let pkt = make_packet(
+        TransportInfo::Udp {
+            src_port: 1234,
+            dst_port: 443,
+        },
+        vec![],
+    );
+    assert!(!a.can_decode(&pkt), "UDP dst=443 must not decode");
 }
 
 // ---------------------------------------------------------------------------
@@ -96,10 +181,31 @@ fn test_dns_can_decode_false_for_non_dns_port() {
 // ---------------------------------------------------------------------------
 
 /// AC-004 / BC-2.08.002 postcondition 1:
-/// When payload[2] & 0x80 == 0 (QR=0) and len >= 12, query_count increments by 1.
+/// When `payload.len() >= 12` AND `(payload[2] & 0x80) == 0` (QR=0),
+/// `analyze` increments `query_count` by 1; `summarize().detail["dns_queries"]`
+/// reflects the increment. `analyze` returns an empty `Vec<Finding>`.
 #[test]
 fn test_dns_analyzer_counts_queries() {
-    panic!("RED GATE: AC-004 not yet verified")
+    let mut a = DnsAnalyzer::new();
+
+    let pkt = udp_dst53_query_packet(); // QR=0, len=12
+    let findings = a.analyze(&pkt);
+    assert!(
+        findings.is_empty(),
+        "BC-2.08.004: analyze must return empty findings"
+    );
+
+    let summary = a.summarize();
+    assert_eq!(
+        summary.detail["dns_queries"],
+        serde_json::json!(1u64),
+        "BC-2.08.002 pc1: dns_queries must be 1 after one query packet"
+    );
+    assert_eq!(
+        summary.detail["dns_responses"],
+        serde_json::json!(0u64),
+        "BC-2.08.002 pc1: dns_responses must be 0"
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -108,10 +214,30 @@ fn test_dns_analyzer_counts_queries() {
 // ---------------------------------------------------------------------------
 
 /// AC-005 / BC-2.08.002 postcondition 2:
-/// When payload[2] & 0x80 != 0 (QR=1) and len >= 12, response_count increments by 1.
+/// When `payload.len() >= 12` AND `(payload[2] & 0x80) != 0` (QR=1),
+/// `analyze` increments `response_count` by 1.
 #[test]
 fn test_dns_analyzer_counts_responses() {
-    panic!("RED GATE: AC-005 not yet verified")
+    let mut a = DnsAnalyzer::new();
+
+    let pkt = udp_src53_response_packet(); // QR=1, len=12
+    let findings = a.analyze(&pkt);
+    assert!(
+        findings.is_empty(),
+        "BC-2.08.004: analyze must return empty findings"
+    );
+
+    let summary = a.summarize();
+    assert_eq!(
+        summary.detail["dns_responses"],
+        serde_json::json!(1u64),
+        "BC-2.08.002 pc2: dns_responses must be 1 after one response packet"
+    );
+    assert_eq!(
+        summary.detail["dns_queries"],
+        serde_json::json!(0u64),
+        "BC-2.08.002 pc2: dns_queries must be 0"
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -119,12 +245,37 @@ fn test_dns_analyzer_counts_responses() {
 // Short payload (<12 bytes): is_query returns false, response_count increments.
 // ---------------------------------------------------------------------------
 
-/// AC-006 / BC-2.08.002 postcondition 3:
-/// When payload.len() < 12, is_query returns false and response_count (not query_count)
-/// is incremented.
+/// AC-006 / BC-2.08.002 postcondition 3 / invariant 2:
+/// When `payload.len() < 12`, `is_query` returns `false` (length guard fires
+/// before the QR-bit test), and `response_count` (not `query_count`) is
+/// incremented. Canonical test vector: 6-byte payload.
 #[test]
 fn test_dns_short_payload_counted_as_response() {
-    panic!("RED GATE: AC-006 not yet verified")
+    let mut a = DnsAnalyzer::new();
+
+    // 11-byte payload: one byte below the 12-byte minimum (BC-2.08.002 EC-003)
+    let short_payload = vec![0u8; 11];
+    let pkt = make_packet(
+        TransportInfo::Udp {
+            src_port: 12345,
+            dst_port: 53,
+        },
+        short_payload,
+    );
+    let findings = a.analyze(&pkt);
+    assert!(findings.is_empty());
+
+    let summary = a.summarize();
+    assert_eq!(
+        summary.detail["dns_responses"],
+        serde_json::json!(1u64),
+        "BC-2.08.002 pc3: short payload must count as response"
+    );
+    assert_eq!(
+        summary.detail["dns_queries"],
+        serde_json::json!(0u64),
+        "BC-2.08.002 pc3: query_count must remain 0 for short payload"
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -133,51 +284,143 @@ fn test_dns_short_payload_counted_as_response() {
 // ---------------------------------------------------------------------------
 
 /// AC-007 / BC-2.08.002 invariant 1:
-/// Exactly one of query_count or response_count is incremented per analyze() call —
-/// their sum always equals the number of analyze() calls made.
+/// Exactly one of `query_count` or `response_count` is incremented per call to
+/// `analyze`. Their sum always equals the total number of `analyze` calls made.
 #[test]
 fn test_dns_analyze_increments_exactly_one_counter() {
-    panic!("RED GATE: AC-007 not yet verified")
+    let mut a = DnsAnalyzer::new();
+
+    // Mix: 3 queries, 2 responses, 1 short (counted as response)
+    for _ in 0..3 {
+        a.analyze(&udp_dst53_query_packet());
+    }
+    for _ in 0..2 {
+        a.analyze(&udp_src53_response_packet());
+    }
+    // Short payload — counted as response
+    let short = make_packet(
+        TransportInfo::Udp {
+            src_port: 12345,
+            dst_port: 53,
+        },
+        vec![0u8; 6],
+    );
+    a.analyze(&short);
+
+    let summary = a.summarize();
+    let dns_q = summary.detail["dns_queries"].as_u64().unwrap();
+    let dns_r = summary.detail["dns_responses"].as_u64().unwrap();
+
+    // 6 analyze calls total: 3 queries + 3 responses (2 real + 1 short)
+    assert_eq!(
+        dns_q + dns_r,
+        6,
+        "BC-2.08.002 inv1: sum of counters must equal analyze call count"
+    );
+    assert_eq!(dns_q, 3, "BC-2.08.002 inv1: query_count must be 3");
+    assert_eq!(
+        dns_r, 3,
+        "BC-2.08.002 inv1: response_count must be 3 (2 real + 1 short)"
+    );
+    assert_eq!(
+        summary.packets_analyzed, 6,
+        "BC-2.08.003 pc5: packets_analyzed must equal sum"
+    );
 }
 
 // ---------------------------------------------------------------------------
 // AC-008 (BC-2.08.003 postcondition 1)
-// summarize().analyzer_name == "DNS".
+// summarize().analyzer_name == "DNS"
 // ---------------------------------------------------------------------------
 
 /// AC-008 / BC-2.08.003 postcondition 1:
-/// summarize() returns an AnalysisSummary with analyzer_name == "DNS".
+/// `DnsAnalyzer::summarize()` returns an `AnalysisSummary` with
+/// `analyzer_name == "DNS"`.
 #[test]
 fn test_dns_summarize_analyzer_name() {
-    panic!("RED GATE: AC-008 not yet verified")
+    let a = DnsAnalyzer::new();
+    let summary = a.summarize();
+    assert_eq!(
+        summary.analyzer_name, "DNS",
+        "BC-2.08.003 pc1: analyzer_name must be \"DNS\""
+    );
 }
 
 // ---------------------------------------------------------------------------
 // AC-009 (BC-2.08.003 postcondition 5)
-// summarize().packets_analyzed == query_count + response_count.
+// summarize().packets_analyzed == query_count + response_count
 // ---------------------------------------------------------------------------
 
 /// AC-009 / BC-2.08.003 postcondition 5:
-/// packets_analyzed equals the total number of analyze() calls (query_count +
-/// response_count).
+/// `summarize().packets_analyzed` equals `query_count + response_count` (total
+/// packets seen by `analyze`). Canonical test vector: 2 queries + 1 response.
 #[test]
 fn test_dns_summarize_packets_analyzed_is_sum() {
-    panic!("RED GATE: AC-009 not yet verified")
+    let mut a = DnsAnalyzer::new();
+
+    a.analyze(&udp_dst53_query_packet()); // query
+    a.analyze(&udp_dst53_query_packet()); // query
+    a.analyze(&udp_src53_response_packet()); // response
+
+    let summary = a.summarize();
+    assert_eq!(
+        summary.packets_analyzed, 3,
+        "BC-2.08.003 pc5: packets_analyzed must be 3 (2 queries + 1 response)"
+    );
+    let dns_q = summary.detail["dns_queries"].as_u64().unwrap();
+    let dns_r = summary.detail["dns_responses"].as_u64().unwrap();
+    assert_eq!(
+        summary.packets_analyzed,
+        dns_q + dns_r,
+        "BC-2.08.003 pc5: packets_analyzed must equal dns_queries + dns_responses"
+    );
 }
 
 // ---------------------------------------------------------------------------
 // AC-010 + AC-011 (BC-2.08.003 postconditions 2 and 3)
-// detail["dns_queries"] == query_count and detail["dns_responses"] == response_count.
+// detail["dns_queries"] and detail["dns_responses"] are correct JSON numbers.
 // ---------------------------------------------------------------------------
 
 /// AC-010 / BC-2.08.003 postcondition 2:
-/// detail["dns_queries"] is a JSON number equal to query_count.
+/// `detail["dns_queries"]` is a `serde_json::Value::Number` equal to `query_count`.
 /// AC-011 / BC-2.08.003 postcondition 3:
-/// detail["dns_responses"] is a JSON number equal to response_count.
-/// (Both ACs share this single test per W1.4 decision in the story spec.)
+/// `detail["dns_responses"]` is a `serde_json::Value::Number` equal to `response_count`.
+/// (Both ACs share this test per W1.4 decision in the story spec.)
 #[test]
 fn test_dns_summarize_detail_keys() {
-    panic!("RED GATE: AC-010/AC-011 not yet verified")
+    let mut a = DnsAnalyzer::new();
+
+    // 3 queries, 1 response (canonical test vector from BC-2.08.003)
+    for _ in 0..3 {
+        a.analyze(&udp_dst53_query_packet());
+    }
+    a.analyze(&udp_src53_response_packet());
+
+    let summary = a.summarize();
+
+    // AC-010: dns_queries value is a JSON number equal to query_count (3)
+    let queries = &summary.detail["dns_queries"];
+    assert!(
+        queries.is_number(),
+        "BC-2.08.003 pc2: dns_queries must be a JSON number"
+    );
+    assert_eq!(
+        queries.as_u64(),
+        Some(3),
+        "BC-2.08.003 pc2: dns_queries must equal 3"
+    );
+
+    // AC-011: dns_responses value is a JSON number equal to response_count (1)
+    let responses = &summary.detail["dns_responses"];
+    assert!(
+        responses.is_number(),
+        "BC-2.08.003 pc3: dns_responses must be a JSON number"
+    );
+    assert_eq!(
+        responses.as_u64(),
+        Some(1),
+        "BC-2.08.003 pc3: dns_responses must equal 1"
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -186,10 +429,26 @@ fn test_dns_summarize_detail_keys() {
 // ---------------------------------------------------------------------------
 
 /// AC-012 / BC-2.08.003 postcondition 4:
-/// The detail BTreeMap contains exactly two keys: "dns_queries" and "dns_responses".
+/// The `detail` `BTreeMap` contains exactly two keys: `"dns_queries"` and
+/// `"dns_responses"` — no other keys.
 #[test]
 fn test_dns_summarize_exactly_two_detail_keys() {
-    panic!("RED GATE: AC-012 not yet verified")
+    let a = DnsAnalyzer::new();
+    let summary = a.summarize();
+
+    assert_eq!(
+        summary.detail.len(),
+        2,
+        "BC-2.08.003 pc4: detail must have exactly 2 keys"
+    );
+
+    let keys: Vec<&str> = summary.detail.keys().map(|s| s.as_str()).collect();
+    // BTreeMap is sorted lexicographically: "dns_queries" < "dns_responses"
+    assert_eq!(
+        keys,
+        vec!["dns_queries", "dns_responses"],
+        "BC-2.08.003 inv1: keys must be in lexicographic order"
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -198,35 +457,90 @@ fn test_dns_summarize_exactly_two_detail_keys() {
 // ---------------------------------------------------------------------------
 
 /// AC-013 / BC-2.08.004 postcondition 1:
-/// analyze() unconditionally returns an empty Vec<Finding> — no DNS condition
-/// causes a Finding to be emitted.
+/// `DnsAnalyzer::analyze(packet)` unconditionally returns an empty `Vec<Finding>`.
+/// Verified for a query, a response, and a short (malformed) payload.
 #[test]
 fn test_dns_analyze_always_returns_empty_findings() {
-    panic!("RED GATE: AC-013 not yet verified")
+    let mut a = DnsAnalyzer::new();
+
+    let query_findings = a.analyze(&udp_dst53_query_packet());
+    assert!(
+        query_findings.is_empty(),
+        "BC-2.08.004 pc1: query packet must produce no findings"
+    );
+
+    let response_findings = a.analyze(&udp_src53_response_packet());
+    assert!(
+        response_findings.is_empty(),
+        "BC-2.08.004 pc1: response packet must produce no findings"
+    );
+
+    // Short/malformed payload
+    let short = make_packet(
+        TransportInfo::Udp {
+            src_port: 12345,
+            dst_port: 53,
+        },
+        vec![0u8; 6],
+    );
+    let short_findings = a.analyze(&short);
+    assert!(
+        short_findings.is_empty(),
+        "BC-2.08.004 pc1: short payload must produce no findings"
+    );
 }
 
 // ---------------------------------------------------------------------------
 // AC-014 (BC-2.08.004 invariant 1)
-// Even 1000 packets produce zero findings.
+// High volume — 1000 packets — never produces findings.
 // ---------------------------------------------------------------------------
 
 /// AC-014 / BC-2.08.004 invariant 1:
-/// The never-emit contract holds under high volume: 1000 analyze() calls all
-/// return vec![].
+/// The never-emit contract holds unconditionally. 1000 `analyze` calls all
+/// return `vec![]`. Also verifies `query_count == 1000` in the summary.
 #[test]
 fn test_dns_high_volume_no_findings() {
-    panic!("RED GATE: AC-014 not yet verified")
+    let mut a = DnsAnalyzer::new();
+
+    for _ in 0..1000 {
+        let findings = a.analyze(&udp_dst53_query_packet());
+        assert!(
+            findings.is_empty(),
+            "BC-2.08.004 inv1: analyze must never return findings"
+        );
+    }
+
+    let summary = a.summarize();
+    assert_eq!(
+        summary.detail["dns_queries"].as_u64(),
+        Some(1000),
+        "BC-2.08.004 inv1: 1000 queries must be counted"
+    );
+    assert_eq!(
+        summary.detail["dns_responses"].as_u64(),
+        Some(0),
+        "BC-2.08.004 inv1: dns_responses must remain 0"
+    );
 }
 
 // ---------------------------------------------------------------------------
-// EC-001 (BC-2.08.001 edge case): UDP src=53 dst=12345 — can_decode true
+// EC-001 (BC-2.08.001 edge case): UDP src=53, dst=12345 — can_decode true
 // ---------------------------------------------------------------------------
 
 /// EC-001 / BC-2.08.001:
-/// UDP src=53, dst=12345 (DNS response to client): can_decode returns true.
+/// UDP src=53, dst=12345 (DNS response packet from server to client):
+/// `can_decode` must return `true` because src_port == 53.
 #[test]
 fn test_dns_ec001_udp_src53_can_decode() {
-    panic!("RED GATE: EC-001 not yet verified")
+    let a = DnsAnalyzer::new();
+    let pkt = make_packet(
+        TransportInfo::Udp {
+            src_port: 53,
+            dst_port: 12345,
+        },
+        vec![],
+    );
+    assert!(a.can_decode(&pkt), "EC-001: UDP src=53 must decode");
 }
 
 // ---------------------------------------------------------------------------
@@ -234,10 +548,12 @@ fn test_dns_ec001_udp_src53_can_decode() {
 // ---------------------------------------------------------------------------
 
 /// EC-002 / BC-2.08.001:
-/// TCP dst=53 (DNS-over-TCP query): can_decode returns true.
+/// TCP dst=53 (DNS-over-TCP query): `can_decode` must return `true`.
 #[test]
 fn test_dns_ec002_tcp_dst53_can_decode() {
-    panic!("RED GATE: EC-002 not yet verified")
+    let a = DnsAnalyzer::new();
+    let pkt = make_packet(make_tcp(54321, 53), vec![]);
+    assert!(a.can_decode(&pkt), "EC-002: TCP dst=53 must decode");
 }
 
 // ---------------------------------------------------------------------------
@@ -245,10 +561,32 @@ fn test_dns_ec002_tcp_dst53_can_decode() {
 // ---------------------------------------------------------------------------
 
 /// EC-003 / BC-2.08.002:
-/// payload.len() == 0: is_query returns false; response_count is incremented.
+/// `payload.len() == 0`: `is_query` returns `false` (length guard fires);
+/// `response_count` is incremented, `query_count` stays at 0.
 #[test]
 fn test_dns_ec003_empty_payload_counted_as_response() {
-    panic!("RED GATE: EC-003 not yet verified")
+    let mut a = DnsAnalyzer::new();
+
+    let pkt = make_packet(
+        TransportInfo::Udp {
+            src_port: 12345,
+            dst_port: 53,
+        },
+        vec![],
+    );
+    a.analyze(&pkt);
+
+    let summary = a.summarize();
+    assert_eq!(
+        summary.detail["dns_responses"].as_u64(),
+        Some(1),
+        "EC-003: zero-length payload must be counted as response"
+    );
+    assert_eq!(
+        summary.detail["dns_queries"].as_u64(),
+        Some(0),
+        "EC-003: query_count must remain 0 for empty payload"
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -256,11 +594,34 @@ fn test_dns_ec003_empty_payload_counted_as_response() {
 // ---------------------------------------------------------------------------
 
 /// EC-004 / BC-2.08.002:
-/// payload[2] == 0xFF (QR=1 plus all other flag bits set): response_count is
-/// incremented because the QR bit is set.
+/// `payload[2] == 0xFF` (QR=1 plus all other flag bits set): `response_count`
+/// is incremented because the QR bit (bit 7) is set.
 #[test]
 fn test_dns_ec004_all_flags_set_counted_as_response() {
-    panic!("RED GATE: EC-004 not yet verified")
+    let mut a = DnsAnalyzer::new();
+
+    let mut payload = vec![0u8; 12];
+    payload[2] = 0xFF; // QR=1 + all other flags set
+    let pkt = make_packet(
+        TransportInfo::Udp {
+            src_port: 53,
+            dst_port: 12345,
+        },
+        payload,
+    );
+    a.analyze(&pkt);
+
+    let summary = a.summarize();
+    assert_eq!(
+        summary.detail["dns_responses"].as_u64(),
+        Some(1),
+        "EC-004: payload[2]==0xFF (QR=1) must count as response"
+    );
+    assert_eq!(
+        summary.detail["dns_queries"].as_u64(),
+        Some(0),
+        "EC-004: query_count must remain 0"
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -268,10 +629,41 @@ fn test_dns_ec004_all_flags_set_counted_as_response() {
 // ---------------------------------------------------------------------------
 
 /// EC-005 / BC-2.08.003 postcondition 1 + invariant 4:
-/// With no calls to analyze(), summarize() returns packets_analyzed=0,
-/// dns_queries=0, dns_responses=0. Also verifies summarize does not reset
-/// counters (call twice; both return same values).
+/// With no calls to `analyze()`, `summarize()` returns `packets_analyzed=0`,
+/// `dns_queries=0`, `dns_responses=0`. Calling `summarize` twice returns the
+/// same values (invariant 4: summarize does NOT reset counters).
 #[test]
 fn test_dns_ec005_zero_packets_summarize() {
-    panic!("RED GATE: EC-005 not yet verified")
+    let a = DnsAnalyzer::new();
+
+    let s1 = a.summarize();
+    assert_eq!(
+        s1.packets_analyzed, 0,
+        "EC-005: packets_analyzed must be 0 with no analyze calls"
+    );
+    assert_eq!(
+        s1.detail["dns_queries"].as_u64(),
+        Some(0),
+        "EC-005: dns_queries must be 0"
+    );
+    assert_eq!(
+        s1.detail["dns_responses"].as_u64(),
+        Some(0),
+        "EC-005: dns_responses must be 0"
+    );
+
+    // Call summarize a second time — counters must not have been reset
+    let s2 = a.summarize();
+    assert_eq!(
+        s2.packets_analyzed, s1.packets_analyzed,
+        "EC-005 / BC-2.08.003 inv4: summarize must not reset counters"
+    );
+    assert_eq!(
+        s2.detail["dns_queries"], s1.detail["dns_queries"],
+        "EC-005: second summarize must match first"
+    );
+    assert_eq!(
+        s2.detail["dns_responses"], s1.detail["dns_responses"],
+        "EC-005: second summarize must match first"
+    );
 }


### PR DESCRIPTION
## Summary

Brownfield-formalization of the DNS traffic-statistics analyzer for `wirerust` (STORY-066, Wave 4). Production code in `src/analyzer/dns.rs` already shipped; this PR adds **18 behavioral-contract tests** in `tests/dns_tests.rs` that formally specify and lock the contracts from BC-2.08.001, BC-2.08.002, BC-2.08.003, and BC-2.08.004.

Additionally, the stale module-level doc comment in `src/analyzer/dns.rs` is corrected: the previous `//!` block described DGA-class entropy scoring, NXDOMAIN spike detection, and confidence-leveled findings — none of which exist in this implementation. The corrected comment honestly describes the statistics-only design (port-53 dispatch, QR-bit counting, never-emit contract) as required by BC-2.08.004.

Exact diff: two files — `tests/dns_tests.rs` (new, 18 tests) and `src/analyzer/dns.rs` (doc-comment-only change). No executable code added or modified.

---

## Architecture Changes

```mermaid
graph TD
    A["tests/dns_tests.rs\nNEW — 18 BC tests"] --> B["src/analyzer/dns.rs\nDnsAnalyzer — already shipped"]
    B --> C["can_decode\nport-53 dispatch TCP+UDP"]
    B --> D["analyze\nQR-bit counter mutation"]
    B --> E["summarize\ndns_queries + dns_responses"]
    B --> F["analyze always returns vec![]"]
    style A fill:#90EE90
```

_No executable source changes. `src/analyzer/dns.rs` receives a doc-comment-only correction._

<details>
<summary><strong>Architecture Decision Record</strong></summary>

### ADR: Statistics-Only DNS Analyzer with Never-Emit Contract

**Context:** The DNS analyzer was implemented with a statistics-only design (port-53 dispatch, QR-bit counting) but its module doc comment still described planned-but-unimplemented DGA detection and finding emission. BC-2.08.004 mandates that no Finding is ever emitted, and the misleading doc created spec drift risk.

**Decision:** Correct the module doc comment to match the actual implementation; formalize all behavioral contracts via the test suite.

**Rationale:** Honest documentation prevents future implementers from believing finding-emission infrastructure exists. The test suite locks the never-emit invariant so any future accidental addition of finding emission is caught immediately.

**Consequences:**
- Behavioral contracts are now machine-enforced via `cargo test`
- The doc comment accurately describes what the module does
- Any future PR that adds finding emission will fail `test_dns_analyze_always_returns_empty_findings` and `test_dns_high_volume_no_findings`

</details>

---

## Story Dependencies

```mermaid
graph LR
    S005["STORY-005\n✅ merged #114"] --> S066["STORY-066\n🟡 this PR"]
    S066 --> S076["STORY-076\n⬜ blocked"]
    style S066 fill:#FFD700
```

STORY-066 depends_on: STORY-005 (merged via PR #114). Blocks: STORY-076.

---

## Spec Traceability

```mermaid
flowchart LR
    BC1["BC-2.08.001\nPort-53 Dispatch"] --> AC001["AC-001\ncan_decode true for port 53 TCP+UDP"]
    BC1 --> AC002["AC-002\ncan_decode false for ICMP"]
    BC1 --> AC003["AC-003\ncan_decode false for non-53"]
    BC2["BC-2.08.002\nQR-Bit Counting"] --> AC004["AC-004\nquery_count++ on QR=0"]
    BC2 --> AC005["AC-005\nresponse_count++ on QR=1"]
    BC2 --> AC006["AC-006\nshort payload → response"]
    BC2 --> AC007["AC-007\nexactly one counter per analyze"]
    BC3["BC-2.08.003\nsummarize Output"] --> AC008["AC-008\nanalyzer_name==DNS"]
    BC3 --> AC009["AC-009\npackets_analyzed==sum"]
    BC3 --> AC010["AC-010\ndns_queries key"]
    BC3 --> AC011["AC-011\ndns_responses key"]
    BC3 --> AC012["AC-012\nexactly two detail keys"]
    BC4["BC-2.08.004\nNever-Emit Contract"] --> AC013["AC-013\nanalyze returns vec![]"]
    BC4 --> AC014["AC-014\nhigh volume never emits"]
    AC001 --> T["tests/dns_tests.rs"]
    AC013 --> T
    T --> S["src/analyzer/dns.rs"]
```

---

## Test Evidence

### Coverage Summary

| Metric | Value | Threshold | Status |
|--------|-------|-----------|--------|
| Unit tests | 18/18 pass | 100% | PASS |
| Coverage | dns.rs fully exercised | >80% | PASS |
| Mutation kill rate | N/A — brownfield (existing code) | N/A | N/A |
| Holdout satisfaction | N/A — evaluated at wave gate | N/A | N/A |

### Test Flow

```mermaid
graph LR
    Unit["18 Unit Tests\n(dns_tests.rs)"]
    Unit -->|18/18 PASS| Pass["PASS"]
    style Pass fill:#90EE90
```

| Metric | Value |
|--------|-------|
| **New tests** | 18 added (tests/dns_tests.rs), 0 modified |
| **Total suite** | 18 tests PASS (all green gate) |
| **Coverage delta** | dns.rs: all branches covered |
| **Regressions** | 0 |

<details>
<summary><strong>Detailed Test Results</strong></summary>

### New Tests (This PR) — AC Coverage

| Test | AC/EC | Result |
|------|-------|--------|
| `test_dns_can_decode_port_53_tcp_and_udp()` | AC-001 | PASS |
| `test_dns_can_decode_false_for_icmp()` | AC-002 | PASS |
| `test_dns_can_decode_false_for_non_dns_port()` | AC-003 | PASS |
| `test_dns_analyzer_counts_queries()` | AC-004 | PASS |
| `test_dns_analyzer_counts_responses()` | AC-005 | PASS |
| `test_dns_short_payload_counted_as_response()` | AC-006 | PASS |
| `test_dns_analyze_increments_exactly_one_counter()` | AC-007 | PASS |
| `test_dns_summarize_analyzer_name()` | AC-008 | PASS |
| `test_dns_summarize_packets_analyzed_is_sum()` | AC-009 | PASS |
| `test_dns_summarize_detail_keys()` | AC-010, AC-011 | PASS |
| `test_dns_summarize_exactly_two_detail_keys()` | AC-012 | PASS |
| `test_dns_analyze_always_returns_empty_findings()` | AC-013 | PASS |
| `test_dns_high_volume_no_findings()` | AC-014 | PASS |
| `test_dns_ec001_udp_src53_can_decode()` | EC-001 | PASS |
| `test_dns_ec002_tcp_dst53_can_decode()` | EC-002 | PASS |
| `test_dns_ec003_empty_payload_counted_as_response()` | EC-003 | PASS |
| `test_dns_ec004_all_flags_set_counted_as_response()` | EC-004 | PASS |
| `test_dns_ec005_zero_packets_summarize()` | EC-005 | PASS |

</details>

---

## Holdout Evaluation

N/A — evaluated at wave gate.

---

## Adversarial Review

| Pass | Context | Findings | Critical | High | Status |
|------|---------|----------|----------|------|--------|
| 1 | Fresh | Cosmetic only | 0 | 0 | PASS |
| 2 | Fresh | Cosmetic only | 0 | 0 | PASS |
| 3 | Fresh | None | 0 | 0 | CONVERGED |

**Convergence:** 3 consecutive clean fresh-context adversarial passes (BC-5.39.001 satisfied).

---

## Security Review

```mermaid
graph LR
    Critical["Critical: 0"]
    High["High: 0"]
    Medium["Medium: 0"]
    Low["Low: 0"]

    style Critical fill:#90EE90
    style High fill:#90EE90
    style Medium fill:#90EE90
    style Low fill:#90EE90
```

<details>
<summary><strong>Security Scan Details</strong></summary>

### SAST
- This PR adds test code only (+ a doc-comment correction). No input processing, no I/O, no unsafe blocks.
- The `DnsAnalyzer` under test uses only safe Rust: slice indexing guarded by length check (`payload.len() < 12`), bitmasking, and counter arithmetic.

### Dependency Audit
- No new dependencies introduced. Existing dependency audit (`cargo audit`, `cargo deny`) runs in CI.

### OWASP / Injection
- Not applicable: no network I/O, no string interpolation, no SQL/shell exec in changed files.

</details>

---

## Risk Assessment & Deployment

### Blast Radius
- **Systems affected:** `tests/dns_tests.rs` (new file), `src/analyzer/dns.rs` (doc comment only)
- **User impact:** None — test-only addition plus non-executable doc change
- **Data impact:** None
- **Risk Level:** LOW

### Performance Impact

| Metric | Before | After | Delta | Status |
|--------|--------|-------|-------|--------|
| Runtime behavior | unchanged | unchanged | 0 | OK |
| Binary size | unchanged | unchanged | 0 | OK |

_Doc-comment changes do not affect the compiled binary. Tests are not included in the release build._

---

## Traceability

| BC | Story AC | Test | Status |
|----|---------|------|--------|
| BC-2.08.001 | AC-001 | `test_dns_can_decode_port_53_tcp_and_udp` | PASS |
| BC-2.08.001 | AC-002 | `test_dns_can_decode_false_for_icmp` | PASS |
| BC-2.08.001 | AC-003 | `test_dns_can_decode_false_for_non_dns_port` | PASS |
| BC-2.08.002 | AC-004 | `test_dns_analyzer_counts_queries` | PASS |
| BC-2.08.002 | AC-005 | `test_dns_analyzer_counts_responses` | PASS |
| BC-2.08.002 | AC-006 | `test_dns_short_payload_counted_as_response` | PASS |
| BC-2.08.002 | AC-007 | `test_dns_analyze_increments_exactly_one_counter` | PASS |
| BC-2.08.003 | AC-008 | `test_dns_summarize_analyzer_name` | PASS |
| BC-2.08.003 | AC-009 | `test_dns_summarize_packets_analyzed_is_sum` | PASS |
| BC-2.08.003 | AC-010/011 | `test_dns_summarize_detail_keys` | PASS |
| BC-2.08.003 | AC-012 | `test_dns_summarize_exactly_two_detail_keys` | PASS |
| BC-2.08.004 | AC-013 | `test_dns_analyze_always_returns_empty_findings` | PASS |
| BC-2.08.004 | AC-014 | `test_dns_high_volume_no_findings` | PASS |
| BC-2.08.001 | EC-001 | `test_dns_ec001_udp_src53_can_decode` | PASS |
| BC-2.08.001 | EC-002 | `test_dns_ec002_tcp_dst53_can_decode` | PASS |
| BC-2.08.002 | EC-003 | `test_dns_ec003_empty_payload_counted_as_response` | PASS |
| BC-2.08.002 | EC-004 | `test_dns_ec004_all_flags_set_counted_as_response` | PASS |
| BC-2.08.003 | EC-005 | `test_dns_ec005_zero_packets_summarize` | PASS |

---

## AI Pipeline Metadata

<details>
<summary><strong>Pipeline Details</strong></summary>

```yaml
ai-generated: true
pipeline-mode: brownfield-formalization
factory-version: "1.0.0-rc.18"
pipeline-stages:
  spec-crystallization: completed
  story-decomposition: completed
  tdd-implementation: completed
  holdout-evaluation: "N/A — evaluated at wave gate"
  adversarial-review: completed
  formal-verification: skipped
  convergence: achieved
convergence-metrics:
  adversarial-passes: 3
  clean-fresh-context-passes: 3
  spec-novelty: N/A
  test-kill-rate: N/A
  implementation-ci: green
models-used:
  builder: claude-sonnet-4-6
  adversary: claude-sonnet-4-6
generated-at: "2026-05-22T00:00:00Z"
```

</details>

---

## Pre-Merge Checklist

- [x] All CI status checks passing
- [x] Coverage delta is positive (18 new tests, 0 regressions)
- [x] No critical/high security findings unresolved
- [x] Rollback procedure: `git revert <merge-sha>` — zero production risk
- [x] No feature flags (test-only PR)
- [x] Demo evidence: N/A — no UI/behavioral output change (statistics-only, never-emit design)
- [x] Diff verified: exactly two files (tests/dns_tests.rs + src/analyzer/dns.rs doc-comment)
- [x] No demo files (.tape/.gif/.webm) committed
