### PR TITLE
test: drift-remediation coverage + assertion strengthening

### DIFF
--- a/src/analyzer/http.rs
+++ b/src/analyzer/http.rs
@@ -649,3 +649,93 @@ impl HttpAnalyzer {
         self.flows.len()
     }
 }
+
+#[cfg(test)]
+#[allow(non_snake_case)]
+mod tests {
+    use super::truncate_uri;
+
+    /// BC-2.06.010 invariant 2: `truncate_uri` must not split a UTF-8 codepoint.
+    ///
+    /// Exercises `floor_char_boundary` on a multibyte URI where the requested
+    /// byte limit falls in the middle of a 2-byte codepoint ('é', U+00E9).
+    #[test]
+    fn test_BC_2_06_010_truncate_uri_multibyte_two_byte_codepoint() {
+        // 'é' encodes as [0xC3, 0xA9] (2 bytes).  A string of 5 'é' characters
+        // is 10 bytes.  A limit of 3 falls mid-codepoint (after byte 2 of the
+        // second 'é').  floor_char_boundary(3) must round down to 2.
+        let uri = "éééé"; // 4 × 2 = 8 bytes
+        let max_len = 3; // falls between byte 2 and 3, i.e. mid-second-codepoint
+        let result = truncate_uri(uri, max_len);
+
+        // (a) result length must not exceed max_len bytes
+        assert!(
+            result.len() <= max_len,
+            "truncate_uri must produce at most {max_len} bytes; got {} bytes",
+            result.len()
+        );
+        // (b) result must be valid UTF-8 (no panic above proves no codepoint split)
+        assert!(
+            std::str::from_utf8(result.as_bytes()).is_ok(),
+            "truncate_uri must produce valid UTF-8"
+        );
+        // (c) result must be strictly shorter than the input (input > max_len)
+        assert!(
+            result.len() < uri.len(),
+            "truncate_uri must shorten the URI when input ({} bytes) > max_len ({max_len})",
+            uri.len()
+        );
+        // (d) exact value: floor_char_boundary(3) on 'é'*4 = 2 (one 'é')
+        assert_eq!(
+            result, "é",
+            "truncate_uri must return exactly one 'é' (2 bytes)"
+        );
+    }
+
+    /// BC-2.06.010 invariant 2: `truncate_uri` must not split a UTF-8 codepoint.
+    ///
+    /// Exercises `floor_char_boundary` with a 4-byte emoji codepoint ('🎯', U+1F3AF).
+    /// A limit of 5 falls mid-codepoint (after 1 byte of the second emoji).
+    #[test]
+    fn test_BC_2_06_010_truncate_uri_multibyte_four_byte_codepoint() {
+        // '🎯' encodes as [0xF0, 0x9F, 0x8E, 0xAF] (4 bytes).
+        // Two emojis = 8 bytes.  A limit of 5 falls after byte 1 of the second
+        // emoji — floor_char_boundary(5) must round down to 4 (one full emoji).
+        let uri = "🎯🎯"; // 8 bytes
+        let max_len = 5;
+        let result = truncate_uri(uri, max_len);
+
+        assert!(
+            result.len() <= max_len,
+            "truncate_uri must produce at most {max_len} bytes; got {} bytes",
+            result.len()
+        );
+        assert!(
+            std::str::from_utf8(result.as_bytes()).is_ok(),
+            "truncate_uri must produce valid UTF-8"
+        );
+        assert!(
+            result.len() < uri.len(),
+            "truncate_uri must shorten the URI when input ({} bytes) > max_len ({max_len})",
+            uri.len()
+        );
+        // floor_char_boundary(5) on '🎯🎯' = 4 (one full emoji)
+        assert_eq!(
+            result, "🎯",
+            "truncate_uri must return exactly one '🎯' (4 bytes)"
+        );
+    }
+
+    /// BC-2.06.010 invariant 2: when the URI fits within max_len bytes,
+    /// `truncate_uri` must return the full URI unchanged.
+    #[test]
+    fn test_BC_2_06_010_truncate_uri_multibyte_no_truncation_when_fits() {
+        let uri = "éé"; // 4 bytes
+        let max_len = 10;
+        let result = truncate_uri(uri, max_len);
+        assert_eq!(
+            result, uri,
+            "truncate_uri must return full URI when it fits within max_len"
+        );
+    }
+}

