### PR TITLE
fix(modbus): correct timestamp units (seconds not microseconds) in detection windows + finding timestamps

### DIFF
--- a/src/analyzer/modbus.rs
+++ b/src/analyzer/modbus.rs
@@ -11,7 +11,7 @@
 //! - `ModbusFlowState` — full per-flow state (BC-2.14.009–012, STORY-103)
 //! - `ModbusAnalyzer` — analyzer-level aggregates and `duplicate_inflight_txn` counter
 //! - `ModbusAnalyzer::process_pdu` — detection engine (BC-2.14.013–022): emits all eight finding kinds
-//! - `ModbusAnalyzer::summarize` — six-key summary (BC-2.14.021): pdu_count, write_count, exception_count, unknown_fc_count, duplicate_inflight_txn, parse_errors
+//! - `ModbusAnalyzer::summarize` — six-key summary (BC-2.14.021): pdu_count, write_count, exception_count, parse_errors, function_code_distribution, dropped_findings
 //! - `MAX_PENDING_TRANSACTIONS` — hard bound of 256 (BC-2.14.012)
 //! - `MAX_FINDINGS` — cap at 10,000 findings (BC-2.14.022)
 //! - VP-022 Kani harnesses (sub-properties A, B, C) — gated by `#[cfg(kani)]`

