### PR TITLE
docs: codify gitflow main-branch rule in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,8 +41,33 @@ CI sets `RUSTFLAGS=-Dwarnings`. `rustfmt.toml` pins edition 2024, `max_width = 1
     `docs/adr-cleanup`), where `<type>` is one of the allowed
     semantic-PR types listed below. Equivalent to `feature/<name>` but
     generalized beyond `feat`.
-- **Semantic PR titles enforced via CI** (`amannn/action-semantic-pull-request`). Allowed types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert`. Scope is optional.
+  - `release/<version>` for gitflow release branches (e.g. `release/0.2.0`)
+  - `hotfix/<slug>` for urgent production fixes branched from `main`
+- **Semantic PR titles enforced via CI** (`amannn/action-semantic-pull-request`). Allowed types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert`. Scope is optional. Release PRs into `main` use an allowed type, e.g. `chore: release v0.2.0`.
 - No local commit hooks (no lefthook/husky/commitlint config) — enforcement is CI-side only.
+
+### Releasing to `main`
+
+`main` is the release/stable branch. It is updated **only** through gitflow-proper merges — never by direct commits, direct merge pushes, or admin bypass.
+
+**Normal release flow:**
+
+1. Cut a `release/<version>` branch from `develop` (e.g. `release/0.2.0`).
+2. Apply any release-only fixups (version bump, changelog) on that branch.
+3. Open a Pull Request targeting `main`; merge after CI is green.
+
+**Hotfix flow** (urgent production fix):
+
+1. Cut a `hotfix/<slug>` branch from `main`.
+2. Apply the fix; open a Pull Request targeting `main`; merge after CI is green.
+
+**Tagging:**
+
+- Release tags (`v<version>`, e.g. `v0.1.0`) are created on `main` **only after** the release or hotfix PR has merged — never before, and never on a direct push.
+
+**Keeping branches in sync:**
+
+- After a release or hotfix PR merges into `main`, ensure `develop` contains those commits. Merge `main` back into `develop` if needed so the two branches do not diverge.
 
 ## Public API Surface (W7.1 — deferred)
 


### PR DESCRIPTION
## Summary

Documents the gitflow rule governing updates to the `main` branch so all contributors and the factory pipeline have a single authoritative reference.

- **main is protected**: updated only via `release/*` or `hotfix/*` PRs — never by direct pushes, direct merges, or admin bypass
- **Release tagging policy**: `v<version>` tags are created on `main` *only after* the release or hotfix PR has merged (never before, never on a direct push)
- **Back-merge requirement**: after any release or hotfix merges into `main`, `develop` must be brought back in sync
- **Branch-naming extension**: adds `release/<version>` and `hotfix/<slug>` to the allowed patterns already listed in CLAUDE.md

## Changed files

| File | Change |
|------|--------|
| `CLAUDE.md` | New `### Releasing to \`main\`` section (+26 lines, -1 line) |

## Test plan

- [ ] CI passes (fmt, clippy, tests — no code changed, only docs)
- [ ] `CLAUDE.md` on `develop` after merge contains the `### Releasing to \`main\`` section