--- a/tests/dispatcher_tests.rs
+++ b/tests/dispatcher_tests.rs
@@ -1,3 +1,14 @@
+// Test ordering / grouping convention
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers (flow_key, etc.) appear first.
+//
+// Test functions are grouped by the Behavioral Contract they exercise and
+// named with the BC-prefixed pattern `test_BC_S_SS_NNN_…` where available.
+// Within each group the tests appear in precondition → postcondition →
+// invariant order, matching the structure of the BC document.  Edge-case and
+// integration tests that exercise multiple BCs follow at the end.
+// ─────────────────────────────────────────────────────────────────────────────
+
 use std::net::IpAddr;
 use wirerust::analyzer::http::HttpAnalyzer;
 use wirerust::analyzer::tls::TlsAnalyzer;
@@ -188,12 +199,12 @@ fn test_port_fallback_443_to_tls() {
     assert!(
         tls.parse_error_count() > 0 || tls.truncated_record_count() > 0,
         "AC-007: port 443 fallback must route to Tls analyzer \
-         (5-byte non-TLS garbage triggers TlsAnalyzer parse/truncation event)"
+         (6-byte non-TLS garbage triggers TlsAnalyzer parse/truncation event)"
     );
 }
 
 /// AC-007 (BC-2.05.003 postcondition 1): Port 8443 → DispatchTarget::Tls via port fallback.
-/// 5-byte non-TLS, non-HTTP data ensures neither content check fires.
+/// 6-byte non-TLS, non-HTTP data ensures neither content check fires.
 #[test]
 fn test_port_fallback_8443_to_tls() {
     let mut dispatcher = StreamDispatcher::new(Some(HttpAnalyzer::new()), Some(TlsAnalyzer::new()));
@@ -224,7 +235,7 @@ fn test_port_fallback_8443_to_tls() {
     assert!(
         tls.parse_error_count() > 0 || tls.truncated_record_count() > 0,
         "AC-007: port 8443 fallback must route to Tls analyzer \
-         (5-byte non-TLS garbage triggers TlsAnalyzer parse/truncation event)"
+         (6-byte non-TLS garbage triggers TlsAnalyzer parse/truncation event)"
     );
 }
 
@@ -633,7 +644,7 @@ fn test_port_fallback_uses_canonical_port_ordering() {
         assert!(
             tls.parse_error_count() > 0 || tls.truncated_record_count() > 0,
             "AC-008: port 8443 canonical-ordering fallback must route to Tls analyzer \
-             (5-byte non-TLS garbage triggers TlsAnalyzer parse/truncation event)"
+             (6-byte non-TLS garbage triggers TlsAnalyzer parse/truncation event)"
         );
     }
 
@@ -674,7 +685,7 @@ fn test_port_fallback_uses_canonical_port_ordering() {
         assert!(
             tls.parse_error_count() > 0 || tls.truncated_record_count() > 0,
             "AC-008: port 443 canonical-ordering fallback must route to Tls analyzer \
-             (5-byte non-TLS garbage triggers TlsAnalyzer parse/truncation event)"
+             (6-byte non-TLS garbage triggers TlsAnalyzer parse/truncation event)"
         );
     }
 

--- a/tests/reassembly_engine_tests.rs
+++ b/tests/reassembly_engine_tests.rs
@@ -11686,6 +11686,12 @@ fn test_BC_2_04_018_conflicting_overlap_emits_t1036_finding() {
         "summary must contain the FlowKey display string; got: {:?}",
         f.summary
     );
+    // BC-2.04.018 PC2: reassembly-engine findings set direction: None
+    // (ConflictingOverlap is a per-stream event, not directional).
+    assert_eq!(
+        f.direction, None,
+        "BC-2.04.018 PC2: ConflictingOverlap finding must have direction == None"
+    );
 }
 
 // --- AC-004 (BC-2.04.018 postcondition 3) ---
@@ -11895,6 +11901,12 @@ fn test_BC_2_04_019_overlap_threshold_emits_medium_t1036_finding() {
         Some("T1036"),
         "mitre_technique must be Some(\"T1036\")"
     );