--- a/src/analyzer/modbus.rs
+++ b/src/analyzer/modbus.rs
@@ -324,7 +324,12 @@ impl ModbusAnalyzer {
     /// - Guard every finding push with `MAX_FINDINGS` poison-skip (BC-2.14.022).
     /// - Return a `Vec<Finding>` containing all findings emitted for this PDU.
     ///
-    /// The `timestamp` argument is the pcap-relative capture timestamp (u32 microseconds).
+    /// The `timestamp` argument is the pcap-relative capture timestamp in WHOLE SECONDS
+    /// (u32, same as `timestamp_secs` from `reader.rs`). The pipeline delivers second
+    /// granularity only — `timestamp_usecs` exists in `RawPacket` but is NOT threaded
+    /// through `StreamHandler::on_data` (threading sub-second precision is a future
+    /// enhancement, out of scope for v0.4.0). All detectors operate at 1-second resolution.
+    ///
     /// All window elapsed computations use `now_ts.wrapping_sub(window_start_ts)` per
     /// f2-fix-directives §11.5b.
     #[allow(clippy::too_many_arguments)] // 8 params: interface dictated by STORY-105 wiring (FlowKey, flow state, direction, header, fc, raw data, timestamp)
@@ -340,27 +345,40 @@ impl ModbusAnalyzer {
     ) -> Vec<Finding> {
         use chrono::DateTime;
 
-        // Convert pcap-relative microsecond u32 to a DateTime<Utc> for Finding.timestamp.
-        // Per BC-2.09.007 post.1: DateTime::from_timestamp(ts_sec, ts_usec * 1_000)
-        // where ts_sec = timestamp / 1_000_000, ts_usec = timestamp % 1_000_000.
-        let ts_sec = (timestamp / 1_000_000) as i64;
-        let ts_nsec = (timestamp % 1_000_000) * 1_000;
-        let finding_ts = DateTime::from_timestamp(ts_sec, ts_nsec);
+        // F-DELTA-001 fix: timestamp is SECONDS (the pipeline delivers timestamp_secs,
+        // not microseconds). Treat it as a whole-second Unix epoch value, matching how
+        // TLS (tls.rs), reassembly (mod.rs), and all other analyzers handle it.
+        // BC-2.09.007 post.1: DateTime::from_timestamp(seconds, 0) — no sub-second
+        // precision available at this layer; sub-second threading is a future enhancement.
+        let finding_ts = DateTime::from_timestamp(timestamp as i64, 0);
 
-        // Resolve source IPs from FlowKey using Modbus port-502 convention
-        // (BC-2.14.013 post.1, BC-2.14.017 post.1, BC-2.14.019 post.A/B, BC-2.14.020).
-        // The Modbus server always listens on port 502; the client is the other endpoint.
-        // FlowKey stores (lower_ip:lower_port, upper_ip:upper_port) canonicalized by
-        // (ip, port) tuple order — we check which port is 502 to identify server vs client.
-        let client_ip = if flow_key.lower_port() == 502 {
-            flow_key.upper_ip()
+        // F-DELTA-005 fix: resolve client/server IPs from the TCP `Direction` argument,
+        // not solely from the port-502 heuristic.
+        //
+        // `Direction::ClientToServer` means the packet is from the TCP initiator (the
+        // Modbus client). `Direction::ServerToClient` means the packet is from the
+        // responder (the Modbus server). This is the authoritative source — it comes from
+        // `TcpFlow::direction()` which tracks the SYN initiator explicitly.
+        //
+        // FlowKey canonicalizes by (ip, port) tuple order, giving `lower_*` and `upper_*`
+        // endpoints with no inherent client/server semantics. We determine which endpoint
+        // is which by combining the port-502 heuristic (Modbus server always listens on
+        // port 502) with the `direction` argument:
+        //   - If lower_port == 502: lower endpoint is the server, upper is the client.
+        //   - Otherwise:            upper endpoint is the server, lower is the client.
+        // The `direction` arg is then used to select `source_ip` for each finding
+        // (ClientToServer → the client endpoint; ServerToClient → the server endpoint),
+        // which is more semantically accurate than deriving source_ip from the heuristic
+        // alone, especially for mid-stream-join flows where the SYN was not observed.
+        //
+        // Note: FlowKey has no `client_ip()`/`server_ip()` accessors — those BCs cite
+        // a non-existent API (spec-steward reconciling). We resolve from direction + ports.
+        let (client_ip, server_ip) = if flow_key.lower_port() == 502 {
+            // lower endpoint is the Modbus server (port 502), upper is the client.
+            (flow_key.upper_ip(), flow_key.lower_ip())
         } else {
-            flow_key.lower_ip()
-        };
-        let server_ip = if flow_key.lower_port() == 502 {
-            flow_key.lower_ip()
-        } else {
-            flow_key.upper_ip()
+            // upper endpoint is the Modbus server (port 502), lower is the client.
+            (flow_key.lower_ip(), flow_key.upper_ip())
         };
 
         // Helper: push a finding into self.all_findings with MAX_FINDINGS poison-skip.
@@ -511,8 +529,10 @@ impl ModbusAnalyzer {
                         let mut emit_t0831 = false;
                         if is_register_write {
                             // Check if window has expired (wrapping_sub).
+                            // F-DELTA-001: timestamp is in SECONDS; compare directly against
+                            // T0831_WINDOW_SECS (5 seconds). No * 1_000_000 scaling.
                             let t0831_elapsed = timestamp.wrapping_sub(flow.t0831_window_start_ts);
-                            if t0831_elapsed > T0831_WINDOW_SECS * 1_000_000 {
+                            if t0831_elapsed > T0831_WINDOW_SECS {
                                 // Window expired → reset.
                                 flow.t0831_window_start_ts = timestamp;
                                 flow.t0831_window_write_count = 1;
@@ -570,8 +590,10 @@ impl ModbusAnalyzer {
                         // Update window FIRST, then check threshold (wrapping_sub).
                         // -------------------------------------------------------
                         {
+                            // F-DELTA-001: timestamp is in SECONDS; compare directly against
+                            // WRITE_BURST_WINDOW_SECS (1 second). No * 1_000_000 scaling.
                             let burst_elapsed = timestamp.wrapping_sub(flow.window_start_ts);
-                            if burst_elapsed > WRITE_BURST_WINDOW_SECS * 1_000_000 {
+                            if burst_elapsed > WRITE_BURST_WINDOW_SECS {
                                 // Window expired → slide forward.
                                 flow.window_start_ts = timestamp;
                                 flow.window_write_count = 1;
@@ -582,14 +604,15 @@ impl ModbusAnalyzer {
                                     && !flow.window_burst_emitted
                                 {
                                     flow.window_burst_emitted = true;
-                                    let elapsed_ms = burst_elapsed / 1_000;
+                                    // elapsed is in seconds; display as whole seconds.
+                                    let elapsed_ms = burst_elapsed;
                                     // Burst finding: SEPARATE from per-PDU finding (BC-2.14.013 inv5).
                                     local_findings.push(Finding {
                                         category: crate::findings::ThreatCategory::Execution,
                                         verdict: crate::findings::Verdict::Likely,
                                         confidence: crate::findings::Confidence::High,
                                         summary: format!(
-                                            "Modbus write burst: {} writes in {}ms window (unit {}, threshold {}/s)",
+                                            "Modbus write burst: {} writes in {}s window (unit {}, threshold {}/s)",
                                             flow.window_write_count,
                                             elapsed_ms,
                                             header.unit_id,
@@ -621,7 +644,20 @@ impl ModbusAnalyzer {
 
                         // -------------------------------------------------------
                         // Sustained detector: >=2-second window (BC-2.14.017 Invariant 2)
-                        // Truncation-free cross-multiplication (f2-fix-directives §11.5a).
+                        // F-DELTA-001 + Gemini #3 fix: timestamp is in SECONDS.
+                        // Truncation-free rate check for second-granularity:
+                        //   count > threshold * elapsed_secs
+                        // (no * 1_000_000 needed — both count and elapsed are already
+                        // in the same unit system; the cross-multiply was only necessary
+                        // when elapsed was in microseconds).
+                        //
+                        // Known v1 limitation (F-DELTA-004): all ADUs delivered in a
+                        // single reassembly flush share the same flush timestamp (the
+                        // pcap timestamp of the triggering packet). Window fidelity is
+                        // therefore limited by reassembly granularity — bursts within
+                        // the same packet appear as a single second. This is an inherent
+                        // v1 detector property; sub-second precision requires threading
+                        // timestamp_usecs through StreamHandler::on_data (future work).
                         // -------------------------------------------------------
                         {
                             if flow.sustained_window_write_count == 0 {
@@ -632,37 +668,36 @@ impl ModbusAnalyzer {
                             } else {
                                 // Accumulate first (update-before-check).
                                 flow.sustained_window_write_count += 1;
-                                let elapsed_us =
+                                let elapsed_secs =
                                     timestamp.wrapping_sub(flow.sustained_window_start_ts);
 
                                 // Check trigger: elapsed >= 2s AND rate exceeded AND not emitted.
-                                // Truncation-free: (count*1_000_000) > (threshold*elapsed_us)
-                                // (f2-fix-directives §11.5a)
-                                if elapsed_us >= WRITE_SUSTAINED_WINDOW_SECS * 1_000_000
+                                // Truncation-free (seconds form): count > threshold * elapsed_secs
+                                // Cast to u64 to prevent u32 overflow on large counts.
+                                if elapsed_secs >= WRITE_SUSTAINED_WINDOW_SECS
                                     && !flow.sustained_burst_emitted
-                                    && (flow.sustained_window_write_count as u64) * 1_000_000
+                                    && (flow.sustained_window_write_count as u64)
                                         > (self.write_sustained_threshold as u64)
-                                            * (elapsed_us as u64)
+                                            * (elapsed_secs as u64)
                                 {
                                     flow.sustained_burst_emitted = true;
-                                    let elapsed_secs_f = (elapsed_us as f64) / 1_000_000.0;
                                     local_findings.push(Finding {
                                         category: crate::findings::ThreatCategory::Execution,
                                         verdict: crate::findings::Verdict::Likely,
                                         confidence: crate::findings::Confidence::High,
                                         summary: format!(
-                                            "Modbus write burst: {} writes over {:.0}s window (unit {}, >{}/s avg)",
+                                            "Modbus write burst: {} writes over {}s window (unit {}, >{}/s avg)",
                                             flow.sustained_window_write_count,
-                                            elapsed_secs_f,
+                                            elapsed_secs,
                                             header.unit_id,
                                             self.write_sustained_threshold
                                         ),
                                         evidence: vec![format!(
-                                            "Sustained write rate exceeded: {} writes over {:.1} seconds \
+                                            "Sustained write rate exceeded: {} writes over {} seconds \
                                              (>{}/s average); sustained_window_start_ts={} \
                                              FC=0x{:02X} UnitID={}",
                                             flow.sustained_window_write_count,
-                                            elapsed_secs_f,
+                                            elapsed_secs,
                                             self.write_sustained_threshold,
                                             flow.sustained_window_start_ts,
                                             fc,
@@ -682,7 +717,7 @@ impl ModbusAnalyzer {
                                 // Window slide: reset when elapsed >= WRITE_SUSTAINED_WINDOW_SECS.
                                 // (f2-fix-directives §11.5 step 5: ALWAYS reset regardless of
                                 // whether a finding fired, to prevent unbounded accumulation.)
-                                if elapsed_us >= WRITE_SUSTAINED_WINDOW_SECS * 1_000_000 {
+                                if elapsed_secs >= WRITE_SUSTAINED_WINDOW_SECS {
                                     flow.sustained_window_start_ts = timestamp;
                                     flow.sustained_window_write_count = 1;
                                     flow.sustained_burst_emitted = false;
@@ -791,7 +826,13 @@ impl ModbusAnalyzer {
                             .unwrap_or(&timestamp),
                     );
 
-                    if exc_elapsed > EXCEPTION_WINDOW_SECS * 1_000_000 {
+                    // F-DELTA-001: timestamp is in SECONDS; compare directly against
+                    // EXCEPTION_WINDOW_SECS (10 seconds). No * 1_000_000 scaling.
+                    // Gemini #6 re-verified: with second granularity the 10s window
+                    // actually expires correctly, and the or_insert anchor in the else
+                    // branch ensures EC-005 cross-window reset works (new exception code
+                    // gets a fresh anchor so subsequent exceptions measure real elapsed).
+                    if exc_elapsed > EXCEPTION_WINDOW_SECS {
                         // Window expired → reset (also handles first-time with exc_elapsed=0
                         // via the else branch below for new codes).
                         flow.exception_window_counts.insert(exc_code, 1);
@@ -1041,12 +1082,17 @@ impl StreamHandler for ModbusAnalyzer {
 
             // 3-point validity gate (BC-2.14.003/004).
             if !is_valid_modbus_adu(&header) {
-                // Invalid protocol_id or out-of-range length.
-                // Per the desync policy (BC-2.14.003): if protocol_id != 0, mark the flow
-                // as non-Modbus so future chunks bail immediately.
-                if header.protocol_id != 0x0000 {
-                    flow.is_non_modbus = true;
-                }
+                // F-DELTA-003 fix: structurally-impossible Modbus ADU → latch is_non_modbus.
+                //
+                // Both failure modes indicate a non-Modbus stream:
+                //   1. protocol_id != 0x0000: a well-specified Modbus/TCP deviation.
+                //   2. length out of [2, 254]: no valid Modbus PDU can have this length;
+                //      a real Modbus device would never emit such a frame. Latching
+                //      is_non_modbus prevents per-chunk re-scan (matching behavior of the
+                //      protocol_id case) and stops parse_errors inflation on subsequent
+                //      calls. Also clears carry so no partial state lingers.
+                flow.is_non_modbus = true;
+                flow.carry.clear();
                 self.parse_errors += 1;
                 break; // Cannot safely advance: length field is invalid.
             }

--- a/tests/bc_2_14_105_modbus_dispatch_tests.rs
+++ b/tests/bc_2_14_105_modbus_dispatch_tests.rs
@@ -1334,3 +1334,92 @@ fn test_f_delta_001_e2e_second_scale_timestamps_through_dispatcher() {
         "F-DELTA-001 E2E: burst finding timestamp must also be year 2023"
     );
 }
+
+// ---------------------------------------------------------------------------
+// F-DELTA-003 — proto-id=0 + length-invalid latch test
+// ---------------------------------------------------------------------------
+
+/// F-DELTA-003 latch: proto-id=0 ADU with length OUT OF [2, 254] latches is_non_modbus.
+///
+/// A Modbus/TCP ADU with protocol_id=0x0000 (valid Modbus identifier) but length=255
+/// (out of the valid range [2, 254]) fails `is_valid_modbus_adu` and must:
+///   (a) increment parse_errors to 1
+///   (b) latch the flow as is_non_modbus (clearing carry)
+///   (c) cause all subsequent ADUs on the SAME flow to be silently ignored
+///       (total_pdu_count stays at 0 even after a structurally-valid follow-up ADU)
+///
+/// This pins the F-DELTA-003 length-invalid branch of the desync policy. The
+/// protocol_id!=0 branch was already tested (F-105-003 pin-2). This test covers the
+/// symmetric proto-id=0 / bad-length path which was previously untested.
+///
+/// Traces to: BC-2.14.003/004 (is_valid_modbus_adu gate), F-DELTA-003 fix directive.
+#[test]
+fn test_f_delta_003_proto_id_0_length_invalid_latches_is_non_modbus_and_bails() {
+    // --- Part (a) + (b): bad ADU causes parse_errors==1 and latches the flow ---
+    let modbus = ModbusAnalyzer::new(20, 10);
+    let mut dispatcher = StreamDispatcher::new(None, None, Some(modbus));
+    let key = flow_key(49152, 502);
+
+    // ADU: protocol_id=0x0000 (valid Modbus), length=0x00FF=255 (OUT OF [2, 254]).
+    // This passes parse_mbap_header (>= 8 bytes) but fails is_valid_modbus_adu.
+    // F-DELTA-003: the invalid-length branch must latch is_non_modbus and increment
+    // parse_errors, symmetrically to the protocol_id!=0 branch.
+    let bad_length_adu = [
+        0x00u8, 0x01, // transaction_id = 1
+        0x00, 0x00, // protocol_id = 0x0000 (Modbus — but length is invalid)
+        0x00, 0xFF, // length = 255 (INVALID: outside [2, 254])
+        0x01, // unit_id
+        0x03, // function_code: Read Holding Registers
+    ];
+    dispatcher.on_data(
+        &key,
+        Direction::ClientToServer,
+        &bad_length_adu,
+        0,
+        1_700_000_000,
+    );
+
+    let modbus_ref = dispatcher.take_modbus_analyzer().unwrap();
+    assert_eq!(
+        modbus_ref.parse_errors, 1,
+        "F-DELTA-003: proto-id=0 + length=255 (invalid) must increment parse_errors to 1 \
+         (is_valid_modbus_adu gate fires on the length-out-of-range path)"
+    );
+
+    // --- Part (c): subsequent valid ADU on the SAME flow is ignored (latch holds) ---
+    // Re-insert the analyzer (with parse_errors=1 and the flow latched) into a new
+    // dispatcher and deliver a structurally-valid Modbus ADU on the SAME flow key.
+    // Because is_non_modbus was set on the flow, on_data must bail immediately —
+    // total_pdu_count must stay at 0.
+    let mut dispatcher2 = StreamDispatcher::new(None, None, Some(modbus_ref));
+
+    // Valid Read Holding Registers request: proto-id=0, length=6 (in range [2, 254]).
+    let valid_adu = [
+        0x00u8, 0x02, // transaction_id = 2
+        0x00, 0x00, // protocol_id = 0x0000
+        0x00, 0x06, // length = 6 (valid)
+        0x01, // unit_id
+        0x03, // function_code: Read Holding Registers
+        0x00, 0x00, // starting address
+        0x00, 0x01, // quantity = 1
+    ];
+    dispatcher2.on_data(
+        &key,
+        Direction::ClientToServer,
+        &valid_adu,
+        8,
+        1_700_000_001,
+    );
+
+    let modbus_final = dispatcher2.take_modbus_analyzer().unwrap();
+    assert_eq!(
+        modbus_final.total_pdu_count, 0,
+        "F-DELTA-003: after length-invalid latch, a subsequent valid ADU on the same flow \
+         must NOT be processed — total_pdu_count must stay at 0 (is_non_modbus bail fires)"
+    );
+    assert_eq!(
+        modbus_final.parse_errors, 1,
+        "F-DELTA-003: parse_errors must remain at 1 after the latch-bail \
+         (no additional parse_errors incremented for latched flows)"
+    );
+}

--- a/tests/bc_2_14_105_modbus_dispatch_tests.rs
+++ b/tests/bc_2_14_105_modbus_dispatch_tests.rs
@@ -86,7 +86,13 @@ fn test_BC_2_14_025_port_502_classified_to_modbus_as_rule_5() {
         0x00, 0x01, // quantity of registers
     ];
     // on_data() routes to ModbusAnalyzer, which parses the complete ADU.
-    dispatcher.on_data(&key, Direction::ClientToServer, &complete_adu, 0, 1_000_000);
+    dispatcher.on_data(
+        &key,
+        Direction::ClientToServer,
+        &complete_adu,
+        0,
+        1_700_000_000,
+    );
     // Verify the PDU was processed.
     let modbus = dispatcher.take_modbus_analyzer().unwrap();
     assert!(
@@ -120,7 +126,7 @@ fn test_BC_2_14_025_port_502_tls_content_classified_to_tls_not_modbus() {
     // This should route to TLS (Rule 1 fires), NOT Modbus (Rule 5).
     // The TLS analyzer receives data (no panic — TLS on_data is implemented).
     // We verify Modbus analyzer gets no PDUs.
-    dispatcher.on_data(&key, Direction::ClientToServer, &tls_data, 0, 1_000_000);
+    dispatcher.on_data(&key, Direction::ClientToServer, &tls_data, 0, 1_700_000_000);
     // Modbus should have zero PDUs — TLS content wins.
     let modbus = dispatcher.take_modbus_analyzer().unwrap();
     assert_eq!(
@@ -146,7 +152,7 @@ fn test_BC_2_14_025_port_502_http_content_classified_to_http_not_modbus() {
     let key = flow_key(12345, 502);
     let http_data = b"GET / HTTP/1.1\r\nHost: example.com\r\n\r\n";
     // Rule 2 fires (HTTP content) before Rule 5 (port 502).
-    dispatcher.on_data(&key, Direction::ClientToServer, http_data, 0, 1_000_000);
+    dispatcher.on_data(&key, Direction::ClientToServer, http_data, 0, 1_700_000_000);
     // Modbus should have zero PDUs — HTTP content wins.
     let modbus = dispatcher.take_modbus_analyzer().unwrap();
     assert_eq!(
@@ -173,7 +179,13 @@ fn test_BC_2_14_025_port_443_mbap_bytes_classified_to_tls_not_modbus() {
     let key = flow_key(12345, 443);
     let mbap_data = [0x00u8, 0x01, 0x00, 0x00, 0x00, 0x06, 0x01, 0x03];
     // Rule 3 (port 443 → TLS) fires before Rule 5 (port 502 → Modbus).
-    dispatcher.on_data(&key, Direction::ClientToServer, &mbap_data, 0, 1_000_000);
+    dispatcher.on_data(
+        &key,
+        Direction::ClientToServer,
+        &mbap_data,
+        0,
+        1_700_000_000,
+    );
     // Modbus should have zero PDUs.
     let modbus = dispatcher.take_modbus_analyzer().unwrap();
     assert_eq!(
@@ -196,7 +208,13 @@ fn test_BC_2_14_025_modbus_disabled_port_502_flow_is_noop() {
     let mbap_data = [0x00u8, 0x01, 0x00, 0x00, 0x00, 0x06, 0x01, 0x03];
     // This calls classify() → Modbus, then on_data() Modbus arm → None check → no-op.
     // Should NOT panic (the arm is `if let Some(...)` not unwrap).
-    dispatcher.on_data(&key, Direction::ClientToServer, &mbap_data, 0, 1_000_000);
+    dispatcher.on_data(
+        &key,
+        Direction::ClientToServer,
+        &mbap_data,
+        0,
+        1_700_000_000,
+    );
     // No assertions needed — just verify no panic.
 }
 
@@ -221,7 +239,13 @@ fn test_BC_2_14_025_on_data_routes_port_502_flow_to_modbus_analyzer() {
         0x00, 0x00, // coil address
         0xFF, 0x00, // coil value (ON)
     ];
-    dispatcher.on_data(&key, Direction::ClientToServer, &write_pdu, 0, 1_000_000);
+    dispatcher.on_data(
+        &key,
+        Direction::ClientToServer,
+        &write_pdu,
+        0,
+        1_700_000_000,
+    );
 
     let modbus = dispatcher.take_modbus_analyzer().unwrap();
     assert!(
@@ -250,7 +274,13 @@ fn test_BC_2_14_025_on_flow_close_routes_modbus_flow_to_analyzer() {
         0x00, 0x00, // starting address
         0x00, 0x01, // quantity of registers
     ];
-    dispatcher.on_data(&key, Direction::ClientToServer, &complete_adu, 0, 1_000_000);
+    dispatcher.on_data(
+        &key,
+        Direction::ClientToServer,
+        &complete_adu,
+        0,
+        1_700_000_000,
+    );
     dispatcher.on_flow_close(&key, CloseReason::Fin);
     // Analyzer is still accessible after flow close; PDU was counted before close.
     let modbus = dispatcher.take_modbus_analyzer().unwrap();
@@ -281,7 +311,13 @@ fn test_BC_2_14_025_unclassified_flows_counted_in_modbus_only_run() {
     let mut dispatcher = StreamDispatcher::new(None, None, Some(ModbusAnalyzer::new(20, 10)))
         .with_max_classification_attempts(1);
 
-    dispatcher.on_data(&key, Direction::ClientToServer, &random_data, 0, 1_000_000);
+    dispatcher.on_data(
+        &key,
+        Direction::ClientToServer,
+        &random_data,
+        0,
+        1_700_000_000,
+    );
     // Close the flow — it had DispatchTarget::None cached.
     dispatcher.on_flow_close(&key, CloseReason::Fin);
 
@@ -738,7 +774,13 @@ fn test_BC_2_14_025_vp004_oracle_port_8080_routes_to_http_not_modbus() {
     // Non-HTTP content bytes — port fallback fires (Rule 4: port 8080 → HTTP).
     let binary_data = [0x00u8, 0x01, 0x00, 0x00, 0x00, 0x06, 0x01, 0x03];
     // No panic — HTTP arm is implemented.
-    dispatcher.on_data(&key, Direction::ClientToServer, &binary_data, 0, 1_000_000);
+    dispatcher.on_data(
+        &key,
+        Direction::ClientToServer,
+        &binary_data,
+        0,
+        1_700_000_000,
+    );
     // Modbus should have zero PDUs.
     let modbus = dispatcher.take_modbus_analyzer().unwrap();
     assert_eq!(
@@ -761,7 +803,13 @@ fn test_BC_2_14_025_vp004_oracle_unknown_port_routes_to_none_not_modbus() {
     let mbap_data = [0x00u8, 0x01, 0x00, 0x00, 0x00, 0x06, 0x01, 0x03];
     // classify() returns None (no content match, not 443/8443/80/8080/502).
     // on_data() Modbus arm is NOT reached.
-    dispatcher.on_data(&key, Direction::ClientToServer, &mbap_data, 0, 1_000_000);
+    dispatcher.on_data(
+        &key,
+        Direction::ClientToServer,
+        &mbap_data,
+        0,
+        1_700_000_000,
+    );
     // Force close so unclassified_flows is incremented.
     dispatcher.on_flow_close(&key, CloseReason::Timeout);
     assert_eq!(
@@ -815,7 +863,7 @@ fn test_F_105_002_pin1_two_complete_adus_in_one_on_data_counted_correctly() {
     combined.extend_from_slice(&adu1);
     combined.extend_from_slice(&adu2);
 
-    dispatcher.on_data(&key, Direction::ClientToServer, &combined, 0, 1_000_000);
+    dispatcher.on_data(&key, Direction::ClientToServer, &combined, 0, 1_700_000_000);
 
     let modbus = dispatcher.take_modbus_analyzer().unwrap();
     assert_eq!(
@@ -874,11 +922,23 @@ fn test_F_105_002_pin2_write_adu_split_across_two_on_data_calls() {
 
     // First on_data: only 5 bytes — not enough for even the MBAP header.
     // With carry buffer: stashed in carry, no PDU processed yet.
-    dispatcher.on_data(&key, Direction::ClientToServer, first_chunk, 0, 1_000_000);
+    dispatcher.on_data(
+        &key,
+        Direction::ClientToServer,
+        first_chunk,
+        0,
+        1_700_000_000,
+    );
 
     // Second on_data: remaining 7 bytes — carry (5) + new (7) = 12 bytes → full ADU.
     // With carry buffer: carry prepended, full 12-byte ADU parsed, process_pdu called.
-    dispatcher.on_data(&key, Direction::ClientToServer, second_chunk, 5, 1_000_000);
+    dispatcher.on_data(
+        &key,
+        Direction::ClientToServer,
+        second_chunk,
+        5,
+        1_700_000_000,
+    );
 
     let modbus = dispatcher.take_modbus_analyzer().unwrap();
     assert_eq!(
@@ -928,10 +988,22 @@ fn test_F_105_002_pin3_partial_mbap_header_3_bytes_then_rest() {
     let second_chunk = &full_adu[3..];
 
     // First on_data: 3 bytes → parse_mbap_header returns None (< 8) → stash in carry.
-    dispatcher.on_data(&key, Direction::ClientToServer, first_chunk, 0, 1_000_000);
+    dispatcher.on_data(
+        &key,
+        Direction::ClientToServer,
+        first_chunk,
+        0,
+        1_700_000_000,
+    );
 
     // Second on_data: carry (3) + new (9) = 12 bytes → full ADU → process_pdu called.
-    dispatcher.on_data(&key, Direction::ClientToServer, second_chunk, 3, 1_000_000);
+    dispatcher.on_data(
+        &key,
+        Direction::ClientToServer,
+        second_chunk,
+        3,
+        1_700_000_000,
+    );
 
     let modbus = dispatcher.take_modbus_analyzer().unwrap();
     assert_eq!(
@@ -997,7 +1069,7 @@ fn test_F_105_003_pin1_carry_cap_near_limit_safe_case() {
         Direction::ClientToServer,
         &full_adu[..259],
         0,
-        1_000_000,
+        1_700_000_000,
     );
 
     // Call 2: deliver final 1 byte — combined buf = carry(259) + data(1) = 260 bytes.
@@ -1007,7 +1079,7 @@ fn test_F_105_003_pin1_carry_cap_near_limit_safe_case() {
         Direction::ClientToServer,
         &full_adu[259..],
         259,
-        1_000_001,
+        1_700_000_001,
     );
 
     let modbus = dispatcher.take_modbus_analyzer().unwrap();
@@ -1070,7 +1142,7 @@ fn test_F_105_003_pin2_dribble_never_completing_stream_is_non_modbus_set() {
             Direction::ClientToServer,
             &crafted[i..=i],
             i as u64,
-            1_000_000,
+            1_700_000_000,
         );
     }
 
@@ -1082,7 +1154,7 @@ fn test_F_105_003_pin2_dribble_never_completing_stream_is_non_modbus_set() {
         Direction::ClientToServer,
         &crafted[7..=7],
         7,
-        1_000_007,
+        1_700_000_007,
     );
 
     // Verify: parse_errors == 1 (desync fired exactly once).
@@ -1112,7 +1184,13 @@ fn test_F_105_003_pin2_dribble_never_completing_stream_is_non_modbus_set() {
             0x00, 0x00, // starting address
             0x00, 0x01, // quantity
         ];
-        dispatcher2.on_data(&key, Direction::ClientToServer, &valid_adu, 8, 1_000_100);
+        dispatcher2.on_data(
+            &key,
+            Direction::ClientToServer,
+            &valid_adu,
+            8,
+            1_700_000_001,
+        );
 
         let modbus_final = dispatcher2.take_modbus_analyzer().unwrap();
         assert_eq!(
@@ -1142,5 +1220,117 @@ fn test_F_105_003_pin3_max_adu_carry_bytes_equals_one_max_adu() {
         MAX_ADU_CARRY_BYTES, 260,
         "MAX_ADU_CARRY_BYTES must equal 260 (6-byte MBAP prefix + max length=254); \
          carry-cap invariant depends on this value"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// F-DELTA-001 mandatory E2E test — timestamp units (seconds) verified end-to-end
+// ---------------------------------------------------------------------------
+
+/// E2E test: port-502 Modbus flow through StreamDispatcher::on_data with second-scale
+/// timestamps (1_700_000_000 ≈ 2023-11-14).
+///
+/// Asserts:
+///   1. Finding.timestamp year is 2023 (confirms pipeline delivers SECONDS, not microseconds).
+///   2. Burst detector fires when 21 writes are delivered within the 1-second burst window.
+///
+/// This is the mandatory end-to-end validation for F-DELTA-001: the timestamp unit fix
+/// that corrected modbus.rs from treating timestamp as microseconds to treating it as
+/// seconds (consistent with all other analyzers and the reassembly pipeline).
+///
+/// Using StreamDispatcher::on_data (not process_pdu directly) ensures the full pipeline
+/// path — dispatcher → ModbusHandler::on_data → process_pdu — is exercised.
+#[test]
+fn test_f_delta_001_e2e_second_scale_timestamps_through_dispatcher() {
+    use chrono::Datelike;
+
+    // 1_700_000_000 seconds = 2023-11-14T22:13:20Z (UTC)
+    // This is a second-scale UNIX timestamp, matching what the pipeline delivers.
+    const TS_2023: u32 = 1_700_000_000;
+
+    // Use a low burst threshold (1) so 2 writes in the same second triggers the burst detector.
+    let modbus = ModbusAnalyzer::new(1, 100);
+    let mut dispatcher = StreamDispatcher::new(None, None, Some(modbus));
+    let key = flow_key(49152, 502); // client:49152 → server:502
+
+    // Helper: build a complete Modbus write-single-register ADU (FC=0x06).
+    // MBAP: TxnID, ProtoID=0x0000, Len=0x0006, UnitID=0x01, FC=0x06, addr, value.
+    let make_write_adu = |txn: u16, addr: u16, value: u16| -> [u8; 12] {
+        [
+            (txn >> 8) as u8,
+            (txn & 0xFF) as u8, // transaction_id
+            0x00,
+            0x00, // protocol_id = 0
+            0x00,
+            0x06, // length = 6 (UnitID + FC + 4 bytes data)
+            0x01, // unit_id
+            0x06, // function_code: Write Single Register
+            (addr >> 8) as u8,
+            (addr & 0xFF) as u8, // register address
+            (value >> 8) as u8,
+            (value & 0xFF) as u8, // register value
+        ]
+    };
+
+    // --- Part 1: Verify timestamp year is 2023 ---
+    // Deliver a single write at TS_2023. The per-PDU write finding should have year=2023.
+    let adu1 = make_write_adu(0x0001, 0x0010, 0x01F4);
+    dispatcher.on_data(&key, Direction::ClientToServer, &adu1, 0, TS_2023);
+
+    let modbus_ref = dispatcher.take_modbus_analyzer().unwrap();
+    let write_findings: Vec<_> = modbus_ref
+        .all_findings
+        .iter()
+        .filter(|f| f.mitre_techniques.contains(&"T0855".to_string()))
+        .collect();
+
+    assert!(
+        !write_findings.is_empty(),
+        "F-DELTA-001 E2E: at least one write finding must be emitted for FC=0x06"
+    );
+    let f = &write_findings[0];
+    let ts = f
+        .timestamp
+        .expect("F-DELTA-001 E2E: write finding must have a timestamp (not None)");
+    assert_eq!(
+        ts.year(),
+        2023,
+        "F-DELTA-001 E2E: finding timestamp year must be 2023 (confirming SECONDS pipeline, \
+         not microseconds). timestamp={ts:?}"
+    );
+
+    // --- Part 2: Burst detector fires with second-scale timestamps ---
+    // Use threshold=1: 2nd write in same 1-second window fires the burst detector.
+    // Deliver 21 writes all at TS_2023 (same second → same burst window).
+    let modbus2 = ModbusAnalyzer::new(1, 100);
+    let mut dispatcher2 = StreamDispatcher::new(None, None, Some(modbus2));
+
+    for txn in 0..21_u16 {
+        let adu = make_write_adu(txn + 2, txn, 1);
+        dispatcher2.on_data(&key, Direction::ClientToServer, &adu, 0, TS_2023);
+    }
+
+    let modbus2_ref = dispatcher2.take_modbus_analyzer().unwrap();
+    let burst_findings: Vec<_> = modbus2_ref
+        .all_findings
+        .iter()
+        .filter(|f| f.mitre_techniques.contains(&"T0806".to_string()))
+        .collect();
+
+    assert_eq!(
+        burst_findings.len(),
+        1,
+        "F-DELTA-001 E2E: burst detector must fire exactly once when 21 writes arrive \
+         within a 1-second window (threshold=1). burst_findings={:?}",
+        burst_findings.len()
+    );
+    // Burst finding also has correct year.
+    let burst_ts = burst_findings[0]
+        .timestamp
+        .expect("F-DELTA-001 E2E: burst finding must have a timestamp");
+    assert_eq!(
+        burst_ts.year(),
+        2023,
+        "F-DELTA-001 E2E: burst finding timestamp must also be year 2023"
     );
 }

--- a/tests/modbus_detection_tests.rs
+++ b/tests/modbus_detection_tests.rs
@@ -339,35 +339,14 @@ fn test_BC_2_14_016_t0831_inline_cotag_on_second_holding_register_write() {
     let mut flow = ModbusFlowState::default();
     let fk = test_flow_key();
 
-    // All three writes within 5s (timestamps 1.0s, 2.0s, 3.0s in microseconds).
+    // All three writes within 5s (timestamps 1s, 2s, 3s — second-granularity after F-DELTA-001 fix).
     let adu1 = build_adu(0x0001, 0x01, 0x06, &[0x00, 0x10, 0x01, 0xF4]);
     let adu2 = build_adu(0x0002, 0x01, 0x06, &[0x00, 0x10, 0x02, 0x00]);
     let adu3 = build_adu(0x0003, 0x01, 0x06, &[0x00, 0x10, 0x03, 0x00]);
 
-    let f1 = drive(
-        &mut az,
-        &mut flow,
-        &fk,
-        Direction::ClientToServer,
-        &adu1,
-        1_000_000,
-    );
-    let f2 = drive(
-        &mut az,
-        &mut flow,
-        &fk,
-        Direction::ClientToServer,
-        &adu2,
-        2_000_000,
-    );
-    let f3 = drive(
-        &mut az,
-        &mut flow,
-        &fk,
-        Direction::ClientToServer,
-        &adu3,
-        3_000_000,
-    );
+    let f1 = drive(&mut az, &mut flow, &fk, Direction::ClientToServer, &adu1, 1);
+    let f2 = drive(&mut az, &mut flow, &fk, Direction::ClientToServer, &adu2, 2);
+    let f3 = drive(&mut az, &mut flow, &fk, Direction::ClientToServer, &adu3, 3);
 
     // First write: T0831 window started, count=1 → no T0831 tag.
     assert_eq!(
@@ -417,29 +396,15 @@ fn test_BC_2_14_016_t0831_window_reset_after_5s() {
     let mut flow = ModbusFlowState::default();
     let fk = test_flow_key();
 
-    // Two writes within 5s to fire T0831.
+    // Two writes within 5s to fire T0831. (F-DELTA-001: second-granularity timestamps)
     let adu1 = build_adu(0x0001, 0x01, 0x06, &[0x00, 0x10, 0x01, 0xF4]);
     let adu2 = build_adu(0x0002, 0x01, 0x06, &[0x00, 0x11, 0x01, 0xF4]);
     drive(&mut az, &mut flow, &fk, Direction::ClientToServer, &adu1, 0);
-    drive(
-        &mut az,
-        &mut flow,
-        &fk,
-        Direction::ClientToServer,
-        &adu2,
-        1_000_000,
-    );
+    drive(&mut az, &mut flow, &fk, Direction::ClientToServer, &adu2, 1);
 
-    // Third write at 6s (window expired — wrapping_sub(6_000_000, 0) = 6_000_000 > 5_000_000).
+    // Third write at 6s (window expired — wrapping_sub(6, 0) = 6 > T0831_WINDOW_SECS=5).
     let adu3 = build_adu(0x0003, 0x01, 0x06, &[0x00, 0x12, 0x01, 0xF4]);
-    let f3 = drive(
-        &mut az,
-        &mut flow,
-        &fk,
-        Direction::ClientToServer,
-        &adu3,
-        6_000_000,
-    );
+    let f3 = drive(&mut az, &mut flow, &fk, Direction::ClientToServer, &adu3, 6);
 
     assert_eq!(f3.len(), 1);
     assert_eq!(
@@ -475,22 +440,9 @@ fn test_BC_2_14_016_t0831_window_update_before_emission_ordering() {
         &[0x00, 0x01, 0x00, 0x01, 0x02, 0x02, 0x00],
     );
 
-    let f1 = drive(
-        &mut az,
-        &mut flow,
-        &fk,
-        Direction::ClientToServer,
-        &adu1,
-        500_000,
-    );
-    let f2 = drive(
-        &mut az,
-        &mut flow,
-        &fk,
-        Direction::ClientToServer,
-        &adu2,
-        1_500_000,
-    );
+    // F-DELTA-001: second-granularity. Two writes at 0s and 1s → within 5s T0831 window.
+    let f1 = drive(&mut az, &mut flow, &fk, Direction::ClientToServer, &adu1, 0);
+    let f2 = drive(&mut az, &mut flow, &fk, Direction::ClientToServer, &adu2, 1);
 
     // If ordering is wrong (check before update): T0831 would never fire because
     // count=1 before increment. Correct ordering means count=2 after increment → fires.
@@ -506,9 +458,10 @@ fn test_BC_2_14_016_t0831_window_update_before_emission_ordering() {
 
 /// test_BC_2_14_016_t0831_wrapping_sub_wrap
 ///
-/// Timestamp wrap: write1 at ts=0xFFFFFF00, write2 at ts=0x00000100.
-/// wrapping_sub(0x00000100, 0xFFFFFF00) = 0x00000200 = 512 µs << 5_000_000 µs → same window.
+/// Timestamp wrap: write1 at ts=0xFFFFFFFE, write2 at ts=0x00000001.
+/// wrapping_sub(0x00000001, 0xFFFFFFFE) = 3 seconds < T0831_WINDOW_SECS=5 → same window.
 /// Both writes within the same T0831 window → second write carries T0831.
+/// F-DELTA-001: timestamps are seconds; 3s elapsed is within the 5s T0831 window.
 /// Traces to: BC-2.14.016 + f2-fix-directives §11.5b (wrapping_sub policy).
 /// Also traces to: STORY-104 AC-006 (wrapping_sub for all window elapsed computations).
 #[test]
@@ -520,14 +473,15 @@ fn test_BC_2_14_016_t0831_wrapping_sub_wrap() {
     let adu1 = build_adu(0x0001, 0x01, 0x06, &[0x00, 0x10, 0x01, 0xF4]);
     let adu2 = build_adu(0x0002, 0x01, 0x06, &[0x00, 0x10, 0x02, 0x00]);
 
-    // write1 near u32::MAX boundary, write2 slightly past zero (wrap-around)
+    // write1 near u32::MAX boundary, write2 slightly past zero (wrap-around).
+    // wrapping_sub(0x00000001, 0xFFFFFFFE) = 3 seconds → within 5s T0831 window.
     drive(
         &mut az,
         &mut flow,
         &fk,
         Direction::ClientToServer,
         &adu1,
-        0xFFFFFF00_u32,
+        0xFFFFFFFE_u32,
     );
     let f2 = drive(
         &mut az,
@@ -535,11 +489,10 @@ fn test_BC_2_14_016_t0831_wrapping_sub_wrap() {
         &fk,
         Direction::ClientToServer,
         &adu2,
-        0x00000100_u32,
+        0x00000001_u32,
     );
 
-    // wrapping_sub(0x100, 0xFFFFFF00) = 0x200 = 512 µs → within 5s window → T0831 fires
-    // (no panic from overflow-checks either)
+    // wrapping_sub(0x1, 0xFFFFFFFE) = 3 → within 5s window → T0831 fires (no panic from overflow-checks)
     assert!(
         f2[0].mitre_techniques.contains(&"T0831".to_string()),
         "wrapping_sub ensures T0831 fires across u32 boundary"
@@ -567,10 +520,11 @@ fn test_BC_2_14_017_burst_detector_fires_at_threshold_plus_1() {
     let fk = test_flow_key();
 
     let mut all_findings = Vec::new();
-    // 21 writes, each 10ms apart (all within 1s window = 200ms total << 1_000_000µs)
+    // 21 writes all at ts=0 (same second, within 1s burst window).
+    // F-DELTA-001: timestamps are seconds; all same second → burst window never expires.
     for i in 0..21_u32 {
         let adu = build_adu(i as u16 + 1, 0x01, 0x06, &[0x00, i as u8, 0x01, 0x00]);
-        let ts = i * 10_000; // 10ms intervals → 200ms total
+        let ts = 0_u32; // all in the same 1-second window
         let mut findings = drive(&mut az, &mut flow, &fk, Direction::ClientToServer, &adu, ts);
         all_findings.append(&mut findings);
     }
@@ -622,9 +576,10 @@ fn test_BC_2_14_017_burst_does_not_fire_at_exactly_threshold() {
     let fk = test_flow_key();
 
     let mut all_findings = Vec::new();
+    // F-DELTA-001: all writes at ts=0 (same second, within burst window).
     for i in 0..20_u32 {
         let adu = build_adu(i as u16 + 1, 0x01, 0x06, &[0x00, i as u8, 0x01, 0x00]);
-        let ts = i * 10_000;
+        let ts = 0_u32; // all in same 1-second window
         let mut f = drive(&mut az, &mut flow, &fk, Direction::ClientToServer, &adu, ts);
         all_findings.append(&mut f);
     }
@@ -650,10 +605,10 @@ fn test_BC_2_14_017_burst_emit_once_per_window() {
     let fk = test_flow_key();
 
     let mut all_findings = Vec::new();
-    // 31 writes within 300ms (all same window)
+    // 31 writes all at ts=0 (same 1-second window). F-DELTA-001: timestamps are seconds.
     for i in 0..31_u32 {
         let adu = build_adu(i as u16 + 1, 0x01, 0x06, &[0x00, i as u8, 0x01, 0x00]);
-        let ts = i * 10_000;
+        let ts = 0_u32; // all in same 1-second window
         let mut f = drive(&mut az, &mut flow, &fk, Direction::ClientToServer, &adu, ts);
         all_findings.append(&mut f);
     }
@@ -674,10 +629,11 @@ fn test_BC_2_14_017_burst_emit_once_per_window() {
 
 /// test_BC_2_14_017_sustained_detector_uses_truncation_free_math_no_false_positive
 ///
-/// 25 writes over 2.9s (elapsed_us = 2_900_000; rate = 8.62/s < 10/s threshold).
-/// Naive integer-division: 25 > 10*2 = 20 → TRUE (FALSE POSITIVE).
-/// Correct formula: 25*1_000_000=25_000_000 > 10*2_900_000=29_000_000 → FALSE → no burst.
-/// Traces to: BC-2.14.017 invariant 2, f2-fix-directives §11.5a, STORY-104 AC-005.
+/// 25 writes over 3 seconds (rate = 25/3 ≈ 8.33/s < 10/s threshold).
+/// Naive integer division: 25 > 10*3 = 30 → FALSE (correct, no burst).
+/// Truncation-free form: 25 > 10*3 = 30 → FALSE → no burst.
+/// F-DELTA-001: timestamps are seconds. First 24 writes at ts=0, 25th at ts=3.
+/// Traces to: BC-2.14.017 invariant 2, STORY-104 AC-005.
 #[test]
 fn test_BC_2_14_017_sustained_detector_uses_truncation_free_math_no_false_positive() {
     // Use a HIGH burst threshold so burst detector does NOT fire on its own.
@@ -686,14 +642,22 @@ fn test_BC_2_14_017_sustained_detector_uses_truncation_free_math_no_false_positi
     let fk = test_flow_key();
 
     let mut all_findings = Vec::new();
-    // 25 writes; first at ts=0, last at ts=2_900_000 (even spacing within 2.9s).
-    // Each write ~116_000µs apart.
-    for i in 0..25_u32 {
+    // 24 writes at ts=0, 25th write at ts=3 (elapsed=3s; count=25; 25 > 10*3=30 → FALSE → no burst).
+    for i in 0..24_u32 {
         let adu = build_adu(i as u16 + 1, 0x01, 0x06, &[0x00, i as u8, 0x01, 0x00]);
-        let ts = i * 116_000;
-        let mut f = drive(&mut az, &mut flow, &fk, Direction::ClientToServer, &adu, ts);
+        let mut f = drive(&mut az, &mut flow, &fk, Direction::ClientToServer, &adu, 0);
         all_findings.append(&mut f);
     }
+    let adu25 = build_adu(0x0019, 0x01, 0x06, &[0x00, 0x18, 0x01, 0x00]);
+    let mut f25 = drive(
+        &mut az,
+        &mut flow,
+        &fk,
+        Direction::ClientToServer,
+        &adu25,
+        3,
+    );
+    all_findings.append(&mut f25);
 
     let sustained_count = all_findings
         .iter()
@@ -701,14 +665,15 @@ fn test_BC_2_14_017_sustained_detector_uses_truncation_free_math_no_false_positi
         .count();
     assert_eq!(
         sustained_count, 0,
-        "truncation-free math: 8.62/s < 10/s threshold → NO sustained finding (would be false positive with naive integer division)"
+        "8.33/s < 10/s threshold: 25 > 10*3=30 → FALSE → NO sustained finding"
     );
 }
 
 /// test_BC_2_14_017_sustained_detector_fires_when_rate_exceeded
 ///
-/// 25 writes over 2.0s (elapsed_us = 2_000_000; rate = 12.5/s > 10/s threshold).
-/// Correct formula: 25*1_000_000=25_000_000 > 10*2_000_000=20_000_000 → TRUE → fires.
+/// 25 writes over 2 seconds (rate = 12.5/s > 10/s threshold).
+/// Truncation-free seconds form: 25 > 10*2=20 → TRUE → fires.
+/// F-DELTA-001: timestamps are seconds. 24 writes at ts=0, 25th at ts=2.
 /// Traces to: BC-2.14.017 invariant 2, STORY-104 AC-005.
 #[test]
 fn test_BC_2_14_017_sustained_detector_fires_when_rate_exceeded() {
@@ -718,15 +683,14 @@ fn test_BC_2_14_017_sustained_detector_fires_when_rate_exceeded() {
     let fk = test_flow_key();
 
     let mut all_findings = Vec::new();
-    // 25 writes over 2s: each ~80_000µs apart so last ts ≈ 1_920_000µs ≈ 2s.
-    // Deliver 24 writes to accumulate; 25th at exactly elapsed=2_000_000.
+    // 24 writes at ts=0 (uninitialized → window starts at ts=0, count=1, then accumulates to 24).
+    // 25th write at ts=2 → elapsed=2, count=25, 25 > 10*2=20 → TRUE → fires.
     for i in 0..24_u32 {
         let adu = build_adu(i as u16 + 1, 0x01, 0x06, &[0x00, i as u8, 0x01, 0x00]);
-        let ts = i * 80_000;
-        let mut f = drive(&mut az, &mut flow, &fk, Direction::ClientToServer, &adu, ts);
+        let mut f = drive(&mut az, &mut flow, &fk, Direction::ClientToServer, &adu, 0);
         all_findings.append(&mut f);
     }
-    // 25th write at ts = 2_000_000 (elapsed from 0 = exactly 2s)
+    // 25th write at ts=2 (elapsed from 0 = exactly 2s)
     let adu25 = build_adu(0x0019, 0x01, 0x06, &[0x00, 0x18, 0x01, 0x00]);
     let mut f25 = drive(
         &mut az,
@@ -734,7 +698,7 @@ fn test_BC_2_14_017_sustained_detector_fires_when_rate_exceeded() {
         &fk,
         Direction::ClientToServer,
         &adu25,
-        2_000_000,
+        2,
     );
     all_findings.append(&mut f25);
 
@@ -772,15 +736,14 @@ fn test_BC_2_14_017_sustained_low_and_slow_fires() {
     let fk = test_flow_key();
 
     let mut all_findings = Vec::new();
-    // 17 writes over 2s (17/2s = 8.5/s > 5/s threshold).
-    // Space them at 125_000µs intervals (8/s). 16 intervals = 2_000_000µs elapsed.
+    // 17 writes over 2s: 16 at ts=0, 17th at ts=2 → elapsed=2s; count=17; 17 > 5*2=10 → fires.
+    // F-DELTA-001: timestamps are seconds; rate = 17/2 = 8.5/s > 5/s threshold.
     for i in 0..16_u32 {
         let adu = build_adu(i as u16 + 1, 0x01, 0x06, &[0x00, i as u8, 0x01, 0x00]);
-        let ts = i * 125_000;
-        let mut f = drive(&mut az, &mut flow, &fk, Direction::ClientToServer, &adu, ts);
+        let mut f = drive(&mut az, &mut flow, &fk, Direction::ClientToServer, &adu, 0);
         all_findings.append(&mut f);
     }
-    // 17th write at exactly ts=2_000_000 triggers the window check
+    // 17th write at ts=2 triggers the sustained window check (elapsed=2 >= WRITE_SUSTAINED_WINDOW_SECS=2)
     let adu17 = build_adu(0x0011, 0x01, 0x06, &[0x00, 0x10, 0x01, 0x00]);
     let mut f17 = drive(
         &mut az,
@@ -788,7 +751,7 @@ fn test_BC_2_14_017_sustained_low_and_slow_fires() {
         &fk,
         Direction::ClientToServer,
         &adu17,
-        2_000_000,
+        2,
     );
     all_findings.append(&mut f17);
 
@@ -972,6 +935,7 @@ fn test_BC_2_14_019_exception_burst_emits_anomaly_finding() {
 
     // Pre-insert a pending request so attribute_exception can match:
     // request: txn=0x000N, unit=0x01, FC=0x06
+    // F-DELTA-001: timestamps in seconds. 11 exceptions at ts=0..10 → all within 10s window.
     let mut all_findings = Vec::new();
     for i in 0..11_u32 {
         // Insert the request first (so exception can be attributed)
@@ -982,11 +946,10 @@ fn test_BC_2_14_019_exception_burst_emits_anomaly_finding() {
             &fk,
             Direction::ClientToServer,
             &req_adu,
-            i * 100_000,
+            i,
         );
 
         // Exception response: FC=0x86 (=0x06|0x80), exception code=0x01
-        // ADU: [txn, 0x00, 0x00, length=0x03, unit=0x01, FC=0x86, code=0x01]
         let exc_adu = build_adu(i as u16, 0x01, 0x86, &[0x01]);
         let mut f = drive(
             &mut az,
@@ -994,7 +957,7 @@ fn test_BC_2_14_019_exception_burst_emits_anomaly_finding() {
             &fk,
             Direction::ServerToClient,
             &exc_adu,
-            i * 100_000 + 50_000,
+            i,
         );
         all_findings.append(&mut f);
     }
@@ -1030,6 +993,7 @@ fn test_BC_2_14_019_exception_burst_does_not_fire_at_threshold() {
     let mut flow = ModbusFlowState::default();
     let fk = test_flow_key();
 
+    // F-DELTA-001: timestamps in seconds. 5 exceptions at ts=0..4 → all within 10s window.
     let mut all_findings = Vec::new();
     for i in 0..5_u32 {
         let req_adu = build_adu(i as u16, 0x01, 0x06, &[0x00, i as u8, 0x01, 0x00]);
@@ -1039,7 +1003,7 @@ fn test_BC_2_14_019_exception_burst_does_not_fire_at_threshold() {
             &fk,
             Direction::ClientToServer,
             &req_adu,
-            i * 100_000,
+            i,
         );
 
         let exc_adu = build_adu(i as u16, 0x01, 0x86, &[0x01]);
@@ -1049,7 +1013,7 @@ fn test_BC_2_14_019_exception_burst_does_not_fire_at_threshold() {
             &fk,
             Direction::ServerToClient,
             &exc_adu,
-            i * 100_000 + 50_000,
+            i,
         );
         all_findings.append(&mut f);
     }
@@ -1075,6 +1039,7 @@ fn test_BC_2_14_019_exception_burst_emit_once_per_window() {
     let mut flow = ModbusFlowState::default();
     let fk = test_flow_key();
 
+    // F-DELTA-001: timestamps in seconds. 20 exceptions at ts=0..9 (reusing ts) → all within 10s window.
     let mut all_findings = Vec::new();
     for i in 0..20_u32 {
         let req_adu = build_adu(i as u16, 0x01, 0x06, &[0x00, i as u8, 0x01, 0x00]);
@@ -1084,7 +1049,7 @@ fn test_BC_2_14_019_exception_burst_emit_once_per_window() {
             &fk,
             Direction::ClientToServer,
             &req_adu,
-            i * 100_000,
+            i % 9, // 0..8 seconds, all within 10s window
         );
         let exc_adu = build_adu(i as u16, 0x01, 0x86, &[0x01]);
         let mut f = drive(
@@ -1093,7 +1058,7 @@ fn test_BC_2_14_019_exception_burst_emit_once_per_window() {
             &fk,
             Direction::ServerToClient,
             &exc_adu,
-            i * 100_000 + 50_000,
+            i % 9,
         );
         all_findings.append(&mut f);
     }
@@ -1296,16 +1261,10 @@ fn test_BC_2_14_021_summarize_returns_six_keys() {
     let fk = test_flow_key();
 
     // 3 reads (FC=0x03), 2 writes (FC=0x06)
+    // F-DELTA-001: timestamps in seconds.
     for i in 0..3_u32 {
         let adu = build_adu(i as u16, 0x01, 0x03, &[0x00, 0x00, 0x00, 0x01]);
-        drive(
-            &mut az,
-            &mut flow,
-            &fk,
-            Direction::ClientToServer,
-            &adu,
-            i * 100_000,
-        );
+        drive(&mut az, &mut flow, &fk, Direction::ClientToServer, &adu, i);
     }
     for i in 0..2_u32 {
         let adu = build_adu((10 + i) as u16, 0x01, 0x06, &[0x00, i as u8, 0x01, 0x00]);
@@ -1315,7 +1274,7 @@ fn test_BC_2_14_021_summarize_returns_six_keys() {
             &fk,
             Direction::ClientToServer,
             &adu,
-            1_000_000 + i * 100_000,
+            10 + i,
         );
     }
 
@@ -1361,16 +1320,10 @@ fn test_BC_2_14_021_summarize_pdu_count_correct() {
     let mut flow = ModbusFlowState::default();
     let fk = test_flow_key();
 
+    // F-DELTA-001: timestamps in seconds.
     for i in 0..5_u32 {
         let adu = build_adu(i as u16, 0x01, 0x03, &[0x00, 0x00, 0x00, 0x01]);
-        drive(
-            &mut az,
-            &mut flow,
-            &fk,
-            Direction::ClientToServer,
-            &adu,
-            i * 100_000,
-        );
+        drive(&mut az, &mut flow, &fk, Direction::ClientToServer, &adu, i);
     }
 
     let summary = az.summarize();
@@ -1393,16 +1346,10 @@ fn test_BC_2_14_021_summarize_write_count_correct() {
     let mut flow = ModbusFlowState::default();
     let fk = test_flow_key();
 
+    // F-DELTA-001: timestamps in seconds.
     for i in 0..2_u32 {
         let adu = build_adu(i as u16, 0x01, 0x06, &[0x00, i as u8, 0x01, 0x00]);
-        drive(
-            &mut az,
-            &mut flow,
-            &fk,
-            Direction::ClientToServer,
-            &adu,
-            i * 100_000,
-        );
+        drive(&mut az, &mut flow, &fk, Direction::ClientToServer, &adu, i);
     }
 
     let summary = az.summarize();
@@ -1656,7 +1603,8 @@ fn test_BC_2_14_013_burst_and_per_pdu_finding_are_separate() {
     let mut total_findings = 0usize;
     for i in 0..21_u32 {
         let adu = build_adu(i as u16 + 1, 0x01, 0x06, &[0x00, i as u8, 0x01, 0x00]);
-        let ts = i * 10_000; // 10ms intervals — all within 1s window
+        // F-DELTA-001: timestamps in seconds. All at ts=0 → within 1s burst window.
+        let ts = 0_u32;
         let findings = drive(&mut az, &mut flow, &fk, Direction::ClientToServer, &adu, ts);
         total_findings += findings.len();
     }
@@ -1728,25 +1676,12 @@ fn test_BC_2_14_022_EC003_second_finding_dropped_when_cap_at_9999() {
     // First write: with threshold=1, after 1st write count=1+1=2 > 1 → burst fires.
     // This PDU would emit: 1 per-PDU write finding + 1 burst finding = 2 findings.
     // Cap allows: first push (9999→10000), second push dropped.
+    // F-DELTA-001: timestamps in seconds.
     let adu = build_adu(0x0001, 0x01, 0x06, &[0x00, 0x10, 0x01, 0xF4]);
-    drive(
-        &mut az,
-        &mut flow,
-        &fk,
-        Direction::ClientToServer,
-        &adu,
-        1_000_000,
-    );
+    drive(&mut az, &mut flow, &fk, Direction::ClientToServer, &adu, 1);
     // Second write at same ts tips burst immediately (window_write_count=2 > threshold=1)
     let adu2 = build_adu(0x0002, 0x01, 0x06, &[0x00, 0x11, 0x01, 0xF4]);
-    drive(
-        &mut az,
-        &mut flow,
-        &fk,
-        Direction::ClientToServer,
-        &adu2,
-        1_000_100,
-    );
+    drive(&mut az, &mut flow, &fk, Direction::ClientToServer, &adu2, 1);
 
     assert_eq!(
         az.all_findings.len(),
@@ -1785,7 +1720,7 @@ fn test_binding_source_ip_client_for_write_finding() {
         &fk,
         Direction::ClientToServer,
         &adu,
-        1_000_000,
+        1, // F-DELTA-001: timestamp in seconds
     );
     assert!(!findings.is_empty(), "write PDU must produce a finding");
     let f = &findings[0];
@@ -1817,6 +1752,7 @@ fn test_binding_source_ip_server_for_exception_finding() {
     let fk = test_flow_key();
 
     // Deliver 6 exception responses to trigger the burst (BC-2.14.019 EC-002: 6th triggers).
+    // F-DELTA-001: timestamps in seconds. 6 exceptions at ts=0..5 → all within 10s window.
     let mut anomaly_finding = None;
     for i in 0..6_u32 {
         let req_adu = build_adu(i as u16, 0x01, 0x06, &[0x00, i as u8, 0x01, 0x00]);
@@ -1826,7 +1762,7 @@ fn test_binding_source_ip_server_for_exception_finding() {
             &fk,
             Direction::ClientToServer,
             &req_adu,
-            i * 100_000,
+            i,
         );
         let exc_adu = build_adu(i as u16, 0x01, 0x86, &[0x01]);
         let findings = drive(
@@ -1835,7 +1771,7 @@ fn test_binding_source_ip_server_for_exception_finding() {
             &fk,
             Direction::ServerToClient,
             &exc_adu,
-            i * 100_000 + 50_000,
+            i,
         );
         for f in findings {
             if matches!(f.category, wirerust::findings::ThreatCategory::Anomaly)
@@ -1918,6 +1854,7 @@ fn test_binding_exception_cross_window_reset() {
     let mut anomaly_count = 0usize;
 
     // First burst: 6 exceptions of exc_code=0x01 within 9 seconds.
+    // F-DELTA-001: timestamps in seconds. ts=0..5 → all within 10s window.
     for i in 0..6_u32 {
         let req_adu = build_adu(i as u16, 0x01, 0x06, &[0x00, i as u8, 0x01, 0x00]);
         drive(
@@ -1926,7 +1863,7 @@ fn test_binding_exception_cross_window_reset() {
             &fk,
             Direction::ClientToServer,
             &req_adu,
-            i * 1_000_000,
+            i,
         );
         let exc_adu = build_adu(i as u16, 0x01, 0x86, &[0x01]);
         let findings = drive(
@@ -1935,7 +1872,7 @@ fn test_binding_exception_cross_window_reset() {
             &fk,
             Direction::ServerToClient,
             &exc_adu,
-            i * 1_000_000 + 50_000,
+            i,
         );
         for f in &findings {
             if matches!(f.category, wirerust::findings::ThreatCategory::Anomaly)
@@ -1951,8 +1888,8 @@ fn test_binding_exception_cross_window_reset() {
     );
 
     // Second burst: 6 more exceptions starting at ts > 10s after the first window start.
-    // Window started at ts=0 (or ts=50_000); 11 seconds later = 11_000_000 µs.
-    let base_ts: u32 = 11_000_000;
+    // Window started at ts=0; 11 seconds later → new window (EXCEPTION_WINDOW_SECS=10).
+    let base_ts: u32 = 11;
     for i in 0..6_u32 {
         let req_adu = build_adu((100 + i) as u16, 0x01, 0x06, &[0x00, i as u8, 0x01, 0x00]);
         drive(
@@ -1961,7 +1898,7 @@ fn test_binding_exception_cross_window_reset() {
             &fk,
             Direction::ClientToServer,
             &req_adu,
-            base_ts + i * 1_000_000,
+            base_ts + i,
         );
         let exc_adu = build_adu((100 + i) as u16, 0x01, 0x86, &[0x01]);
         let findings = drive(
@@ -1970,7 +1907,7 @@ fn test_binding_exception_cross_window_reset() {
             &fk,
             Direction::ServerToClient,
             &exc_adu,
-            base_ts + i * 1_000_000 + 50_000,
+            base_ts + i,
         );
         for f in &findings {
             if matches!(f.category, wirerust::findings::ThreatCategory::Anomaly)
@@ -2008,6 +1945,7 @@ fn test_binding_per_flow_counters_updated() {
     assert_eq!(flow.last_ts, 0, "initial last_ts = 0");
 
     // One write PDU (FC=0x06)
+    // F-DELTA-001: timestamps in seconds.
     let adu_write = build_adu(0x0001, 0x01, 0x06, &[0x00, 0x10, 0x01, 0xF4]);
     drive(
         &mut az,
@@ -2015,7 +1953,7 @@ fn test_binding_per_flow_counters_updated() {
         &fk,
         Direction::ClientToServer,
         &adu_write,
-        1_000_000,
+        1,
     );
     assert_eq!(flow.pdu_count, 1, "pdu_count = 1 after one write PDU");
     assert_eq!(flow.write_count, 1, "write_count = 1 after one write PDU");
@@ -2023,7 +1961,7 @@ fn test_binding_per_flow_counters_updated() {
         flow.exception_count, 0,
         "exception_count unchanged after write PDU"
     );
-    assert_eq!(flow.last_ts, 1_000_000, "last_ts updated to 1_000_000");
+    assert_eq!(flow.last_ts, 1, "last_ts updated to 1");
 
     // One read PDU (FC=0x03)
     let adu_read = build_adu(0x0002, 0x01, 0x03, &[0x00, 0x00, 0x00, 0x01]);
@@ -2033,14 +1971,14 @@ fn test_binding_per_flow_counters_updated() {
         &fk,
         Direction::ClientToServer,
         &adu_read,
-        2_000_000,
+        2,
     );
     assert_eq!(flow.pdu_count, 2, "pdu_count = 2 after two PDUs");
     assert_eq!(
         flow.write_count, 1,
         "write_count unchanged after read PDU (read is not write)"
     );
-    assert_eq!(flow.last_ts, 2_000_000, "last_ts updated to 2_000_000");
+    assert_eq!(flow.last_ts, 2, "last_ts updated to 2");
 
     // One exception response (FC=0x86)
     let exc_adu = build_adu(0x0001, 0x01, 0x86, &[0x01]);
@@ -2050,14 +1988,14 @@ fn test_binding_per_flow_counters_updated() {
         &fk,
         Direction::ServerToClient,
         &exc_adu,
-        3_000_000,
+        3,
     );
     assert_eq!(flow.pdu_count, 3, "pdu_count = 3 after three PDUs");
     assert_eq!(
         flow.exception_count, 1,
         "exception_count = 1 after one exception PDU (BC-2.14.019 inv4)"
     );
-    assert_eq!(flow.last_ts, 3_000_000, "last_ts updated to 3_000_000");
+    assert_eq!(flow.last_ts, 3, "last_ts updated to 3");
 }
 
 // ---------------------------------------------------------------------------
@@ -2096,6 +2034,7 @@ fn test_binding_total_flows_analyzed_incremented_on_first_pdu() {
     );
 
     // Second PDU on the SAME flow — must NOT re-increment
+    // F-DELTA-001: timestamps in seconds.
     let adu2 = build_adu(0x0002, 0x01, 0x03, &[0x00, 0x00, 0x00, 0x01]);
     drive(
         &mut az,
@@ -2103,7 +2042,7 @@ fn test_binding_total_flows_analyzed_incremented_on_first_pdu() {
         &fk,
         Direction::ClientToServer,
         &adu2,
-        100_000,
+        1,
     );
     assert_eq!(
         az.total_flows_analyzed, 1,
@@ -2125,7 +2064,7 @@ fn test_binding_total_flows_analyzed_incremented_on_first_pdu() {
         &fk2,
         Direction::ClientToServer,
         &adu3,
-        200_000,
+        2,
     );
     assert_eq!(
         az.total_flows_analyzed, 2,

--- a/tests/modbus_detection_tests.rs
+++ b/tests/modbus_detection_tests.rs
@@ -623,8 +623,8 @@ fn test_BC_2_14_017_burst_emit_once_per_window() {
 }
 
 // ---------------------------------------------------------------------------
-// BC-2.14.017 — Sustained detector (truncation-free microsecond math)
-// AC-005: (count*1_000_000) > (threshold*elapsed_us) AND elapsed_us >= 2_000_000
+// BC-2.14.017 — Sustained detector (truncation-free second-scale math)
+// AC-005: count > threshold*elapsed_s AND elapsed_s >= 2
 // ---------------------------------------------------------------------------
 
 /// test_BC_2_14_017_sustained_detector_uses_truncation_free_math_no_false_positive
@@ -773,8 +773,8 @@ fn test_BC_2_14_017_sustained_low_and_slow_fires() {
 ///
 /// Deliver a write at ts=0xFFFFFF00 (near u32::MAX), then a write at ts=0x00000100.
 /// Plain subtraction: 0x100 - 0xFFFFFF00 = underflow → panic in debug mode.
-/// wrapping_sub: 0x100u32.wrapping_sub(0xFFFFFF00) = 0x00000200 = 512 µs → no panic.
-/// Expected: no panic; 512µs elapsed << 1_000_000µs → still in burst window.
+/// wrapping_sub: 0x100u32.wrapping_sub(0xFFFFFF00) = 0x00000200 = 512 seconds → no panic.
+/// Expected: no panic; 512 seconds elapsed < 1s burst window boundary check → still in window.
 /// Traces to: BC-2.14.017 + f2-fix-directives §11.5b, STORY-104 AC-006.
 #[test]
 fn test_BC_2_14_017_window_elapsed_uses_wrapping_sub_no_panic() {
@@ -803,7 +803,7 @@ fn test_BC_2_14_017_window_elapsed_uses_wrapping_sub_no_panic() {
         0x00000100_u32,
     );
 
-    // wrapping_sub = 0x200 = 512µs → WITHIN 1s burst window → window_write_count = 2
+    // wrapping_sub = 0x200 = 512 seconds elapsed > 1s burst window → window resets
     // (No burst yet since threshold = 20; just verifying no panic and correct window state.)
     assert!(
         !f2.is_empty(),
@@ -812,7 +812,7 @@ fn test_BC_2_14_017_window_elapsed_uses_wrapping_sub_no_panic() {
     assert!(
         !f2.iter()
             .any(|f| f.mitre_techniques.contains(&"T0806".to_string())),
-        "512µs elapsed with 2 writes: no burst (threshold=20)"
+        "512 seconds elapsed with 2 writes: no burst (threshold=20, window reset)"
     );
 }
 


### PR DESCRIPTION
# fix(modbus): correct timestamp units (seconds not microseconds) in detection windows + finding timestamps

## Summary

**Bug severity: CRITICAL (integration-seam defect)**

The Modbus analyzer (`src/analyzer/modbus.rs`) treated the `on_data` `timestamp`
argument as microseconds, but the reassembly pipeline delivers it as **whole seconds**
(`timestamp_secs`, per BC-2.09.007). Every other analyzer (TLS, HTTP, reassembly) already
treats it as seconds. This was invisible to all per-story reviews because it was an
integration-seam mismatch discovered only via F5 combined-delta adversarial review (Claude
+ Gemini cross-model, independent slices, no information sharing).

**Impact of the defect (before this fix):**

- Every Modbus `Finding.timestamp` was wrong by ~1,000,000x (timestamps resolving to
  1970-epoch dates instead of real capture dates).
- All rate-detection windows (burst/sustained/T0831/exception) compared timestamp values
  scaled as microseconds against window-size constants expressed in seconds. With real
  second-scale timestamps, `wrapping_sub` always produced values far below the threshold
  (e.g., `ts_elapsed = 5` compared against `T0831_WINDOW_SECS * 1_000_000 = 5_000_000`),
  making windows **never expire** and detectors non-functional on real captures.

**Fix summary (2 commits):**

1. `fix(modbus): correct F5 combined-delta adversarial findings (F-DELTA-001..005)`
   - F-DELTA-001 (CRITICAL): `process_pdu` now treats `timestamp` as seconds:
     `DateTime::from_timestamp(timestamp as i64, 0)` (was: divide-by-1,000,000 dance).
   - Window comparisons corrected: `t0831_elapsed > T0831_WINDOW_SECS` (was: `> T0831_WINDOW_SECS * 1_000_000`).
   - Sustained-write rate formula corrected: `count > threshold * elapsed_secs` (was: microsecond scaling).
   - F-DELTA-003: `is_non_modbus` latch now fires on length-invalid ADUs (previously skipped).
   - F-DELTA-005: `source_ip` resolved from TCP `Direction` argument (not port-heuristic alone).
   - Confirmed summarize six-key set matches BC-2.14.021.
   - 78 existing test timestamps corrected from microsecond values (e.g., `1_000_000`) to
     second-scale values (e.g., `1_000_000` → `1` or `5`, `2`, `3` per test intent).
     This is a legitimate units correction — tests are not weakened, they now match the
     actual pipeline interface. Re-verified: all detection logic still fires correctly.

2. `fix(modbus): F5 cleanup — correct summarize docstring, fix stale µs comments, pin F-DELTA-003 latch path`
   - Updated `summarize` docstring to reflect actual six-key set.
   - Removed stale "microseconds" comments throughout `process_pdu`.
   - Pinned F-DELTA-003 `is_non_modbus` latch to the length-invalid code path.
   - 3 LOW-severity cleanups.

**Mandatory E2E test added** (`test_f_delta_001_e2e_second_scale_timestamps_through_dispatcher`):

- Drives a port-502 flow through `StreamDispatcher::on_data` with `TS_2023 = 1_700_000_000`
  (≈ 2023-11-14).
- Asserts `Finding.timestamp.year() == 2023` (confirms seconds pipeline, not microseconds).
- Asserts burst detector fires when 21 writes land in the same 1-second window.

**Both Claude and Gemini independently rated the units mismatch CRITICAL.**
SS-14 BCs reconciled to seconds in a separate factory-artifacts commit.
Sub-second rate precision deferred to a future enhancement (threading `timestamp_usecs`
through `on_data` is out of scope for v0.4.0).

---

## Architecture Changes

```mermaid
graph TD
    A[StreamDispatcher::on_data] -->|timestamp_secs u32| B[ModbusAnalyzer::process_pdu]
    B --> C{timestamp units}
    C -->|BEFORE: treated as µs| D[DateTime divide-by-1M WRONG]
    C -->|AFTER F-DELTA-001: treated as secs| E[DateTime::from_timestamp secs,0 CORRECT]
    B --> F[Detection windows]
    F -->|BEFORE: compare vs WINDOW*1_000_000| G[Windows never expire BROKEN]
    F -->|AFTER: compare vs WINDOW_SECS directly| H[Windows expire correctly FIXED]
    B --> I[source_ip resolution]
    I -->|BEFORE: port-502 heuristic only| J[Ambiguous for mid-stream joins]
    I -->|AFTER F-DELTA-005: Direction + port| K[Authoritative TCP direction]
```

---

## Story Dependencies

This is a **standalone bug fix** — no upstream story dependency PRs.

```mermaid
graph LR
    A[Feature #7 v0.4.0 F5 hardening] --> B[fix/f5-modbus-timestamp-units]
    C[STORY-105 merged PR#214] -.->|provides ModbusAnalyzer wiring| B
    D[STORY-097/098/099 merged] -.->|establishes timestamp pipeline| B
```

---

## Spec Traceability

```mermaid
flowchart LR
    BC1[BC-2.09.007\ntimestamp=secs] --> AC1[F-DELTA-001\ntimestamp units]
    BC2[BC-2.14.013\nburst detection] --> AC2[F-DELTA-001\nwindow comparisons]
    BC3[BC-2.14.016\nT0831 window] --> AC2
    BC4[BC-2.14.022\nMAX_FINDINGS] --> AC3[F-DELTA-003\nis_non_modbus latch]
    BC5[BC-2.14.013\nsource_ip] --> AC4[F-DELTA-005\nDirection-based ip]
    AC1 --> T1[test_f_delta_001_e2e\nsecond-scale timestamps]
    AC2 --> T2[test_BC_2_14_016_t0831\n_inline_cotag]
    AC3 --> T3[is_non_modbus\nlatch test]
    AC4 --> T4[source_ip\ndirection tests]
    T1 --> I1[modbus.rs\nDateTime::from_timestamp]
    T2 --> I1
```

---

## Test Evidence

| Category | Count / Result |
|----------|---------------|
| Total tests passing (worktree) | All (full regression green) |
| New tests added | 1 mandatory E2E (F-DELTA-001) + updates across dispatch + detection test files |
| Files changed | 3 (src/analyzer/modbus.rs, tests/bc_2_14_105_modbus_dispatch_tests.rs, tests/modbus_detection_tests.rs) |
| Lines changed | +497 / -233 |
| Test timestamp corrections | 78 values corrected from µs-scale to second-scale (not weakened) |
| Clippy (-D warnings) | CLEAN |
| cargo fmt --check | CLEAN |
| cargo build --release | CLEAN (overflow-checks=true) |
| Burst detector E2E | FIRES correctly at second-scale timestamps (TS_2023 = 1_700_000_000) |
| T0831 window test | FIRES at 2nd write within 5-second window |
| wrapping_sub overflow | PASSES (overflow-checks=true, no panic) |

**On the 78 test timestamp corrections:** These are a legitimate units correction,
not a weakening. The tests previously passed incorrect values (e.g., `1_000_000` as
"1 microsecond" when the function signature expects seconds). After correction, each
test passes a semantically correct second-scale value and still validates the same
detection logic at the correct scale. All 78 corrected tests were re-verified to
pass with the fixed implementation.

---

## Demo Evidence

N/A — this is a backend Rust library fix with no interactive UI component.
Correctness is demonstrated by the mandatory E2E test
(`test_f_delta_001_e2e_second_scale_timestamps_through_dispatcher`) and the full
regression test suite (green in worktree).

---

## Holdout Evaluation

N/A — evaluated at wave gate. Feature #100 holdout: satisfaction score 0.99
(no must-pass scenario < 0.6, recorded in phase-f7 delta-convergence-report).

---

## Adversarial Review

F5 combined-delta cross-model adversarial review completed:
- **Claude adversary (fresh context):** Identified F-DELTA-001 (CRITICAL timestamp units),
  F-DELTA-003 (is_non_modbus latch), F-DELTA-005 (source_ip resolution).
- **Gemini cross-model (independent slices):** Independently confirmed timestamp units
  as CRITICAL. Two source claims refuted (hallucinations from diff-only context).
  Test-slice finding (cross-model agreement on timestamp corrections being valid) confirmed.
- **Convergence:** 0 adversary novelty score (F5 round clean after fixes).
- **Reference:** `.factory/phase-f5-adversarial/adversarial-delta-review.md`,
  `.factory/phase-f5-adversarial/gemini-review.md`

---

## Security Review

No security findings. This fix:
- Corrects timestamp values (no authentication/authorization changes).
- Fixes rate-detection windows (no network exposure changes).
- Adds one E2E test (no new attack surface).
- No input validation regressions (Modbus ADU parsing unchanged).
- No injection vectors introduced.

---

## Risk Assessment

| Dimension | Assessment |
|-----------|-----------|
| Blast radius | `src/analyzer/modbus.rs` only (+ tests) |
| Behavior change | Modbus findings now carry correct timestamps; rate detectors now actually expire windows |
| Regression risk | LOW — full test suite green; existing behavior was provably broken |
| Performance impact | NEGLIGIBLE — integer arithmetic only |
| Rollback | Simple revert of 2 commits |

---

## AI Pipeline Metadata

| Field | Value |
|-------|-------|
| Pipeline mode | F5 combined-delta adversarial (cross-model) |
| Models | Claude (adversary, fresh context) + Gemini 0.44.1 (independent slices) |
| Information asymmetry | Preserved — Gemini reviewed without seeing Claude findings |
| Fix authorization | Feature #7 v0.4.0 F5 hardening, AUTHORIZE_MERGE=yes |

---

## Pre-Merge Checklist

- [x] PR description matches actual diff
- [x] All ACs covered by mandatory E2E test (F-DELTA-001) + detection suite
- [x] Traceability chain: BC-2.09.007 → F-DELTA-001 → test_f_delta_001_e2e → modbus.rs
- [x] 78 test timestamp corrections verified not weakened
- [x] Clippy clean (-D warnings)
- [x] cargo fmt clean
- [x] cargo build --release clean (overflow-checks=true)
- [x] Worktree branch: fix/f5-modbus-timestamp-units (off origin/develop dba5f26)
- [x] Merge target: develop
- [x] No dependency PRs pending
- [x] AUTHORIZE_MERGE=yes (Feature #7 v0.4.0 F5 hardening)
