### PR TITLE
fix(cli): reject --reassembly-depth/-memcap 0 via value_parser (FIX-P5-002, ADV-IMPL-P04-MED-001)

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -13,6 +13,16 @@ use std::path::PathBuf;
 
 use clap::{Parser, Subcommand, ValueEnum};
 
+/// Value parser for usize arguments that must be >= 1 (0 is rejected).
+/// Used for `--reassembly-depth` and `--reassembly-memcap`.
+fn parse_nonzero_usize(s: &str) -> Result<usize, String> {
+    let v: usize = s.parse().map_err(|e| format!("invalid value '{s}': {e}"))?;
+    if v == 0 {
+        return Err("0 is not in 1..".to_string());
+    }
+    Ok(v)
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
 pub enum OutputFormat {
     Json,
@@ -67,11 +77,11 @@ pub struct Cli {
     pub no_reassemble: bool,
 
     /// Per-direction stream reassembly limit in MB (default: 10)
-    #[arg(long, global = true, default_value_t = 10)]
+    #[arg(long, global = true, default_value_t = 10, value_parser = parse_nonzero_usize)]
     pub reassembly_depth: usize,
 
     /// Global reassembly memory cap in MB (default: 1024)
-    #[arg(long, global = true, default_value_t = 1024)]
+    #[arg(long, global = true, default_value_t = 1024, value_parser = parse_nonzero_usize)]
     pub reassembly_memcap: usize,
 
     /// Override the overlapping-segment anomaly threshold (default: 50).

--- a/tests/cli_story_087_tests.rs
+++ b/tests/cli_story_087_tests.rs
@@ -386,22 +386,50 @@ mod story_087 {
     }
 
     // -----------------------------------------------------------------------
-    // EC-001 — --reassembly-depth 0 accepted
+    // EC-001 — --reassembly-depth 0 rejected (FIX-P5-002)
     // -----------------------------------------------------------------------
 
-    /// EC-001 (STORY-087 EC-001): `--reassembly-depth 0` is accepted (0 is a
-    /// valid value); `reassembly_depth = 0`.
-    ///
-    /// Discriminating assertions:
-    ///   Positive: parse returns Ok.
-    ///   Positive: reassembly_depth == 0.
-    ///   Negative: parse does NOT fail with a range error.
+    // STORY-087 EC-001 (revised FIX-P5-002, ADV-IMPL-P04-MED-001):
+    // --reassembly-depth 0 rejected with usage error.
+    //
+    // Before the fix, clap accepted 0 (no range validator). After the fix,
+    // `value_parser = clap::value_parser!(usize).range(1..)` rejects 0 with
+    // a ValueValidation error (clap exit code 2) instead of letting the
+    // process reach the assert!(max_depth > 0) in reassembly/mod.rs which
+    // panics with exit 101.
+    //
+    // RED: FAILS now because 0 is accepted (no range validator exists yet).
     #[test]
-    fn test_EC_001_reassembly_depth_zero_accepted() {
-        let cli = parse_ok(&["wirerust", "--reassembly-depth", "0", "summary", "x.pcap"]);
+    fn test_EC_001_reassembly_depth_zero_rejected() {
+        let err = parse_err(&["wirerust", "--reassembly-depth", "0", "summary", "x.pcap"]);
         assert_eq!(
-            cli.reassembly_depth, 0,
-            "--reassembly-depth 0 must be accepted and yield reassembly_depth = 0"
+            err.kind(),
+            ErrorKind::ValueValidation,
+            "--reassembly-depth 0 must produce ValueValidation error, got: {:?}",
+            err.kind()
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // EC-001b — --reassembly-memcap 0 rejected (FIX-P5-002)
+    // -----------------------------------------------------------------------
+
+    // STORY-087 EC-001 (memcap twin, FIX-P5-002, ADV-IMPL-P04-MED-001):
+    // --reassembly-memcap 0 rejected with usage error.
+    //
+    // Mirrors test_EC_001_reassembly_depth_zero_rejected for the sibling flag.
+    // After the fix, `value_parser = clap::value_parser!(usize).range(1..)`
+    // rejects 0 at parse time.
+    //
+    // RED: FAILS now because 0 is accepted (no range validator exists yet).
+    #[test]
+    fn test_EC_001_reassembly_memcap_zero_rejected() {
+        let err = parse_err(&["wirerust", "--reassembly-memcap", "0", "summary", "x.pcap"]);
+        assert_eq!(
+            err.kind(),
+            ErrorKind::ValueValidation,
+            "--reassembly-memcap 0 must produce ValueValidation error, got: {:?}",
+            err.kind()
         );
     }
 
@@ -511,6 +539,72 @@ mod story_087 {
             cli.out_of_window_threshold.is_none(),
             "out_of_window_threshold must be None"
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // Integration tests (assert_cmd): 0 causes clap exit-2, NOT panic exit-101
+    // -----------------------------------------------------------------------
+
+    // FIX-P5-002, ADV-IMPL-P04-MED-001:
+    // `--reassembly-depth 0` on the `analyze` subcommand must be rejected at
+    // parse time (clap exit code 2, stderr contains an invalid-value message)
+    // and must NOT panic (exit 101) or succeed (exit 0).
+    //
+    // The fixture http-ooo.pcap contains TCP HTTP traffic; `--http` causes
+    // TCP reassembly to be exercised. Before the fix, depth=0 reaches
+    // `assert!(max_depth > 0)` in reassembly/mod.rs and panics with exit 101.
+    //
+    // RED: FAILS now — binary exits 101 (panic) instead of 2 (clap rejection).
+    #[test]
+    fn test_analyze_reassembly_depth_zero_exits_usage_error() {
+        use assert_cmd::Command;
+        use predicates::prelude::*;
+
+        const FIXTURE: &str = "tests/fixtures/http-ooo.pcap";
+
+        let assert = Command::cargo_bin("wirerust")
+            .expect("binary built")
+            .args(["--reassembly-depth", "0", "analyze", FIXTURE, "--http"])
+            .assert();
+
+        // Must exit with clap's usage-error code (2), not success (0) or
+        // panic (101).
+        assert
+            .failure()
+            .code(2)
+            .stderr(
+                predicate::str::contains("invalid value")
+                    .or(predicate::str::contains("0 is not in")),
+            )
+            .stderr(predicate::str::contains("panicked").not());
+    }
+
+    // FIX-P5-002, ADV-IMPL-P04-MED-001:
+    // `--reassembly-memcap 0` mirror of the depth test above.
+    //
+    // RED: FAILS now — binary exits 101 (panic) instead of 2 (clap rejection).
+    #[test]
+    fn test_analyze_reassembly_memcap_zero_exits_usage_error() {
+        use assert_cmd::Command;
+        use predicates::prelude::*;
+
+        const FIXTURE: &str = "tests/fixtures/http-ooo.pcap";
+
+        let assert = Command::cargo_bin("wirerust")
+            .expect("binary built")
+            .args(["--reassembly-memcap", "0", "analyze", FIXTURE, "--http"])
+            .assert();
+
+        // Must exit with clap's usage-error code (2), not success (0) or
+        // panic (101).
+        assert
+            .failure()
+            .code(2)
+            .stderr(
+                predicate::str::contains("invalid value")
+                    .or(predicate::str::contains("0 is not in")),
+            )
+            .stderr(predicate::str::contains("panicked").not());
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## Finding

**ADV-IMPL-P04-MED-001** (Phase-5 whole-impl adversarial Pass 4): `wirerust analyze
--reassembly-depth 0` (or `--reassembly-memcap 0`) was accepted by clap with no
validation, causing the process to reach `assert!(max_depth > 0)` / `assert!(memcap > 0)`
inside `TcpReassembler::new` and panic with exit code 101. Spec claimed NFR-REL-004 /
E-RAS-004 enforced a range validator that did not exist.

## What Changed

Added a `parse_nonzero_usize` value-parser to both global args in `src/cli.rs`:

```rust
fn parse_nonzero_usize(s: &str) -> Result<usize, String> { … }
```

Both `--reassembly-depth` and `--reassembly-memcap` now carry
`value_parser = parse_nonzero_usize`. Clap rejects `0` at argument-parse time with a
`ValueValidation` error (exit 2) and the message `"0 is not in 1.."`. The internal
`assert!` guards are retained as programmer-error backstops. Default values (10 / 1024)
and all values ≥ 1 are unaffected.

> **Behavior change:** `--reassembly-depth 0` / `--reassembly-memcap 0` previously caused
> a process panic (exit 101) on `analyze`, or were silently accepted on `summary`. Now
> rejected with a clap usage error (exit 2) on **all** subcommands. STORY-087 EC-001
> revised; BC-2.12.005 v1.3 / NFR-REL-004 / E-RAS-004 reconciled on factory-artifacts.

## Architecture Changes

```mermaid
graph TD
    A[CLI arg parse] -->|value_parser=parse_nonzero_usize| B{v == 0?}
    B -->|yes| C[clap ValueValidation\nexit 2]
    B -->|no| D[TcpReassembler::new\nassert! backstop retained]
    D --> E[normal execution]
```

## Spec Traceability

```mermaid
flowchart LR
    BC["BC-2.12.005 v1.3\nNFR-REL-004 / E-RAS-004"] --> AC["STORY-087 EC-001 (revised)\nreject depth/memcap=0"]
    AC --> T1["test_EC_001_reassembly_depth_zero_rejected\ntest_EC_001_reassembly_memcap_zero_rejected"]
    AC --> T2["test_analyze_reassembly_depth_zero_exits_usage_error\ntest_analyze_reassembly_memcap_zero_exits_usage_error"]
    T1 --> IMPL["src/cli.rs\nparse_nonzero_usize"]
    T2 --> IMPL
```

## Story Dependencies

```mermaid
graph LR
    FIX-P5-002 -->|fixes finding from| STORY-087
    FIX-P5-002 -->|no blocking deps| DEVELOP[develop]
```

## Test Evidence

| Test | Type | Result |
|------|------|--------|
| `test_EC_001_reassembly_depth_zero_rejected` | Unit (clap parse) | GREEN |
| `test_EC_001_reassembly_memcap_zero_rejected` | Unit (clap parse) | GREEN |
| `test_analyze_reassembly_depth_zero_exits_usage_error` | Integration (assert_cmd) | GREEN |
| `test_analyze_reassembly_memcap_zero_exits_usage_error` | Integration (assert_cmd) | GREEN |
| Full suite (`cargo test --all-targets`) | All | GREEN |
| `cargo clippy --all-targets -- -D warnings` | Lint | GREEN |
| `cargo fmt --check` | Format | GREEN |

Scope: 2 files changed, 118 insertions(+), 14 deletions(−). No other behavior modified.

## Demo Evidence

Recordings in `.factory/demo-evidence/FIX-P5-002/`:

| AC | Recording | Exit Code |
|----|-----------|-----------|
| AC-001 | `AC-001-depth-zero-rejected.gif` | **2** (clap error, no panic) |
| AC-002 | `AC-002-memcap-zero-rejected.gif` | **2** (clap error, no panic) |
| AC-003 | `AC-003-valid-depth-succeeds.gif` | **0** (normal, unaffected) |

Coverage: 3/3 ACs demonstrated (100%). No panic observed on any run.

## Security Review

No security-relevant surface changed. `parse_nonzero_usize` is a pure value validator
with no I/O, no allocation beyond the parsed integer, and no attack surface. Finding
ADV-IMPL-P04-MED-001 was a reliability issue (panic on bad input), not an injection or
auth issue. No OWASP-relevant changes.

## Holdout Evaluation

N/A — evaluated at wave gate.

## Adversarial Review

Finding originated in Phase-5 adversarial Pass 4. Fix directly closes ADV-IMPL-P04-MED-001.

## Risk Assessment

- **Blast radius:** Minimal. Only `--reassembly-depth 0` and `--reassembly-memcap 0` are
  affected. All other values and all other flags are unchanged.
- **Regression risk:** Low. Existing tests cover the success path; new tests cover the
  rejection path.
- **Performance impact:** None. Value parser runs once at argument-parse time.
- **Behavior change classification:** Breaking for callers passing `0`; those callers would
  have panicked before anyway. Net improvement in error-handling quality.

## AI Pipeline Metadata

- Pipeline mode: Fix (Phase-5 adversarial finding closure)
- Story: FIX-P5-002 / ADV-IMPL-P04-MED-001
- Branch: `fix/reassembly-zero-validator`
- Model: claude-sonnet-4-6

## Pre-Merge Checklist

- [x] PR description matches actual diff
- [x] All ACs covered by demo evidence (3/3)
- [x] Traceability chain complete (BC → AC → Test → Demo)
- [x] Security review: no security surface changed
- [x] Full test suite green (cargo test --all-targets)
- [x] Clippy clean (-D warnings)
- [x] Cargo fmt --check passes
- [ ] CI checks passing (pending)
- [ ] pr-reviewer approval (pending)
- [ ] HELD FOR HUMAN/ORCHESTRATOR APPROVAL BEFORE MERGE