+    // BC-2.04.019 PC1 evidence string (src/reassembly/mod.rs:441)
+    assert_eq!(
+        f.evidence,
+        vec!["Possible evasion attempt"],
+        "BC-2.04.019 PC1: evidence must be exactly [\"Possible evasion attempt\"]"
+    );
 }
 
 // --- AC-007 (BC-2.04.019 postcondition 4) ---
@@ -12065,6 +12077,15 @@ fn test_BC_2_04_020_small_segment_run_emits_finding() {
     assert_eq!(
         f.mitre_technique, None,
         "mitre_technique must be None for small-segment alert"
+    );
+    // BC-2.04.020 PC1 evidence string (src/reassembly/mod.rs:476)
+    assert_eq!(
+        f.evidence,
+        vec![
+            "Long unbroken run of undersized TCP segments; possible \
+              segmentation-based IDS evasion"
+        ],
+        "BC-2.04.020 PC1: evidence must be the canonical small-segment evasion string"
     );
 }
 
@@ -13208,58 +13229,17 @@ fn test_BC_2_04_023_truncated_finding_emitted() {
 #[allow(non_snake_case)]
 #[test]
 fn test_BC_2_04_023_truncated_finding_dropped_at_cap() {
-    // Fill findings to MAX_FINDINGS (10,000) by sending conflicting overlaps across
-    // 10,000 unique flows. Strategy: SYN + out-of-order data (leaves gap, won't flush)
-    // + conflicting retransmit at same seq → ConflictingOverlap finding per flow.
+    // Fill findings to MAX_FINDINGS (10,000) using the shared helper, then verify
+    // that a depth-truncation finding on a new flow is silently dropped
+    // (BC-2.04.023 PC2) and dropped_findings increments (BC-2.04.023 INV-2).
     let config = ReassemblyConfig {
         max_depth: 10,
-        max_flows: 20_000,
         ..ReassemblyConfig::default()
     };
-    let mut reassembler = TcpReassembler::new(config);
+    let mut reassembler = fill_findings_to_cap(config);
     let mut handler = RecordingHandler::new();
-
-    let server = [10, 0, 0, 2];
-    let client = [10, 0, 0, 1];
-
-    // Generate exactly 10,000 findings via ConflictingOverlap on unique flows.
-    // Each flow: SYN (ISN=1000) + out-of-order data at seq=1002 (offset=2, gap at 1)
-    //             + conflicting data at seq=1002 (same offset, different bytes) → 1 finding.
-    for port in 1u16..=10_000u16 {
-        // SYN → establishes ISN=1000, base_offset=1
-        reassembler.process_packet(
-            &make_tcp_packet(
-                client,
-                port,
-                server,
-                80,
-                1000,
-                &[],
-                true,
-                false,
-                false,
-                false,
-            ),
-            1,
-            &mut handler,
-        );
-        // Out-of-order data at offset=2 (gap at offset=1 prevents flush → stays in BTreeMap)
-        reassembler.process_packet(
-            &make_tcp_packet(
-                client, port, server, 80, 1002, b"AAAA", false, true, false, false,
-            ),
-            2,
-            &mut handler,
-        );
-        // Conflicting retransmission at same offset=2, different bytes → ConflictingOverlap → 1 finding
-        reassembler.process_packet(
-            &make_tcp_packet(
-                client, port, server, 80, 1002, b"BBBB", false, true, false, false,
-            ),
-            3,
-            &mut handler,
-        );
-    }
+    let client = [10u8, 0, 0, 1];
+    let server = [10u8, 0, 0, 2];
 
     // Verify we've reached MAX_FINDINGS (10,000)
     let findings_before = reassembler.findings().len();
@@ -13269,7 +13249,8 @@ fn test_BC_2_04_023_truncated_finding_dropped_at_cap() {
     );
     let dropped_before = reassembler.stats().dropped_findings;
 
-    // Now trigger depth truncation on a new flow (port 10001)
+    // Now trigger depth truncation on a new flow (port 10001, dst 80 — unused by
+    // fill_findings_to_cap which uses dst 8080 on ports 1..=10_000).
     let new_port: u16 = 10_001;
     reassembler.process_packet(
         &make_tcp_packet(


### PR DESCRIPTION
# test: drift-remediation coverage + assertion strengthening

**Scope:** Test-only — no production behavior changes
**Branch:** `test/drift-remediation-coverage`
**Commit:** `76ae222`
**Drift items addressed:** W10-D10, W10-D11, W10-D14, W12-D1, W13-D1, F-W16-S043-P3-002
**Unreachable-arm documented:** F-W16-S052-P2-002 (dead defensive code, no test added)

---

## Summary

Seven validated drift findings (DF-VALIDATION-001 policy satisfied) are remediated here.
All changes are confined to `tests/dispatcher_tests.rs`, `tests/reassembly_engine_tests.rs`,
and `#[cfg(test)]` blocks in `src/analyzer/http.rs` — zero production behavior change.

- **W12-D1:** Corrected "5-byte" → "6-byte" prose in three dispatcher fallback test assertions
  (the actual test arrays at those sites are `[0x16,0x04,0x01,0x00,0x01,0xFF]` = 6 bytes).
  Port-80/8080 tests use genuine 5-byte arrays and are unchanged.
- **W13-D1:** Added top-of-file block comment to `dispatcher_tests.rs` documenting the
  BC-prefixed test ordering/grouping convention.
- **W10-D10:** Refactored `test_BC_2_04_023_truncated_finding_dropped_at_cap` to use the
  existing `fill_findings_to_cap` helper instead of re-implementing the 10,000-flow fill loop.
  Behavior identical; eliminates duplicated logic.
- **W10-D11:** Pinned exact evidence strings in `test_BC_2_04_019` ("Possible evasion attempt")
  and `test_BC_2_04_020` ("Long unbroken run of undersized TCP segments; possible
  segmentation-based IDS evasion") against the canonical source values in `src/reassembly/mod.rs`.
- **W10-D14:** Added `assert_eq!(f.direction, None)` to `test_BC_2_04_018` covering BC-2.04.018
  PC2 (ConflictingOverlap findings carry `direction: None`).
- **F-W16-S043-P3-002:** Added three `#[cfg(test)]` unit tests in `src/analyzer/http.rs` for
  `truncate_uri` — exercises multibyte char-boundary safety (2-byte 'é', 4-byte '🎯' codepoints
  with byte limit mid-codepoint) per BC-2.06.010 invariant 2.
- **F-W16-S052-P2-002:** The `Err(_)` arm in `handle_client_hello` is functionally unreachable
  via `on_data` (nom `many0(complete(...))` absorbs Error, returns Ok). Documented as dead
  defensive code in commit message; no test added.

---

## Architecture Changes

```mermaid
graph TD
    DriftItems["Drift Items\nW10/W12/W13 + F-W16"]
    DispatcherTests["tests/dispatcher_tests.rs\n(W12-D1, W13-D1)"]
    ReassemblyTests["tests/reassembly_engine_tests.rs\n(W10-D10/D11/D14)"]
    HttpSrc["src/analyzer/http.rs\n(#[cfg(test)] only)\n(F-W16-S043-P3-002)"]
    NoProduction["No production behavior change"]

    DriftItems --> DispatcherTests
    DriftItems --> ReassemblyTests
    DriftItems --> HttpSrc
    DispatcherTests --> NoProduction
    ReassemblyTests --> NoProduction
    HttpSrc --> NoProduction
```

---

## Story Dependencies

```mermaid
graph LR
    S041["STORY-041 merged #139"]
    S042["STORY-042 merged #140"]
    S052["STORY-052 merged #141"]
    S043["STORY-043 merged #142"]
    S044["STORY-044 merged #143"]
    W16P1["W16-REM-P1 merged #144"]
    W16P2["W16-REM-P2 merged #145"]
    W16P3["W16-REM-P3 merged #146"]
    DRIFT["DRIFT-REM (this PR)"]

    S041 --> S042
    S042 --> S043
    S052 --> S044
    S043 --> W16P1
    W16P1 --> W16P2
    W16P2 --> W16P3
    W16P3 --> DRIFT
```

All upstream PRs already merged. No blockers.

---

## Spec Traceability

```mermaid
flowchart LR
    W12D1["W12-D1\nDispatcher fallback\n5→6 byte prose fix"]
    W13D1["W13-D1\nOrdering convention\ncomment added"]
    W10D10["W10-D10\nAC-005 cap-fill\nhelper refactor"]
    W10D11["W10-D11\nEvidence strings\npinned exactly"]
    W10D14["W10-D14\ndirection==None\nassertion added"]
    FW16S043["F-W16-S043-P3-002\ntruncate_uri\nmultibyte tests"]
    FW16S052["F-W16-S052-P2-002\nErr arm unreachable\ndocumented, no test"]

    BC205["BC-2.05.003\nPort fallback routing"]
    BC204a["BC-2.04.023\nTruncated finding cap"]
    BC204b["BC-2.04.019/020\nEvidence strings"]
    BC204c["BC-2.04.018 PC2\ndirection: None"]
    BC206["BC-2.06.010 inv2\nchar-boundary safety"]

    W12D1 --> BC205
    W10D10 --> BC204a
    W10D11 --> BC204b
    W10D14 --> BC204c
    FW16S043 --> BC206
```

---

## Findings Detail

| Finding ID | Severity | File | Description |
|------------|----------|------|-------------|
| W12-D1 | MEDIUM | `tests/dispatcher_tests.rs` | "5-byte" → "6-byte" prose in 3 assertion messages for port-443/8443/8443-canonical tests |
| W13-D1 | LOW | `tests/dispatcher_tests.rs` | Top-of-file ordering convention block comment |
| W10-D10 | LOW | `tests/reassembly_engine_tests.rs` | Use `fill_findings_to_cap` helper in cap-fill test |
| W10-D11 | MEDIUM | `tests/reassembly_engine_tests.rs` | Pin exact evidence strings for T1036 and small-segment findings |
| W10-D14 | MEDIUM | `tests/reassembly_engine_tests.rs` | Add `direction == None` assertion for ConflictingOverlap |
| F-W16-S043-P3-002 | MEDIUM | `src/analyzer/http.rs` (#[cfg(test)]) | 3 new unit tests for `truncate_uri` multibyte char-boundary safety |
| F-W16-S052-P2-002 | INFO | — (documented only) | `Err(_)` arm in `handle_client_hello` is unreachable via `on_data`; no test added |

---

## Test Evidence

- `cargo test --all-targets` — ~847 tests, all green
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo fmt --check` — clean
- Files changed: 3 files (+135/-53), all test code
- Zero production code added or modified; blast radius = zero

---

## Holdout Evaluation

N/A — evaluated at wave gate.

---

## Adversarial Review

All drift findings validated per DF-VALIDATION-001 before implementation.
F-W16-S052-P2-002 documented as dead defensive code with nom `many0/complete` semantics
explanation; no regression risk.

---

## Demo Evidence

N/A — test-quality and assertion-strengthening fixes only. No new user-visible ACs
introduced. Prior demo evidence for affected stories remains valid and unaffected.

---

## Security Review

N/A — test-only changes (plus one `#[cfg(test)]` module in `src/`). No production paths
modified. No new dependencies introduced. No input validation, authentication, or
data-handling production code touched.

---

## Risk Assessment

- **Blast radius:** Zero — all changes are in `#[cfg(test)]` or `tests/`. No production
  behavior altered.
- **Performance impact:** None.
- **Rollback:** Trivial — test-only changes can be reverted without any runtime impact.

---

## AI Pipeline Metadata

- **Pipeline mode:** brownfield-drift-remediation
- **Models used:** claude-sonnet-4-6
- **Policy satisfied:** DF-VALIDATION-001 (all drift items validated before fix)

---

## Pre-Merge Checklist

- [x] PR description matches actual diff (test-only, 7 drift items)
- [x] All upstream story PRs and wave PRs merged
- [x] `cargo test --all-targets` green (~847 tests)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] Security review: N/A (test-only)
- [x] Demo evidence: N/A (no new ACs)
- [x] Semantic PR title: `test: drift-remediation coverage + assertion strengthening`
- [x] Target branch: `develop`
- [x] DF-VALIDATION-001 policy: all items validated before filing
