### PR TITLE
fix(arp): D1 spoof HIGH finding carries verdict Likely per BC-2.16.004 (D-075)

### DIFF
--- a/src/analyzer/arp.rs
+++ b/src/analyzer/arp.rs
@@ -771,7 +771,11 @@ impl ArpAnalyzer {
         // Build evidence: sender_ip, old_mac, new_mac (AC-016 / BC-2.16.004 PC1.e).
         Finding {
             category: ThreatCategory::Anomaly,
-            verdict: Verdict::Possible,
+            verdict: if confidence == Confidence::High {
+                Verdict::Likely
+            } else {
+                Verdict::Possible
+            },
             confidence,
             summary: format!(
                 "D1: ARP Spoof — IP→MAC rebind detected for sender_ip={}.{}.{}.{}",
@@ -2185,7 +2189,7 @@ mod tests {
 mod story_114 {
     use super::*;
     use crate::decoder::ArpFrame;
-    use crate::findings::{Confidence, ThreatCategory};
+    use crate::findings::{Confidence, ThreatCategory, Verdict};
 
     // -----------------------------------------------------------------------
     // Shared frame builders (RFC 826 canonical values)
@@ -3065,6 +3069,144 @@ mod story_114 {
             impact_str, ics_impact_str,
             "AC-014 / BC-2.10.002 v1.5: Display strings of Impact and IcsImpact must differ \
              (\"Impact\" vs \"Impact (ICS)\"). D-069 preservation check."
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // G1 / D-075 — BC-2.16.004 lines 45/74/118: HIGH D1 finding carries
+    // Verdict::Likely (not Verdict::Possible).
+    // -----------------------------------------------------------------------
+
+    /// G1 / D-075 (BC-2.16.004 lines 45/74/118): a D1 ARP-spoof finding that
+    /// escalates to HIGH confidence MUST carry `verdict: Verdict::Likely`.
+    ///
+    /// BC-2.16.004 line 45  (precondition): rebind_count >= spoof_threshold AND
+    ///   elapsed <= ARP_FLAP_WINDOW_SECS AND !spoof_high_emitted
+    ///   is the HIGH escalation condition.
+    /// BC-2.16.004 line 74  (postcondition): HIGH confidence finding has
+    ///   `verdict = Verdict::Likely`.
+    /// BC-2.16.004 line 118 (invariant): verdict=Likely iff confidence=High on D1.
+    ///
+    /// Canonical test vector: threshold=3, rebind_count=3 within 60 s →
+    ///   confidence=High, verdict=Likely.
+    ///
+    /// The LOAD-BEARING ASSERTION below currently FAILS because
+    /// `emit_d1_spoof_finding_impl` (src/analyzer/arp.rs:774) hardcodes
+    /// `Verdict::Possible` for all D1 findings regardless of confidence.
+    /// This test will pass once the fix routes HIGH confidence to Verdict::Likely.
+    #[test]
+    #[allow(non_snake_case)]
+    fn test_BC_2_16_004_d1_high_confidence_carries_verdict_likely() {
+        let mut analyzer =
+            ArpAnalyzer::new(SPOOF_REBIND_ESCALATION_DEFAULT, ARP_STORM_RATE_DEFAULT);
+        // Seed initial binding: 10.0.0.1 → MAC_A at ts=0
+        seed_binding(&mut analyzer, 0);
+
+        // Rebind 1 (count→1, MEDIUM — below threshold=3)
+        let _ = analyzer.process_arp_for_test(&make_reply(IP_A, MAC_B), 2);
+        // Rebind 2 (count→2, MEDIUM — below threshold=3)
+        let _ = analyzer.process_arp_for_test(&make_reply(IP_A, MAC_C), 5);
+        // Rebind 3 (count→3, HIGH — count == threshold=3, elapsed=8s <= 60s)
+        let findings = analyzer.process_arp_for_test(&make_reply(IP_A, MAC_D), 8);
+
+        // Locate the D1 spoof finding (mitre T0830 or "spoof" in summary)
+        let d1 = findings.iter().find(|f| {
+            f.mitre_techniques.contains(&"T0830".to_string())
+                || f.summary.to_lowercase().contains("spoof")
+                || f.summary.to_lowercase().contains("rebind")
+        });
+        assert!(
+            d1.is_some(),
+            "G1 / D-075 / BC-2.16.004 PC1.c: 3rd rebind must emit a D1 spoof finding. \
+             Got {} finding(s): {:?}.",
+            findings.len(),
+            findings
+                .iter()
+                .map(|f| (&f.confidence, &f.summary))
+                .collect::<Vec<_>>()
+        );
+        let d1 = d1.unwrap();
+
+        // Regression guard: confidence must be HIGH (verifies escalation path is exercised).
+        // This assertion is GREEN: the escalation logic is already correct for confidence.
+        assert_eq!(
+            d1.confidence,
+            Confidence::High,
+            "G1 / D-075 setup assertion: 3rd rebind at threshold=3 must produce HIGH confidence \
+             (BC-2.16.004 PC1.c). Got {:?}.",
+            d1.confidence
+        );
+
+        // LOAD-BEARING ASSERTION (BC-2.16.004 lines 74/118):
+        // A HIGH D1 finding MUST carry Verdict::Likely (displays \"LIKELY\", serializes \"Likely\").
+        // This assertion currently FAILS because emit_d1_spoof_finding_impl hardcodes
+        // Verdict::Possible (src/analyzer/arp.rs:774) for all D1 findings.
+        // The test passes once the fix sets verdict=Verdict::Likely when confidence=High.
+        assert_eq!(
+            d1.verdict,
+            Verdict::Likely,
+            "G1 / D-075 / BC-2.16.004 line 74+118: HIGH D1 finding must carry \
+             Verdict::Likely. Got {:?}. \
+             Root cause: emit_d1_spoof_finding_impl hardcodes Verdict::Possible (line 774) \
+             for both HIGH and MEDIUM D1 findings.",
+            d1.verdict
+        );
+    }
+
+    /// G1 / D-075 regression guard (BC-2.16.004 line 118):
+    /// a D1 finding at MEDIUM confidence (below threshold) must carry
+    /// `verdict: Verdict::Possible`.
+    ///
+    /// This assertion is GREEN now and must remain GREEN after the HIGH-path fix.
+    /// It guards against overcorrection (raising all D1 verdicts to Likely).
+    ///
+    /// Canonical test vector: threshold=3, rebind_count=1 → confidence=Medium,
+    /// verdict=Possible.
+    #[test]
+    #[allow(non_snake_case)]
+    fn test_BC_2_16_004_d1_medium_confidence_carries_verdict_possible() {
+        let mut analyzer =
+            ArpAnalyzer::new(SPOOF_REBIND_ESCALATION_DEFAULT, ARP_STORM_RATE_DEFAULT);
+        // Seed initial binding: 10.0.0.1 → MAC_A at ts=0
+        seed_binding(&mut analyzer, 0);
+
+        // Rebind 1 (count→1, MEDIUM — below threshold=3)
+        let findings = analyzer.process_arp_for_test(&make_reply(IP_A, MAC_B), 2);
+
+        let d1 = findings.iter().find(|f| {
+            f.mitre_techniques.contains(&"T0830".to_string())
+                || f.summary.to_lowercase().contains("spoof")
+                || f.summary.to_lowercase().contains("rebind")
+        });
+        assert!(
+            d1.is_some(),
+            "G1 / D-075 regression guard: first rebind must emit a D1 spoof finding. \
+             Got {} finding(s): {:?}.",
+            findings.len(),
+            findings
+                .iter()
+                .map(|f| (&f.confidence, &f.summary))
+                .collect::<Vec<_>>()
+        );
+        let d1 = d1.unwrap();
+
+        // Confidence must be MEDIUM (below threshold).
+        assert_eq!(
+            d1.confidence,
+            Confidence::Medium,
+            "G1 / D-075 regression guard: first rebind must be MEDIUM (count=1 < threshold=3). \
+             Got {:?}.",
+            d1.confidence
+        );
+
+        // Verdict must be Possible for MEDIUM D1 findings (BC-2.16.004 line 118 invariant).
+        // This assertion is GREEN now and must remain GREEN after the HIGH fix.
+        assert_eq!(
+            d1.verdict,
+            Verdict::Possible,
+            "G1 / D-075 regression guard / BC-2.16.004 line 118: MEDIUM D1 finding must \
+             carry Verdict::Possible (not Likely). Got {:?}.",
+            d1.verdict
         );
     }
 }


### PR DESCRIPTION
## Summary

Fixes holdout-evaluation finding **G1** (decision **D-075**): the D1 ARP-spoof detector at `src/analyzer/arp.rs:774` hardcoded `Verdict::Possible` for **all** D1 findings regardless of confidence class, violating BC-2.16.004 lines 45/74/118.

BC-2.16.004 mandates:
- HIGH-confidence D1 findings → `Verdict::Likely`
- MEDIUM-confidence D1 findings → `Verdict::Possible`

### Root Cause

`emit_d1_spoof_finding_impl` returned `verdict: Verdict::Possible` unconditionally. The high-confidence escalation path (`rebind_count >= spoof_threshold` within the flap window) correctly set `confidence = Confidence::High` but the verdict field was never updated to match.

### Why Static Review Missed It

The static adversarial review and consistency-check passes both examined the D1 detection logic but focused on the escalation *condition* (correct) rather than the verdict *field* on the emitted finding. The black-box holdout evaluation caught it because it checks the actual `Finding` output, not just the code path.

### Fix

```rust
// Before (arp.rs:774):
verdict: Verdict::Possible,

// After:
verdict: if confidence == Confidence::High {
    Verdict::Likely
} else {
    Verdict::Possible
},
```

One-line semantic change; no other logic is touched.

## Spec Traceability

```
BC-2.16.004 (line 45 — HIGH precondition)
    └─> BC-2.16.004 (line 74 — verdict=Likely postcondition)
            └─> BC-2.16.004 (line 118 — verdict=Likely iff confidence=High invariant)
                    └─> arp.rs emit_d1_spoof_finding_impl (line 774)
                            └─> test_BC_2_16_004_d1_high_confidence_carries_verdict_likely
                            └─> test_BC_2_16_004_d1_medium_confidence_carries_verdict_possible
```

## Test Evidence

- **2 new regression tests** added inside `mod story_114` in `src/analyzer/arp.rs`
- `test_BC_2_16_004_d1_high_confidence_carries_verdict_likely`: vector with threshold=3, 3 rebinds within 60 s → asserts `confidence=High`, `verdict=Likely`
- `test_BC_2_16_004_d1_medium_confidence_carries_verdict_possible`: vector with threshold=3, 2 rebinds → asserts `confidence=Medium`, `verdict=Possible`
- Full suite: **all tests pass** (no regressions)
- `cargo clippy --all-targets -- -D warnings`: **clean**
- `cargo fmt --check`: **clean**

## Holdout / Adversarial Provenance

| Field | Value |
|-------|-------|
| Holdout finding | G1 |
| Decision | D-075 |
| Detection method | Black-box holdout evaluation (missed by static review) |
| BC source | BC-2.16.004 lines 45, 74, 118 |
| Score at holdout | 0.95 |

## Risk Assessment

- **Blast radius**: D1 ARP-spoof findings only. No other finding type is affected.
- **Behavioral delta**: HIGH-confidence D1 findings will now surface as `Likely` instead of `Possible`. This is a severity *upgrade* for confirmed spoof events, consistent with spec intent.
- **Performance impact**: None — one conditional expression replacing an unconditional literal.
- **Regression risk**: Low — the two new tests plus the existing D1 test suite guard against reversion.

## Pre-Merge Checklist

- [x] `cargo test --all-targets` green
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] BC-2.16.004 traceability complete (lines 45/74/118)
- [x] Two regression tests covering both confidence branches
- [x] No .factory/ or STATE.md changes