### PR TITLE
fix(reassembly): use saturating_add for overlap_count (wave-10 hardening)

### DIFF
--- a/src/reassembly/segment.rs
+++ b/src/reassembly/segment.rs
@@ -140,7 +140,7 @@ impl FlowDirection {
         }
 
         if has_overlap {
-            self.overlap_count += 1;
+            self.overlap_count = self.overlap_count.saturating_add(1);
 
             let fully_covered = trimmed_ranges
                 .iter()


### PR DESCRIPTION
Wave 10 wave-level adversarial pass-1 F-W10P1-001 (HIGH).

src/reassembly/segment.rs:143 lacked saturating_add hardening that sibling per-direction counters use. With release profile overflow-checks=true (Cargo.toml:31), 2^32 overlaps would trigger panic — adversarial-input DoS vector.

Sibling hardening confirmed: out_of_window_count (segment.rs:65), fin_count (flow.rs:256), small_segment_run (mod.rs:366) all use saturating_add. Now overlap_count joins.

1-line change. Zero test-suite impact (all tests pass).