### PR TITLE
test(fuzz): add VP-008 deterministic corpus seeding helper

### DIFF
--- a/fuzz/seed_corpus.py
+++ b/fuzz/seed_corpus.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Seed the fuzz_decode_packet corpus for VP-008.
+
+The fuzz target consumes a raw link-layer FRAME (&[u8]), not a full pcap file.
+So we:
+  1. Parse each classic .pcap/.cap fixture (stdlib only) and emit each record's
+     frame bytes as one corpus file.
+  2. Emit truncated variants of a sample of real frames (every header boundary).
+  3. Emit synthetic adversarial/malformed frames per VP-008 Corpus Seeding.
+
+Corpus filenames are content-hash based so duplicates collapse.
+"""
+import hashlib
+import os
+import struct
+import sys
+
+CORPUS = os.path.join(os.path.dirname(__file__), "corpus", "fuzz_decode_packet")
+FIXTURES = sys.argv[1]
+
+os.makedirs(CORPUS, exist_ok=True)
+
+written = 0
+def emit(data: bytes):
+    global written
+    h = hashlib.sha1(data).hexdigest()
+    path = os.path.join(CORPUS, h)
+    if not os.path.exists(path):
+        with open(path, "wb") as f:
+            f.write(data)
+        written += 1
+
+def parse_classic_pcap(raw: bytes):
+    """Yield each record's captured frame bytes. Supports LE/BE magic."""
+    if len(raw) < 24:
+        return
+    magic = raw[:4]
+    if magic in (b"\xd4\xc3\xb2\xa1", b"\x4d\x3c\xb2\xa1"):  # little-endian (us / ns)
+        endian = "<"
+    elif magic in (b"\xa1\xb2\xc3\xd4", b"\xa1\xb2\x3c\x4d"):  # big-endian
+        endian = ">"
+    else:
+        return  # not classic pcap (e.g. pcapng) -- skip
+    off = 24
+    n = len(raw)
+    while off + 16 <= n:
+        ts_sec, ts_usec, incl_len, orig_len = struct.unpack(
+            endian + "IIII", raw[off:off + 16]
+        )
+        off += 16
+        if incl_len > n - off:
+            # truncated final record; take what's there as an adversarial seed too
+            frame = raw[off:]
+            if frame:
+                yield frame
+            break
+        frame = raw[off:off + incl_len]
+        off += incl_len
+        if frame:
+            yield frame
+
+# 1. Real frames from fixtures
+real_frames = []
+for name in sorted(os.listdir(FIXTURES)):
+    if not (name.endswith(".pcap") or name.endswith(".cap") or name.endswith(".trace")):
+        continue
+    p = os.path.join(FIXTURES, name)
+    with open(p, "rb") as f:
+        raw = f.read()
+    cnt = 0
+    for frame in parse_classic_pcap(raw):
+        emit(frame)
+        real_frames.append(frame)
+        cnt += 1
+        # cap per-file frames to keep corpus lean but representative
+        if cnt >= 200:
+            break
+
+# 2. Truncations of a representative sample of real frames at header boundaries.
+# Header boundaries of interest: ethernet=14, IPv4 min=20, IPv6=40, TCP min=20,
+# Linux SLL=16, plus 1 byte and "1 short of full".
+sample = real_frames[:: max(1, len(real_frames) // 60)] if real_frames else []
+boundaries = [1, 2, 4, 8, 13, 14, 15, 16, 19, 20, 21, 33, 34, 39, 40, 41, 53, 54]
+for frame in sample:
+    for b in boundaries:
+        if 0 < b < len(frame):
+            emit(frame[:b])
+    if len(frame) > 1:
+        emit(frame[:-1])  # one short of full
+
+# 3. Synthetic adversarial / malformed frames (per VP-008 Corpus Seeding)
+emit(b"")                       # empty
+emit(b"\x00")                   # single byte
+emit(b"\xff")                   # single byte
+for i in range(1, 14):          # truncated ethernet header (< 14 bytes)
+    emit(b"\x00" * i)
+# Minimal ethernet header, IPv4 ethertype, no payload (truncated IP)
+emit(bytes.fromhex("ffffffffffff000000000000") + b"\x08\x00")
+# Ethernet + IPv4 ethertype + truncated IPv4 header (claims more)
+emit(bytes.fromhex("ffffffffffff000000000000") + b"\x08\x00" + b"\x45" + b"\x00" * 5)
+# Ethernet + IPv6 ethertype + truncated IPv6 header
+emit(bytes.fromhex("ffffffffffff000000000000") + b"\x86\xdd" + b"\x60" + b"\x00" * 10)
+# IPv4 frame with oversized total-length field (0xffff) but tiny actual payload
+emit(b"\x45\x00\xff\xff\x00\x00\x00\x00\x40\x06\x00\x00" + b"\x01\x02\x03\x04" + b"\x05\x06\x07\x08")
+# IPv4 with IHL claiming huge options but truncated
+emit(b"\x4f\x00\x00\x3c" + b"\x00" * 8 + b"\x01\x02\x03\x04\x05\x06\x07\x08")
+# IPv6 with bogus next-header chain and oversized payload length
+emit(b"\x60\x00\x00\x00\xff\xff\x2c\x40" + b"\x00" * 32 + b"\x3b" + b"\x00" * 16)
+# TCP-ish: ethernet + IPv4(proto=6) + truncated TCP with huge data offset
+emit(
+    bytes.fromhex("ffffffffffff000000000000") + b"\x08\x00"
+    + b"\x45\x00\x00\x28\x00\x00\x00\x00\x40\x06\x00\x00\x0a\x00\x00\x01\x0a\x00\x00\x02"
+    + b"\x00\x50\x00\x50\x00\x00\x00\x00\x00\x00\x00\x00\xf0\x02\xff\xff\x00\x00\x00\x00"
+)
+# Linux SLL (cooked) truncated header (< 16 bytes)
+for i in range(1, 16):
+    emit(b"\x00\x04" + b"\x00" * (i - 2)) if i >= 2 else emit(b"\x00")
+# Linux SLL full 16-byte header + IPv4 ethertype + nothing
+emit(b"\x00\x00\x00\x01\x00\x06" + b"\x00" * 8 + b"\x08\x00")
+# Wrong/unknown ethertype
+emit(bytes.fromhex("ffffffffffff000000000000") + b"\xde\xad" + b"\x01\x02\x03\x04")
+# All-0xff jumbo
+emit(b"\xff" * 64)
+emit(b"\xff" * 1500)
+# VLAN-tagged (0x8100) then truncated
+emit(bytes.fromhex("ffffffffffff000000000000") + b"\x81\x00\x00\x01\x08\x00" + b"\x45")
+# Nested double-VLAN
+emit(bytes.fromhex("ffffffffffff000000000000") + b"\x81\x00\x00\x01\x81\x00\x00\x02\x86\xdd")
+
+print(f"WROTE {written} unique seeds; total real frames sampled: {len(real_frames)}")
+print(f"CORPUS SIZE: {len(os.listdir(CORPUS))} files")


### PR DESCRIPTION
## Summary

Adds `fuzz/seed_corpus.py` — a stdlib-only Python helper that deterministically regenerates the seed corpus for the VP-008 `fuzz_decode_packet` fuzz target.

The fuzz target consumes raw link-layer frames (`&[u8]`), not full pcap files, so this script:
1. Parses classic `.pcap`/`.cap`/`.trace` fixtures and extracts per-record frame bytes (capped at 200 frames/file, content-hash deduped).
2. Emits truncations of a representative frame sample at all meaningful header boundaries (Ethernet=14, SLL=16, IPv4 min=20, IPv6=40, etc.).
3. Emits ~30 synthetic adversarial/malformed frames covering empty input, truncated headers, oversized length fields, bogus next-header chains, unknown ethertypes, VLAN nesting, and all-0xff jumbos.

**No Rust source or Cargo manifest changes.** The corpus directory (`fuzz/corpus/`) is gitignored; this script makes it reproducible.

## VP-008 Fuzz Campaign Result

The campaign referenced by this helper has already completed and is recorded at `.factory/cycles/v0.1.0-greenfield-spec/hardening/fuzz-results/vp-008-fuzz-summary.md`:

| Metric | Value |
|--------|-------|
| Toolchain | `nightly-2026-05-21` (exact CI pin — no divergence) |
| Wall-clock | 301 s (≥ 5-min no-crash bar) |
| Total executions | 21,775,342 |
| Avg exec/s | 72,343 |
| **Crashes / panics** | **0** |
| OOM / timeout / leak artifacts | 0 |
| Seeds loaded | 1,812 (1,813 written, 1 deduped by libFuzzer) |

**VP-008 fuzz-evidence bar (no crash after ≥5 min): SATISFIED.**

Source contracts covered: BC-2.02.007 (reject malformed input, no panic), BC-2.02.008 (reject unsupported link types), BC-2.02.009 (surface no-IP-layer error).

## Reproduction

```bash
python3 fuzz/seed_corpus.py tests/fixtures
cargo +nightly-2026-05-21 fuzz run fuzz_decode_packet -- -max_total_time=300 -print_final_stats=1
```

## CI Impact

None — no Rust source changed. All 8 CI checks should pass unchanged.