### PR TITLE
chore: release v0.1.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ env:
 
 jobs:
   # ---------------------------------------------------------------------------
-  # Build matrix — native runners, no cross-compilation.
+  # Build matrix — native runners; x86_64-apple-darwin cross-compiles on macos-latest (arm64).
   # Runs on both tag push and workflow_dispatch so the matrix can be validated
   # before the real tag is cut.
   # ---------------------------------------------------------------------------
@@ -36,7 +36,7 @@ jobs:
           - os: macos-latest
             target: aarch64-apple-darwin
             archive_ext: tar.gz
-          - os: macos-13
+          - os: macos-latest
             target: x86_64-apple-darwin
             archive_ext: tar.gz
           - os: windows-latest


### PR DESCRIPTION
## Summary

Brings the macOS runner reliability fix to main ahead of tagging; supersedes prior staging.

- Merges develop into main via the gitflow release branch `release/v0.1.0`.
- Key change: `x86_64-apple-darwin` in `.github/workflows/release.yml` now cross-compiles on `macos-latest` (arm64) instead of the retiring/queue-starved `macos-13` (Intel) runner.
- All other CI matrix entries are unchanged.
- No tag and no GitHub Release are created by this PR.

## What's included since last main sync

- `ci(release)`: cross-compile x86_64-apple-darwin on macos-latest to avoid flaky macos-13 runner (#190)
- `docs`: codify gitflow main-branch rule in CLAUDE.md (#188)