### PR TITLE
ci: migrate release actions off Node 20 (SHA-pinned v7/v8/v3) + add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,39 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    # Check daily so that a version finishing its cooldown surfaces within
+    # 24h of becoming eligible, rather than waiting up to a week for the
+    # next weekly check. The cooldown block below is the actual gate;
+    # daily just removes the slack a weekly schedule would add on top.
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 5
+    # Supply-chain hardening: wait for the upstream release to "soak" before
+    # opening an update PR, so that yanked/compromised releases (e.g.
+    # post-publish hijacking) age out before we surface them for review.
+    # Cooldown does NOT apply to security advisories — Dependabot still opens
+    # those immediately, which is the desired behavior.
+    cooldown:
+      default-days: 7
+      # Majors (in Rust, also pre-1.0 minor bumps) almost always involve API
+      # breakage. Hold them a full month so the ecosystem can shake out
+      # release-day regressions before we look at the diff. Matches the
+      # risk-tiered split GitHub uses in its own canonical example.
+      semver-major-days: 30
+      # Minor + patch stay at the policy floor of 7 days. Patches do NOT
+      # drop below this — "patch" labels don't make a release immune to
+      # post-publish hijacking; if anything the opposite is true.
+      semver-minor-days: 7
+      semver-patch-days: 7
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    # Same daily cadence + cooldown rationale as the cargo block above.
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 5
+    # GitHub Actions doesn't follow strict semver, so only default-days is
+    # honored here per the Dependabot options reference.
+    cooldown:
+      default-days: 7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,7 +115,7 @@ jobs:
       #   for manual inspection without creating a GitHub Release.
       # ------------------------------------------------------------------
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: wirerust-${{ matrix.target }}
           path: ${{ env.ARCHIVE }}
@@ -139,7 +139,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Download all build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: artifacts/
 
@@ -180,7 +180,7 @@ jobs:
           ls -lh release-assets/
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           tag_name: ${{ github.ref_name }}
           name: ${{ github.ref_name }}


### PR DESCRIPTION
## Why

GitHub is enforcing Node20 deprecation for Actions with hard-enforcement landing around **2026-06-16**. The three affected actions in `release.yml` are:

| Old reference | Runtime | New reference |
|---|---|---|
| `actions/upload-artifact@v4` | Node20 | `actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1` |
| `actions/download-artifact@v4` | Node20 | `actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1` |
| `softprops/action-gh-release@v2` | Node20 | `softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0` |

Note: v4/v5 of upload/download-artifact are still Node20, so a **major version bump to v7/v8** is required. All three SHAs have been soaking on the Actions marketplace for 57–89 days (well past the 7-day policy floor).

All other actions in release.yml (`checkout@v6`, `Swatinem/rust-cache@v2`, `dtolnay/rust-toolchain@stable`) are already Node24 or composite — left untouched.

## Behavioral verification (all three are no-ops)

1. **upload-artifact v7 excludes hidden files by default** — not applicable: the upload step uploads a named `.tar.gz` / `.zip` archive set via `${{ env.ARCHIVE }}`, not a directory scan. No hidden files in scope.

2. **download-artifact v8 single-artifact path layout change** — not applicable: the download step uses no `name:` / `id:` filter (downloads all artifacts). The subsequent "Stage archives" step already uses `find artifacts/ -type f ... -exec mv {} release-assets/` which recursively flattens any subdirectory layout. Already written to handle v5+ behavior.

3. **softprops/action-gh-release v3.0.0** — pure Node20→Node24 runtime bump; inputs API unchanged. The `with:` keys used (`tag_name`, `name`, `body_path`, `files`, `prerelease`, `make_latest`) are all valid in v3.

## Dependabot

Adds `.github/dependabot.yml` mirroring the supply-chain soak convention from [Zious11/jira-cli](https://github.com/Zious11/jira-cli):

- **cargo**: daily schedule, 5 PR limit, cooldown `default-days: 7` / `semver-major-days: 30` / `semver-minor-days: 7` / `semver-patch-days: 7`
- **github-actions**: daily schedule, 5 PR limit, cooldown `default-days: 7` (only `default-days` is honored for Actions per the Dependabot options reference)

Security advisories bypass the cooldown and open immediately — intended behavior.

## Delivery scope

- Targets `develop` only. This CI change reaches `main` at the next release.
- Dependabot reads config from the default branch (`develop`) — correct placement.
- No tag was created; no `workflow_dispatch` was triggered.