### PR TITLE
refactor(dispatcher): encapsulate analyzer fields behind accessors

### DIFF
--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -48,8 +48,8 @@ pub struct StreamDispatcher {
     classification_attempts: HashMap<FlowKey, u32>,
     /// Hard cap on classification retries per flow. LESSON-P2.11.
     max_classification_attempts: u32,
-    pub http: Option<HttpAnalyzer>,
-    pub tls: Option<TlsAnalyzer>,
+    http: Option<HttpAnalyzer>,
+    tls: Option<TlsAnalyzer>,
     unclassified_flows: u64,
 }
 
@@ -84,6 +84,30 @@ impl StreamDispatcher {
     /// Returns the configured per-flow classification-retry cap.
     pub fn max_classification_attempts(&self) -> u32 {
         self.max_classification_attempts
+    }
+
+    /// Returns a reference to the HTTP analyzer, if one was configured.
+    pub fn http_analyzer(&self) -> Option<&HttpAnalyzer> {
+        self.http.as_ref()
+    }
+
+    /// Returns a reference to the TLS analyzer, if one was configured.
+    pub fn tls_analyzer(&self) -> Option<&TlsAnalyzer> {
+        self.tls.as_ref()
+    }
+
+    /// Moves the TLS analyzer out of the dispatcher, consuming the slot.
+    ///
+    /// Intended for callers that need ownership of the analyzer after
+    /// processing is complete (e.g., to collect results after the capture
+    /// loop finishes).
+    ///
+    /// After this call the internal slot is permanently `None`. Any subsequent
+    /// [`StreamHandler::on_data`] calls will no longer route data to the TLS
+    /// analyzer — there is no re-insertion path. Only call this once the
+    /// capture loop has finished.
+    pub fn take_tls_analyzer(&mut self) -> Option<TlsAnalyzer> {
+        self.tls.take()
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -196,10 +196,10 @@ fn run_analyze(
 
     capture_result?;
 
-    if let Some(ref http) = dispatcher.http {
+    if let Some(http) = dispatcher.http_analyzer() {
         all_findings.extend(http.findings());
     }
-    if let Some(ref tls) = dispatcher.tls {
+    if let Some(tls) = dispatcher.tls_analyzer() {
         all_findings.extend(tls.findings());
     }
 
@@ -215,10 +215,10 @@ fn run_analyze(
     if enable_dns {
         analyzer_summaries.push(dns_analyzer.summarize());
     }
-    if let Some(ref http) = dispatcher.http {
+    if let Some(http) = dispatcher.http_analyzer() {
         analyzer_summaries.push(http.summarize());
     }
-    if let Some(ref tls) = dispatcher.tls {
+    if let Some(tls) = dispatcher.tls_analyzer() {
         analyzer_summaries.push(tls.summarize());
     }
 

--- a/tests/dispatcher_tests.rs
+++ b/tests/dispatcher_tests.rs
@@ -45,7 +45,7 @@ fn test_tls_content_wins_over_port_8080() {
     dispatcher.on_data(&fk, Direction::ClientToServer, &tls_data, 0);
 
     // Content-first wins: HTTP must not have received any data from this flow.
-    let http = dispatcher.http.as_ref().unwrap();
+    let http = dispatcher.http_analyzer().unwrap();
     assert_eq!(
         http.method_counts().len(),
         0,
@@ -68,7 +68,7 @@ fn test_tls_content_routes_tls_on_port_443() {
     let tls_data = [0x16u8, 0x03, 0x03, 0x00, 0x50, 0x01, 0x00, 0x00, 0x4c, 0x03];
     dispatcher.on_data(&fk, Direction::ClientToServer, &tls_data, 0);
 
-    let http = dispatcher.http.as_ref().unwrap();
+    let http = dispatcher.http_analyzer().unwrap();
     assert_eq!(
         http.method_counts().len(),
         0,
@@ -89,7 +89,7 @@ fn test_dispatcher_routes_http() {
     let http_data = b"GET /index.html HTTP/1.1\r\nHost: example.com\r\n\r\n";
     dispatcher.on_data(&fk, Direction::ClientToServer, http_data, 0);
 
-    let http = dispatcher.http.as_ref().unwrap();
+    let http = dispatcher.http_analyzer().unwrap();
     assert_eq!(*http.method_counts().get("GET").unwrap(), 1);
 }
 
@@ -130,8 +130,8 @@ fn test_all_http_method_prefixes_route_to_http() {
         let fk = flow_key(49152 + i as u16, 9999);
         dispatcher.on_data(&fk, Direction::ClientToServer, data, 0);
 
-        let http = dispatcher.http.as_ref().expect("HTTP analyzer set");
-        let tls = dispatcher.tls.as_ref().expect("TLS analyzer set");
+        let http = dispatcher.http_analyzer().expect("HTTP analyzer set");
+        let tls = dispatcher.tls_analyzer().expect("TLS analyzer set");
 
         // Either HTTP saw the data (method recorded or parse-error counted),
         // OR (for HTTP/ response-first) the parser may register differently —
@@ -162,7 +162,7 @@ fn test_dispatcher_content_detection_tls_on_port_80() {
     dispatcher.on_data(&fk, Direction::ClientToServer, &tls_data, 0);
 
     // HTTP analyzer should NOT have received this data
-    let http = dispatcher.http.as_ref().unwrap();
+    let http = dispatcher.http_analyzer().unwrap();
     assert_eq!(http.method_counts().len(), 0);
     assert_eq!(http.parse_error_count(), 0); // Confirms HTTP didn't try to parse TLS bytes
 }
@@ -182,7 +182,7 @@ fn test_port_fallback_443_to_tls() {
     dispatcher.on_data(&fk, Direction::ClientToServer, &unknown_data, 0);
 
     // Should have routed to TLS based on port 443; HTTP must not have received it.
-    let http = dispatcher.http.as_ref().unwrap();
+    let http = dispatcher.http_analyzer().unwrap();
     assert_eq!(
         http.method_counts().len(),
         0,
@@ -195,7 +195,7 @@ fn test_port_fallback_443_to_tls() {
     );
     // Positive TLS discriminator: non-TLS garbage routed to TlsAnalyzer triggers a
     // parse/truncation event — proves TlsAnalyzer actually received the bytes.
-    let tls = dispatcher.tls.as_ref().unwrap();
+    let tls = dispatcher.tls_analyzer().unwrap();
     assert!(
         tls.parse_error_count() > 0 || tls.truncated_record_count() > 0,
         "AC-007: port 443 fallback must route to Tls analyzer \
@@ -218,7 +218,7 @@ fn test_port_fallback_8443_to_tls() {
     let ambiguous_data = [0x16u8, 0x04, 0x01, 0x00, 0x01, 0xFF];
     dispatcher.on_data(&fk, Direction::ClientToServer, &ambiguous_data, 0);
 
-    let http = dispatcher.http.as_ref().unwrap();
+    let http = dispatcher.http_analyzer().unwrap();
     assert_eq!(
         http.method_counts().len(),
         0,
@@ -231,7 +231,7 @@ fn test_port_fallback_8443_to_tls() {
     );
     // Positive TLS discriminator: non-TLS garbage routed to TlsAnalyzer triggers a
     // parse/truncation event — proves TlsAnalyzer actually received the bytes.
-    let tls = dispatcher.tls.as_ref().unwrap();
+    let tls = dispatcher.tls_analyzer().unwrap();
     assert!(
         tls.parse_error_count() > 0 || tls.truncated_record_count() > 0,
         "AC-007: port 8443 fallback must route to Tls analyzer \
@@ -261,7 +261,7 @@ fn test_port_fallback_80_to_http() {
     // Discriminator: HTTP analyzer must have attempted to parse the bytes (the data is
     // non-HTTP garbage, so httparse will increment parse_error_count). If the flow were
     // mis-routed to Tls, HTTP would never see the bytes → parse_error_count == 0 → fails.
-    let http = dispatcher.http.as_ref().unwrap();
+    let http = dispatcher.http_analyzer().unwrap();
     assert!(
         http.parse_error_count() > 0,
         "AC-007: port 80 fallback must route to Http analyzer (received the 5-byte \
@@ -292,7 +292,7 @@ fn test_port_fallback_8080_to_http() {
     // Discriminator: HTTP analyzer must have attempted to parse the bytes (the data is
     // non-HTTP garbage, so httparse will increment parse_error_count). If the flow were
     // mis-routed to Tls, HTTP would never see the bytes → parse_error_count == 0 → fails.
-    let http = dispatcher.http.as_ref().unwrap();
+    let http = dispatcher.http_analyzer().unwrap();
     assert!(
         http.parse_error_count() > 0,
         "AC-007/EC-010: port 8080 fallback must route to Http analyzer (received the 5-byte \
@@ -320,7 +320,7 @@ fn test_tls_check_skipped_below_len_5() {
 
     // TLS content check skipped (too short), HTTP content check also fails (no method prefix),
     // port fallback also fails (unknown port) → flow unclassified.
-    let http = dispatcher.http.as_ref().unwrap();
+    let http = dispatcher.http_analyzer().unwrap();
     assert_eq!(
         http.method_counts().len(),
         0,
@@ -351,7 +351,7 @@ fn test_tls_check_requires_byte1_equals_0x03() {
     let almost_tls = [0x16u8, 0x04, 0x03, 0x00, 0x05];
     dispatcher.on_data(&fk, Direction::ClientToServer, &almost_tls, 0);
 
-    let http = dispatcher.http.as_ref().unwrap();
+    let http = dispatcher.http_analyzer().unwrap();
     assert_eq!(
         http.method_counts().len(),
         0,
@@ -469,7 +469,7 @@ fn test_late_classification_within_attempt_budget_still_routes() {
         0,
     );
 
-    let http = dispatcher.http.as_ref().unwrap();
+    let http = dispatcher.http_analyzer().unwrap();
     assert_eq!(
         *http.method_counts().get("GET").unwrap(),
         1,
@@ -496,7 +496,7 @@ fn test_zero_attempt_budget_classifies_nothing() {
 
     let http_data = b"GET / HTTP/1.1\r\nHost: example.com\r\n\r\n";
     dispatcher.on_data(&fk, Direction::ClientToServer, http_data, 0);
-    let http = dispatcher.http.as_ref().unwrap();
+    let http = dispatcher.http_analyzer().unwrap();
     assert_eq!(
         *http.method_counts().get("GET").unwrap(),
         1,
@@ -518,7 +518,7 @@ fn test_http_no_space_does_not_match() {
 
     // b"GET" without trailing space — must not match any HTTP prefix.
     dispatcher.on_data(&fk, Direction::ClientToServer, b"GET", 0);
-    let http = dispatcher.http.as_ref().unwrap();
+    let http = dispatcher.http_analyzer().unwrap();
     assert_eq!(
         http.method_counts().len(),
         0,
@@ -537,7 +537,7 @@ fn test_http_no_space_does_not_match() {
         0,
     );
     assert_eq!(
-        dispatcher.http.as_ref().unwrap().method_counts().len(),
+        dispatcher.http_analyzer().unwrap().method_counts().len(),
         0,
         "AC-005: lowercase b\"get \" must not route to Http (case-sensitive check)"
     );
@@ -567,8 +567,7 @@ fn test_http_no_space_does_not_match() {
     );
     assert_eq!(
         *dispatcher
-            .http
-            .as_ref()
+            .http_analyzer()
             .unwrap()
             .method_counts()
             .get("GET")
@@ -595,7 +594,7 @@ fn test_tls_takes_priority_over_http_methods_check() {
     dispatcher.on_data(&fk, Direction::ClientToServer, &tls_then_garbage, 0);
 
     // TLS wins — HTTP analyzer must have received nothing.
-    let http = dispatcher.http.as_ref().unwrap();
+    let http = dispatcher.http_analyzer().unwrap();
     assert_eq!(
         http.method_counts().len(),
         0,
@@ -627,7 +626,7 @@ fn test_port_fallback_uses_canonical_port_ordering() {
         b"\x16\x04\x01\x00\x01\xFF",
         0,
     );
-    let http = dispatcher.http.as_ref().unwrap();
+    let http = dispatcher.http_analyzer().unwrap();
     assert_eq!(
         http.method_counts().len(),
         0,
@@ -640,7 +639,7 @@ fn test_port_fallback_uses_canonical_port_ordering() {
     );
     // Positive TLS discriminator for 8443 sub-case.
     {
-        let tls = dispatcher.tls.as_ref().unwrap();
+        let tls = dispatcher.tls_analyzer().unwrap();
         assert!(
             tls.parse_error_count() > 0 || tls.truncated_record_count() > 0,
             "AC-008: port 8443 canonical-ordering fallback must route to Tls analyzer \
@@ -670,18 +669,18 @@ fn test_port_fallback_uses_canonical_port_ordering() {
         0,
     );
     assert_eq!(
-        dispatcher.http.as_ref().unwrap().method_counts().len(),
+        dispatcher.http_analyzer().unwrap().method_counts().len(),
         0,
         "AC-008: port 443 via canonical port ordering must fall back to Tls"
     );
     assert_eq!(
-        dispatcher.http.as_ref().unwrap().parse_error_count(),
+        dispatcher.http_analyzer().unwrap().parse_error_count(),
         0,
         "AC-008: port 443 canonical-ordering fallback must route to Tls (HTTP analyzer must not be invoked)"
     );
     // Positive TLS discriminator for 443-upper sub-case.
     {
-        let tls = dispatcher.tls.as_ref().unwrap();
+        let tls = dispatcher.tls_analyzer().unwrap();
         assert!(
             tls.parse_error_count() > 0 || tls.truncated_record_count() > 0,
             "AC-008: port 443 canonical-ordering fallback must route to Tls analyzer \
@@ -707,7 +706,7 @@ fn test_http_content_on_port_443_routes_to_http() {
     let http_on_tls_port = b"GET / HTTP/1.1\r\nHost: example.com\r\n\r\n";
     dispatcher.on_data(&fk, Direction::ClientToServer, http_on_tls_port, 0);
 
-    let http = dispatcher.http.as_ref().unwrap();
+    let http = dispatcher.http_analyzer().unwrap();
     assert_eq!(
         *http.method_counts().get("GET").unwrap_or(&0),
         1,
@@ -739,14 +738,14 @@ fn test_BC_2_05_005_classification_cached_after_first_match() {
     // First chunk: valid HTTP GET — classify returns Http; cached in routes[fk].
     let http_bytes = b"GET / HTTP/1.1\r\nHost: example.com\r\n\r\n";
     dispatcher.on_data(&fk, Direction::ClientToServer, http_bytes, 0);
-    let http = dispatcher.http.as_ref().unwrap();
+    let http = dispatcher.http_analyzer().unwrap();
     assert_eq!(
         *http.method_counts().get("GET").unwrap_or(&0),
         1,
         "AC-004: first GET chunk must be routed to HttpAnalyzer and recorded"
     );
     assert_eq!(
-        dispatcher.tls.as_ref().unwrap().parse_error_count(),
+        dispatcher.tls_analyzer().unwrap().parse_error_count(),
         0,
         "AC-004: TlsAnalyzer must not receive first chunk (classified as Http)"
     );
@@ -759,12 +758,12 @@ fn test_BC_2_05_005_classification_cached_after_first_match() {
     dispatcher.on_data(&fk, Direction::ClientToServer, &tls_bytes, 0);
 
     assert_eq!(
-        dispatcher.tls.as_ref().unwrap().parse_error_count(),
+        dispatcher.tls_analyzer().unwrap().parse_error_count(),
         0,
         "AC-005: cached Http flow must NOT route TLS bytes to TlsAnalyzer (immutable cache)"
     );
     assert!(
-        dispatcher.http.as_ref().unwrap().parse_error_count() > 0,
+        dispatcher.http_analyzer().unwrap().parse_error_count() > 0,
         "AC-004/cache-hit: second chunk (TLS bytes) forwarded to HttpAnalyzer via cache — \
          HttpAnalyzer attempted to parse them, incrementing parse_error_count"
     );
@@ -814,12 +813,12 @@ fn test_BC_2_05_005_cache_evicted_on_flow_close_then_reclassified() {
     // Sanity-check that None is cached: a TLS chunk must not reach TlsAnalyzer.
     dispatcher.on_data(&fk, Direction::ClientToServer, &tls_bytes, 0);
     assert_eq!(
-        dispatcher.tls.as_ref().unwrap().parse_error_count(),
+        dispatcher.tls_analyzer().unwrap().parse_error_count(),
         0,
         "EC-008/setup: after cap=3, None is cached; TLS chunk must not reach TlsAnalyzer"
     );
     assert_eq!(
-        dispatcher.tls.as_ref().unwrap().truncated_record_count(),
+        dispatcher.tls_analyzer().unwrap().truncated_record_count(),
         0,
         "EC-008/setup: cached None short-circuits; no TLS events expected"
     );
@@ -837,8 +836,8 @@ fn test_BC_2_05_005_cache_evicted_on_flow_close_then_reclassified() {
     // event. If the stale None were still present, TlsAnalyzer would remain silent.
     dispatcher.on_data(&fk, Direction::ClientToServer, &tls_bytes, 0);
     assert!(
-        dispatcher.tls.as_ref().unwrap().parse_error_count() > 0
-            || dispatcher.tls.as_ref().unwrap().truncated_record_count() > 0,
+        dispatcher.tls_analyzer().unwrap().parse_error_count() > 0
+            || dispatcher.tls_analyzer().unwrap().truncated_record_count() > 0,
         "EC-008/reclassify: after close, same FlowKey with TLS bytes must re-run classify; \
          TlsAnalyzer must receive data (stale None route was evicted, not reused)"
     );
@@ -850,8 +849,7 @@ fn test_BC_2_05_005_cache_evicted_on_flow_close_then_reclassified() {
     dispatcher.on_data(&fk, Direction::ClientToServer, http_bytes, 0);
     assert_eq!(
         dispatcher
-            .http
-            .as_ref()
+            .http_analyzer()
             .unwrap()
             .method_counts()
             .get("GET")
@@ -899,12 +897,12 @@ fn test_BC_2_05_006_none_not_cached_before_retry_cap() {
     }
     // Confirm neither analyzer received anything (all discarded as DispatchTarget::None).
     assert_eq!(
-        dispatcher.http.as_ref().unwrap().parse_error_count(),
+        dispatcher.http_analyzer().unwrap().parse_error_count(),
         0,
         "AC-006: unmatched chunks must not reach HttpAnalyzer"
     );
     assert_eq!(
-        dispatcher.tls.as_ref().unwrap().parse_error_count(),
+        dispatcher.tls_analyzer().unwrap().parse_error_count(),
         0,
         "AC-006: unmatched chunks must not reach TlsAnalyzer"
     );
@@ -917,8 +915,8 @@ fn test_BC_2_05_006_none_not_cached_before_retry_cap() {
     dispatcher.on_data(&fk, Direction::ClientToServer, &tls_bytes, 0);
 
     assert!(
-        dispatcher.tls.as_ref().unwrap().parse_error_count() > 0
-            || dispatcher.tls.as_ref().unwrap().truncated_record_count() > 0,
+        dispatcher.tls_analyzer().unwrap().parse_error_count() > 0
+            || dispatcher.tls_analyzer().unwrap().truncated_record_count() > 0,
         "AC-003/AC-006: None must NOT be cached after 7 attempts (cap=8); \
          8th chunk with TLS bytes must re-run classify, route to TlsAnalyzer, \
          and produce a parse/truncation event"
@@ -969,18 +967,18 @@ fn test_BC_2_05_006_none_cached_permanently_after_retry_cap() {
     dispatcher.on_data(&fk, Direction::ClientToServer, &tls_bytes, 0);
 
     assert_eq!(
-        dispatcher.tls.as_ref().unwrap().parse_error_count(),
+        dispatcher.tls_analyzer().unwrap().parse_error_count(),
         0,
         "AC-002/AC-007: after cap=3 is hit, None is permanently cached; \
          4th chunk (TLS bytes) must NOT reach TlsAnalyzer (classify not called)"
     );
     assert_eq!(
-        dispatcher.tls.as_ref().unwrap().truncated_record_count(),
+        dispatcher.tls_analyzer().unwrap().truncated_record_count(),
         0,
         "AC-002/AC-007: 4th chunk must be silently dropped via cached None route (not parsed)"
     );
     assert_eq!(
-        dispatcher.http.as_ref().unwrap().parse_error_count(),
+        dispatcher.http_analyzer().unwrap().parse_error_count(),
         0,
         "AC-002/AC-007: 4th chunk must NOT reach HttpAnalyzer either (cached None short-circuits)"
     );
@@ -1004,12 +1002,12 @@ fn test_BC_2_05_006_none_cached_permanently_after_retry_cap() {
     // Second chunk: TLS bytes — must not reach TlsAnalyzer (None cached after chunk 1).
     d_zero.on_data(&fk2, Direction::ClientToServer, &tls_bytes, 0);
     assert_eq!(
-        d_zero.tls.as_ref().unwrap().parse_error_count(),
+        d_zero.tls_analyzer().unwrap().parse_error_count(),
         0,
         "EC-004: cap=0 caches None on first chunk; second TLS chunk must not reach TlsAnalyzer"
     );
     assert_eq!(
-        d_zero.tls.as_ref().unwrap().truncated_record_count(),
+        d_zero.tls_analyzer().unwrap().truncated_record_count(),
         0,
         "EC-004: cap=0 cached-None short-circuits classify on all subsequent chunks"
     );
@@ -1041,18 +1039,18 @@ fn test_BC_2_05_006_none_cached_permanently_after_retry_cap() {
     d_default.on_data(&fk3, Direction::ClientToServer, &tls_bytes_default, 0);
 
     assert_eq!(
-        d_default.tls.as_ref().unwrap().parse_error_count(),
+        d_default.tls_analyzer().unwrap().parse_error_count(),
         0,
         "EC-002/default-cap=8: after 8 None results, None is permanently cached; \
          9th chunk (TLS bytes) must not reach TlsAnalyzer (classify not called)"
     );
     assert_eq!(
-        d_default.tls.as_ref().unwrap().truncated_record_count(),
+        d_default.tls_analyzer().unwrap().truncated_record_count(),
         0,
         "EC-002/default-cap=8: cached-None short-circuits classify; no TLS records parsed"
     );
     assert_eq!(
-        d_default.http.as_ref().unwrap().parse_error_count(),
+        d_default.http_analyzer().unwrap().parse_error_count(),
         0,
         "EC-002/default-cap=8: 9th chunk must not reach HttpAnalyzer either (cached None)"
     );
@@ -1092,13 +1090,13 @@ fn test_BC_2_05_006_late_classification_after_nones() {
     dispatcher.on_data(&fk, Direction::ClientToServer, &tls_bytes, 0);
 
     assert!(
-        dispatcher.tls.as_ref().unwrap().parse_error_count() > 0
-            || dispatcher.tls.as_ref().unwrap().truncated_record_count() > 0,
+        dispatcher.tls_analyzer().unwrap().parse_error_count() > 0
+            || dispatcher.tls_analyzer().unwrap().truncated_record_count() > 0,
         "AC-009/EC-006: TLS bytes on 4th call (3 prior Nones, cap=8) must classify as Tls \
          and route to TlsAnalyzer"
     );
     assert_eq!(
-        dispatcher.http.as_ref().unwrap().parse_error_count(),
+        dispatcher.http_analyzer().unwrap().parse_error_count(),
         0,
         "AC-009/EC-006: HttpAnalyzer must not receive the TLS bytes (routed to Tls)"
     );
@@ -1115,8 +1113,7 @@ fn test_BC_2_05_006_late_classification_after_nones() {
     // proof of cache-hit is the negative: HttpAnalyzer must NOT have received the data.
     assert_eq!(
         dispatcher
-            .http
-            .as_ref()
+            .http_analyzer()
             .unwrap()
             .method_counts()
             .get("GET")
@@ -1146,8 +1143,8 @@ fn test_BC_2_05_006_late_classification_after_nones() {
     d2.on_data(&fk2, Direction::ClientToServer, &tls_bytes, 0);
 
     assert!(
-        d2.tls.as_ref().unwrap().parse_error_count() > 0
-            || d2.tls.as_ref().unwrap().truncated_record_count() > 0,
+        d2.tls_analyzer().unwrap().parse_error_count() > 0
+            || d2.tls_analyzer().unwrap().truncated_record_count() > 0,
         "EC-007: TLS bytes on 8th call (7 prior Nones, cap=8) must classify as Tls; \
          cap is not yet hit when TLS arrives (count=7 < 8 before this call's increment)"
     );
@@ -1251,8 +1248,7 @@ fn test_BC_2_05_007_classified_flow_not_counted_as_unclassified() {
     // Verify the flow was routed to Http (method_counts proves routing).
     assert_eq!(
         *dispatcher
-            .http
-            .as_ref()
+            .http_analyzer()
             .unwrap()
             .method_counts()
             .get("GET")
@@ -1355,8 +1351,7 @@ fn test_BC_2_05_008_single_analyzer_not_early_returned() {
 
     assert_eq!(
         *dispatcher_http_only
-            .http
-            .as_ref()
+            .http_analyzer()
             .unwrap()
             .method_counts()
             .get("GET")
@@ -1377,7 +1372,7 @@ fn test_BC_2_05_008_single_analyzer_not_early_returned() {
 
     // TlsAnalyzer must have received the data: active_flows_len_for_testing == 1 OR
     // parse/truncation counter > 0 (depending on how tls_parser handles the 1-byte payload).
-    let tls_analyzer = dispatcher_tls_only.tls.as_ref().unwrap();
+    let tls_analyzer = dispatcher_tls_only.tls_analyzer().unwrap();
     assert!(
         tls_analyzer.active_flows_len_for_testing() >= 1
             || tls_analyzer.parse_error_count() > 0
@@ -1403,8 +1398,7 @@ fn test_BC_2_05_009_flow_close_forwards_to_http_analyzer() {
     // Verify HttpAnalyzer has per-flow state before close.
     assert_eq!(
         dispatcher
-            .http
-            .as_ref()
+            .http_analyzer()
             .unwrap()
             .active_flows_len_for_testing(),
         1,
@@ -1416,8 +1410,7 @@ fn test_BC_2_05_009_flow_close_forwards_to_http_analyzer() {
     // After on_flow_close, HttpAnalyzer.on_flow_close must have been called → flows entry removed.
     assert_eq!(
         dispatcher
-            .http
-            .as_ref()
+            .http_analyzer()
             .unwrap()
             .active_flows_len_for_testing(),
         0,
@@ -1444,8 +1437,7 @@ fn test_BC_2_05_009_flow_close_forwards_to_http_analyzer() {
     // TlsAnalyzer must have per-flow state before close.
     assert_eq!(
         dispatcher2
-            .tls
-            .as_ref()
+            .tls_analyzer()
             .unwrap()
             .active_flows_len_for_testing(),
         1,
@@ -1457,8 +1449,7 @@ fn test_BC_2_05_009_flow_close_forwards_to_http_analyzer() {
     // After on_flow_close, TlsAnalyzer.on_flow_close must have been called → flows entry removed.
     assert_eq!(
         dispatcher2
-            .tls
-            .as_ref()
+            .tls_analyzer()
             .unwrap()
             .active_flows_len_for_testing(),
         0,
@@ -1499,8 +1490,7 @@ fn test_BC_2_05_009_flow_close_for_unknown_flow_key() {
     // Verify no analyzer received a close call (no per-flow state to remove).
     assert_eq!(
         dispatcher
-            .http
-            .as_ref()
+            .http_analyzer()
             .unwrap()
             .active_flows_len_for_testing(),
         0,
@@ -1508,8 +1498,7 @@ fn test_BC_2_05_009_flow_close_for_unknown_flow_key() {
     );
     assert_eq!(
         dispatcher
-            .tls
-            .as_ref()
+            .tls_analyzer()
             .unwrap()
             .active_flows_len_for_testing(),
         0,

--- a/tests/tls_integration_tests.rs
+++ b/tests/tls_integration_tests.rs
@@ -20,7 +20,7 @@ fn analyze_pcap(path: &str) -> TlsAnalyzer {
     reasm.finalize(&mut dispatcher);
 
     // Move the TLS analyzer out of the dispatcher
-    dispatcher.tls.unwrap()
+    dispatcher.take_tls_analyzer().unwrap()
 }
 
 #[test]


### PR DESCRIPTION
## Finding

**CR-001** (Phase-5 secondary code-review, MEDIUM, P2 tech-debt):
`StreamDispatcher` in `src/dispatcher.rs` had both analyzer fields (`http` and
`tls`) declared `pub`, leaking the internal analyzer state into the public API
surface. The fields were only `pub` to give test code and `src/main.rs` direct
field access. This contradicted the W7.1 public-API hardening goal: before the
surface is frozen, these fields should be encapsulated behind proper accessor
methods rather than using bare field visibility.

## What Changed

Made both analyzer fields private and added three accessor methods to
`StreamDispatcher`:

- `http_analyzer(&self) -> Option<&HttpAnalyzer>` — read-only borrow.
- `tls_analyzer(&self) -> Option<&TlsAnalyzer>` — read-only borrow.
- `take_tls_analyzer(&mut self) -> Option<TlsAnalyzer>` — consuming move-out
  for callers (e.g. `tests/tls_integration_tests.rs`) that need ownership of
  the analyzer after the capture loop finishes.

All call sites updated:

- `src/main.rs`: 4 `dispatcher.http` / `dispatcher.tls` field refs → accessor calls.
- `tests/dispatcher_tests.rs`: ~40 field accesses → accessor calls throughout.
- `tests/tls_integration_tests.rs`: 1 `dispatcher.tls.unwrap()` →
  `dispatcher.take_tls_analyzer().unwrap()`.

No `_for_testing` seams or test-only symbols were added to `src/`.
No `pub(crate)` half-measures — the fields are fully private.

> **Behavior change:** None. The accessor methods are trivial wrappers that do
> not alter dispatch logic, analysis results, or any CLI output.

## Architecture Changes

```mermaid
graph TD
    A["StreamDispatcher (public struct)"] --> B["http: Option<HttpAnalyzer> (private)"]
    A --> C["tls: Option<TlsAnalyzer> (private)"]
    A --> D["http_analyzer() -> Option<&HttpAnalyzer>"]
    A --> E["tls_analyzer() -> Option<&TlsAnalyzer>"]
    A --> F["take_tls_analyzer() -> Option<TlsAnalyzer>"]
    D -->|read borrow| B
    E -->|read borrow| C
    F -->|consuming take| C
    B -->|was pub before CR-001| X["PUBLIC FIELD (removed)"]
    C -->|was pub before CR-001| Y["PUBLIC FIELD (removed)"]
```

## Spec Traceability

```mermaid
flowchart LR
    CR001["CR-001 Finding\nPhase-5 secondary review\nMEDIUM / P2"] --> ENC["Encapsulate pub fields\nsrc/dispatcher.rs"]
    ENC --> ACC1["http_analyzer()"]
    ENC --> ACC2["tls_analyzer()"]
    ENC --> ACC3["take_tls_analyzer()"]
    ACC1 --> MAIN["src/main.rs\ncall-site updates"]
    ACC2 --> MAIN
    ACC1 --> DTESTS["tests/dispatcher_tests.rs\n~40 accessor call-sites"]
    ACC2 --> DTESTS
    ACC3 --> ITESTS["tests/tls_integration_tests.rs\ncall-site update"]
    ENC --> W71["W7.1 public-API\nsurface narrowed"]
```

## Story Dependencies

```mermaid
graph LR
    CR001["CR-001 fix-PR\nrefactor/dispatcher-encapsulate-fields"] -->|no blocking deps| DEVELOP["develop @ c115d61"]
    CR001 -->|tech-debt entry closed| REGISTER[".factory/tech-debt-register.md"]
```

## Test Evidence

| Test | Type | Result |
|------|------|--------|
| Full suite (`cargo test --all-targets`) | All (39 suites, 0 failures) | GREEN |
| `cargo clippy --all-targets -- -D warnings` | Lint | GREEN |
| `cargo fmt --check` | Format | GREEN |

Review convergence: 1 effective cycle — code review CONVERGED with only MINOR
+ NIT findings. The one MINOR (unused `take_http_analyzer` enlarging W7.1
surface) was fixed in commit `0795007` before the PR was opened.
0 blocking findings remaining.

Scope: 4 files changed, 93 insertions(+), 80 deletions(−).
No other behavior modified.

## Demo Evidence

This is a pure refactor with no user-visible output change. Demo evidence is
N/A — behavior is identical for all inputs; observable effect is a narrower
public API surface and better encapsulation. No AC-gated demo recording applies.

## Security Review

APPROVE — CLEAN, 0 critical / 0 high / 0 medium findings.

The refactor NARROWS the mutable surface:
- Both accessor methods return read-only borrows (`Option<&T>`); no `&mut`
  references to inner analyzers are handed out.
- `take_tls_analyzer` requires `&mut self` on the dispatcher but does not
  expose a mutable reference to the analyzer internals — it moves ownership out.
- No new attack surface on the untrusted-packet path. `on_data` / `on_flow_close`
  dispatch logic is completely unchanged.
- No `_for_testing` symbols added to `src/`.

## Holdout Evaluation

N/A — evaluated at wave gate.

## Adversarial Review

Finding originated in Phase-5 secondary code-review (MEDIUM priority). Fix
directly closes CR-001 in `.factory/tech-debt-register.md`. No new adversarial
surface introduced. Refactor is behavior-preserving by construction (same
dispatch logic, same results, same output format).

## Risk Assessment

- **Blast radius:** Minimal. Only `src/dispatcher.rs` field visibility changes;
  accessors are trivial wrappers. Call sites in `main.rs` and test files updated
  mechanically.
- **Regression risk:** Very low. The full 39-suite test run is green; the
  dispatcher tests exercise every routing path exhaustively.
- **Performance impact:** Neutral. Accessor calls compile to the same instructions
  as direct field access — the optimizer will inline them.
- **Behavior change classification:** Pure structural refactor. No observable
  output change for any input.
- **W11-D2 trust-boundary gate:** No `_for_testing` symbols added to `src/`.
  The gate grep should pass cleanly.

## AI Pipeline Metadata

- Pipeline mode: Fix (Phase-5 secondary code-review finding closure)
- Finding: CR-001 / MEDIUM / P2 tech-debt
- Branch: `refactor/dispatcher-encapsulate-fields`
- Worktree: `.worktrees/cr-001`
- Final commit: `0795007`
- Base: `develop @ c115d61`
- Model: claude-sonnet-4-6

## Pre-Merge Checklist

- [x] PR description matches actual diff
- [x] Demo evidence: N/A (pure refactor, no observable output change)
- [x] Traceability chain complete (CR-001 finding → encapsulation → call-site updates)
- [x] Security review: APPROVE, CLEAN — 0 critical/high/medium, surface narrowed
- [x] Full test suite green (39 suites, 0 failures)
- [x] Clippy clean (-D warnings)
- [x] Cargo fmt --check passes
- [x] Code review converged (1 effective cycle, 0 blocking findings remaining)
- [x] W11-D2 trust-boundary gate: no `_for_testing` symbols in `src/`
- [ ] CI checks passing (pending)
- [ ] Merge authorized (AUTHORIZE_MERGE=yes — human-approved P2 fix-PR cleanup)
