### PR TITLE
docs(demo-evidence): correct STORY-080 epic-rollup AC counts + reporter-role attribution (Wave-22 finding F-W22-T1)

### DIFF
--- a/docs/demo-evidence/STORY-080/evidence-report.md
+++ b/docs/demo-evidence/STORY-080/evidence-report.md
@@ -18,8 +18,8 @@ brownfield formalization).
 
 Full test suite: **970 passed / 0 failed / 0 ignored**.
 
-This story COMPLETES the E-8 reporter epic. JSON reporter (STORY-076/077/078),
-Terminal reporter (STORY-077), and CSV reporter (STORY-079/080) are all fully formalized.
+This story COMPLETES the E-8 reporter epic. JSON reporter (STORY-076),
+Terminal reporter (STORY-077/078), and CSV reporter (STORY-079/080) are all fully formalized.
 
 ---
 
@@ -123,8 +123,8 @@ Command: `cargo test --test reporter_csv_tests story_080 -- --nocapture`
 | Sub-story | BC Range | ACs | Status |
 |-----------|----------|-----|--------|
 | STORY-076 | BC-2.11.001..006 | 13 | FORMALIZED |
-| STORY-077 | BC-2.11.007..012 | 13 | FORMALIZED |
-| STORY-078 | BC-2.11.013..019 | 13 | FORMALIZED |
+| STORY-077 | BC-2.11.007..012 | 14 | FORMALIZED |
+| STORY-078 | BC-2.11.013..019 | 16 | FORMALIZED |
 | STORY-079 | BC-2.11.020..022 | 13 | FORMALIZED |
 | STORY-080 | BC-2.11.023..024 | 12 | FORMALIZED |
 


### PR DESCRIPTION
## Summary

Fixes factual errors in the E-8 Epic Completion Status rollup section of `docs/demo-evidence/STORY-080/evidence-report.md` (Wave-22 finding F-W22-T1, MEDIUM). The per-AC PASS manifest is correct and unchanged.

**Corrections made:**

| Field | Old | New |
|-------|-----|-----|
| Prose reporter-grouping | STORY-078 attributed to JSON reporter | STORY-078 correctly attributed to Terminal reporter |
| STORY-077 AC count | 13 | 14 (per STORY-077.md AC-001..AC-014) |
| STORY-078 AC count | 13 | 16 (per STORY-078.md AC-001..AC-016) |

Correct grouping: JSON = STORY-076; Terminal = STORY-077 + STORY-078; CSV = STORY-079 + STORY-080.

## Files changed

- `docs/demo-evidence/STORY-080/evidence-report.md` — prose lines 21-22 and epic-rollup table rows for STORY-077 and STORY-078 only.

## Test plan

- [ ] Docs-only change — no src/ or test/ files modified
- [ ] CI lint/test/build all pass trivially (no Rust changes)
- [ ] Semantic PR title matches `docs` type (CI semantic-PR check passes)