### PR TITLE
build(deps): bump indicatif to 0.18 to drop unmaintained number_prefix (RUSTSEC-2025-0119)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,16 +143,13 @@ jobs:
       - name: Run cargo audit
         # --ignore flags suppress informational (non-vulnerability) advisories
         # that are blocked by transitive dependency constraints:
-        #   RUSTSEC-2025-0119: number_prefix unmaintained (via indicatif 0.17.x
-        #     — no newer release fixes this; indicatif is a dev/progress dep)
         #   RUSTSEC-2026-0097: rand 0.8.5 unsound (via phf_generator -> tls-parser
         #     — rand upgrade is tls-parser upstream's responsibility; not a direct
         #     dep and the unsound path requires a custom logger + reseed race)
-        # Both are informational findings, not CVE-severity vulnerabilities.
-        # Revisit when indicatif or tls-parser releases a fix.
+        # RUSTSEC-2025-0119 (number_prefix unmaintained) was resolved by bumping
+        # indicatif 0.17→0.18, which replaced number_prefix with unit-prefix.
         run: |
           cargo audit \
-            --ignore RUSTSEC-2025-0119 \
             --ignore RUSTSEC-2026-0097
 
   deny:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,7 +71,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -82,7 +82,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -291,15 +291,14 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "console"
