### PR TITLE
ci: cross-compile x86_64-apple-darwin on macos-latest in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ env:
 
 jobs:
   # ---------------------------------------------------------------------------
-  # Build matrix — native runners, no cross-compilation.
+  # Build matrix — native runners; x86_64-apple-darwin cross-compiles on macos-latest (arm64).
   # Runs on both tag push and workflow_dispatch so the matrix can be validated
   # before the real tag is cut.
   # ---------------------------------------------------------------------------
@@ -36,7 +36,7 @@ jobs:
           - os: macos-latest
             target: aarch64-apple-darwin
             archive_ext: tar.gz
-          - os: macos-13
+          - os: macos-latest
             target: x86_64-apple-darwin
             archive_ext: tar.gz
           - os: windows-latest


### PR DESCRIPTION
## Summary

- Changes the `x86_64-apple-darwin` build matrix entry from `os: macos-13` to `os: macos-latest`.
- The `macos-13` Intel runner is being retired and is queue-starved (30+ min wait), which would stall the tagged release pipeline since all 4 targets must succeed before the `release` job can publish.
- `macos-latest` (Apple Silicon / arm64) cross-compiles `x86_64-apple-darwin` natively via the `dtolnay/rust-toolchain@stable` `targets:` field already present in the matrix step — no additional deps needed for this pure-Rust crate.
- All binary paths remain target-parameterized (`target/${{ matrix.target }}/release/wirerust`) and artifact names are unchanged (`wirerust-<target>`).
- All other matrix entries (`aarch64-apple-darwin`, `x86_64-unknown-linux-gnu`, `x86_64-pc-windows-msvc`) are untouched.

## Test plan

- [ ] CI passes all 8 required checks on this PR
- [ ] `release.yml` contains no reference to `macos-13`
- [ ] Artifact names and binary paths are unchanged from before