-version = "0.15.11"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
 dependencies = [
  "encode_unicode",
  "libc",
- "once_cell",
  "unicode-width",
- "windows-sys 0.59.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -463,7 +462,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -624,14 +623,14 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
-version = "0.17.11"
+version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
+checksum = "25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb"
 dependencies = [
  "console",
- "number_prefix",
  "portable-atomic",
  "unicode-width",
+ "unit-prefix",
  "web-time",
 ]
 
@@ -780,12 +779,6 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
-
-[[package]]
-name = "number_prefix"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "once_cell"
@@ -1138,7 +1131,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1273,7 +1266,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1385,6 +1378,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unit-prefix"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
 
 [[package]]
 name = "utf8parse"
@@ -1550,7 +1549,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1620,85 +1619,12 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
-dependencies = [
- "windows-targets",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
-
-[[package]]
-name = "windows-targets"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
-dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
-]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ serde_json = "1"
 csv = "1"
 anyhow = "1"
 owo-colors = "4"
-indicatif = "0.17"
+indicatif = "0.18"
 chrono = { version = "0.4", features = ["serde"] }
 rayon = "1"
 


### PR DESCRIPTION
# build(deps): bump indicatif to 0.18 to drop unmaintained number_prefix (RUSTSEC-2025-0119)

**Epic:** Security / Supply-chain hygiene
**Mode:** maintenance
**Convergence:** N/A — dependency-only change, no adversarial spec passes required

![Tests](https://img.shields.io/badge/tests-1035%2F1035-brightgreen)
![Coverage](https://img.shields.io/badge/coverage-unchanged-brightgreen)
![Mutation](https://img.shields.io/badge/mutation-N%2FA-lightgrey)
![Audit](https://img.shields.io/badge/cargo_audit-CLEAN-brightgreen)

Bumps `indicatif` 0.17.11 → 0.18.4 to eliminate the `number_prefix` 0.4.0 crate flagged by RUSTSEC-2025-0119 (unmaintained advisory). indicatif 0.18 replaced `number_prefix` with `unit-prefix` 0.5.2. Zero source-code changes were required: all wirerust call sites (`ProgressBar::new`, `set_style`, `ProgressStyle::with_template`, `pb.inc`, `pb.finish_and_clear`) are API-stable across the 0.17→0.18 boundary. The `--ignore RUSTSEC-2025-0119` flag is removed from the CI audit step; `RUSTSEC-2026-0097` (rand 0.8.5 via tls-parser) remains ignored as it is upstream-only and unreachable.

---

## Architecture Changes

```mermaid
graph TD
    MainRS["src/main.rs<br/>(ProgressBar usage)"] -->|unchanged API| Indicatif["indicatif 0.18.4"]
    Indicatif -->|replaced dep| UnitPrefix["unit-prefix 0.5.2 (new)"]
    Indicatif -.->|removed dep| NumberPrefix["number_prefix 0.4.0 (REMOVED)"]
    style UnitPrefix fill:#90EE90
    style NumberPrefix fill:#FFB6C1
```

<details>
<summary><strong>Architecture Decision Record</strong></summary>

### ADR: Accept indicatif 0.18 minor version bump

**Context:** RUSTSEC-2025-0119 flagged `number_prefix 0.4.0` as unmaintained. It is a transitive dependency pulled in by `indicatif 0.17.x`. The advisory is informational (no CVE, no known exploit vector), but a clean audit is preferable to an indefinitely-ignored advisory.

**Decision:** Bump `indicatif` from `"0.17"` to `"0.18"` in Cargo.toml. This is a SemVer minor bump; indicatif's public API used by wirerust is unchanged.

**Rationale:** indicatif 0.18.4 is the current stable release. It replaced `number_prefix` with `unit-prefix`, resolving the advisory at source. No source changes needed. Verified via `cargo tree -i number_prefix` → absent; `cargo audit --ignore RUSTSEC-2026-0097` → zero findings.

**Alternatives Considered:**
1. Keep `--ignore RUSTSEC-2025-0119` indefinitely — rejected because: accumulating ignored advisories erodes audit hygiene and hides future real issues.
2. Replace indicatif with a different progress crate — rejected because: unnecessary churn; indicatif is well-maintained and the 0.18 release resolves the issue.

**Consequences:**
- Cargo.lock gains `unit-prefix 0.5.2`, drops `number_prefix 0.4.0`, drops 10 `windows-sys`/`windows-targets` crates (console 0.15→0.16 transitive cleanup).
- CI audit runs without the 2025-0119 ignore flag going forward.

</details>

---

## Story Dependencies

```mermaid
graph LR
    THIS["build/indicatif-0.18<br/>this PR"]
    style THIS fill:#FFD700
```

No upstream PRs required. No downstream PRs blocked by this change.

---

## Spec Traceability

```mermaid
flowchart LR
    ADV["RUSTSEC-2025-0119<br/>number_prefix unmaintained"] --> FIX["indicatif 0.17→0.18<br/>Cargo.toml"]
    FIX --> LOCK["Cargo.lock<br/>unit-prefix replaces number_prefix"]
    LOCK --> CI["ci.yml audit step<br/>--ignore RUSTSEC-2025-0119 removed"]
    CI --> GATE["cargo audit CLEAN<br/>1035 tests PASS"]
```

**Traceability:** RUSTSEC-2025-0119 → indicatif 0.18.4 → `number_prefix` absent from tree → CI audit step removes ignore flag → zero audit findings.

---

## Test Evidence

### Coverage Summary

| Metric | Value | Threshold | Status |
|--------|-------|-----------|--------|
| Unit tests | 1035/1035 pass | 100% | PASS |
| Coverage | unchanged (dep-only) | — | N/A |
| Mutation kill rate | N/A (no src changes) | — | N/A |
| Holdout satisfaction | N/A — evaluated at wave gate | — | N/A |

### Test Flow

```mermaid
graph LR
    Unit["1035 Unit/Integration Tests"]
    Audit["cargo audit (no ignores except 2026-0097)"]
    Tree["cargo tree -i number_prefix"]

    Unit -->|all pass| Pass1["PASS"]
    Audit -->|zero findings| Pass2["PASS"]
    Tree -->|empty - crate absent| Pass3["PASS"]

    style Pass1 fill:#90EE90
    style Pass2 fill:#90EE90
    style Pass3 fill:#90EE90
```

| Metric | Value |
|--------|-------|
| **New tests** | 0 added (no source changes) |
| **Total suite** | 1035 tests PASS |
| **Coverage delta** | 0% (dependency bump only) |
| **Mutation kill rate** | N/A |
| **Regressions** | 0 |

<details>
<summary><strong>Detailed Test Results</strong></summary>

### Verification Commands Run Locally

| Command | Result |
|---------|--------|
| `cargo fmt --check` | PASS |
| `cargo clippy --all-targets -- -D warnings` | PASS (0 warnings) |
| `cargo test --all-targets` | PASS (1035 tests) |
| `cargo audit --ignore RUSTSEC-2026-0097` | PASS (0 findings) |
| `cargo tree -i number_prefix` | empty (crate absent) |

</details>

---

## Holdout Evaluation

N/A — evaluated at wave gate. This is a dependency-only maintenance change with no behavioral impact.

---

## Adversarial Review

N/A — evaluated at Phase 5 of the feature wave. This maintenance PR has no logic changes to adversarially review.

---

## Security Review

```mermaid
graph LR
    Critical["Critical: 0"]
    High["High: 0"]
    Medium["Medium: 0"]
    Low["Low: 0 (advisory resolved)"]

    style Critical fill:#90EE90
    style High fill:#90EE90
    style Medium fill:#90EE90
    style Low fill:#90EE90
```

<details>
<summary><strong>Security Scan Details</strong></summary>

### Dependency Audit

- `cargo audit` (without `--ignore RUSTSEC-2025-0119`): **CLEAN** — 0 findings
- `RUSTSEC-2025-0119`: RESOLVED — `number_prefix 0.4.0` is no longer in the dependency tree after bumping to `indicatif 0.18.4`, which substituted `unit-prefix 0.5.2`.
- `RUSTSEC-2026-0097` (rand 0.8.5 via tls-parser): still present, still ignored — this is a transitive dep of `tls-parser` used by the pcap-parsing path; the unsound path requires a custom logger + reseed race and is unreachable in wirerust's usage. Upstream (tls-parser) owns this fix.

### Research Validation

- DF-VALIDATION-001 satisfied: finding validated via registry-confirmed research before PR.
- indicatif CHANGELOG confirms 0.18.0 release replaced `number_prefix` with `unit-prefix`.
- RUSTSEC-2025-0119 advisory classification: INFO / unmaintained (no CVE assigned, no exploit vector).

</details>

---

## Risk Assessment & Deployment

### Blast Radius
- **Systems affected:** CLI progress-bar display only (no packet analysis logic touched)
- **User impact:** None — progress bar behavior is identical across indicatif 0.17→0.18 for the API surface wirerust uses
- **Data impact:** None
- **Risk Level:** LOW

### Performance Impact
| Metric | Before | After | Delta | Status |
|--------|--------|-------|-------|--------|
| Progress bar rendering | unchanged | unchanged | 0 | OK |
| Binary size | ~same | ~same | negligible | OK |
| Test suite runtime | ~same | ~same | negligible | OK |

<details>
<summary><strong>Rollback Instructions</strong></summary>

**Immediate rollback (< 2 min):**
```bash
git revert <MERGE_SHA>
git push origin develop
```

**Verification after rollback:**
- `cargo audit --ignore RUSTSEC-2025-0119 --ignore RUSTSEC-2026-0097` passes
- `cargo test --all-targets` passes

</details>

### Feature Flags
None — this is a dependency version bump.

---

## Traceability

| Requirement | Change | Verification | Status |
|-------------|--------|--------------|--------|
| RUSTSEC-2025-0119 remediation | `indicatif = "0.18"` in Cargo.toml | `cargo audit` CLEAN | PASS |
| No API breakage | `ProgressBar::new/set_style/with_template/inc/finish_and_clear` unchanged | `cargo test --all-targets` (1035) | PASS |
| CI audit step clean | Removed `--ignore RUSTSEC-2025-0119` from ci.yml | CI Audit job | PASS |

---

## AI Pipeline Metadata

<details>
<summary><strong>Pipeline Details</strong></summary>

```yaml
ai-generated: true
pipeline-mode: maintenance
factory-version: "1.0.0"
pipeline-stages:
  spec-crystallization: N/A
  story-decomposition: N/A
  tdd-implementation: completed (dep bump, no src changes)
  holdout-evaluation: N/A
  adversarial-review: N/A
  formal-verification: N/A
  convergence: N/A (maintenance PR)
convergence-metrics:
  advisory-remediated: RUSTSEC-2025-0119
  tests-passing: 1035
  audit-findings: 0
models-used:
  builder: claude-sonnet-4-6
generated-at: "2026-06-02T00:00:00Z"
```

</details>

---

## Pre-Merge Checklist

- [x] All CI status checks passing (fmt / clippy / test / audit / deny / semver — see CI run)
- [x] Coverage delta is positive or neutral (dep-only, no coverage impact)
- [x] No critical/high security findings unresolved (RUSTSEC-2025-0119 resolved; 2026-0097 kept-ignored per accepted policy)
- [x] Rollback procedure validated (revert commit restores indicatif 0.17 pin)
- [x] No feature flags required
- [x] Human pre-approved (squash-merge authorized in dispatch)
- [x] No monitoring alert changes required (no production-impacting behavior change)
