### PR TITLE
docs(arp): correct D-075 regression-test prose to past-tense regression-guard (D-076)

### DIFF
--- a/src/analyzer/arp.rs
+++ b/src/analyzer/arp.rs
@@ -3090,10 +3090,11 @@ mod story_114 {
     /// Canonical test vector: threshold=3, rebind_count=3 within 60 s →
     ///   confidence=High, verdict=Likely.
     ///
-    /// The LOAD-BEARING ASSERTION below currently FAILS because
-    /// `emit_d1_spoof_finding_impl` (src/analyzer/arp.rs:774) hardcodes
-    /// `Verdict::Possible` for all D1 findings regardless of confidence.
-    /// This test will pass once the fix routes HIGH confidence to Verdict::Likely.
+    /// Regression guard for D-075 / BC-2.16.004: a HIGH-confidence D1 ARP-spoof
+    /// finding MUST carry `Verdict::Likely` (MEDIUM carries `Verdict::Possible`).
+    /// The fix (merged in D-075) introduced the conditional in
+    /// `emit_d1_spoof_finding_impl`. This test FAILS if a future refactor routes
+    /// HIGH confidence back to `Verdict::Possible`.
     #[test]
     #[allow(non_snake_case)]
     fn test_BC_2_16_004_d1_high_confidence_carries_verdict_likely() {
@@ -3137,11 +3138,11 @@ mod story_114 {
             d1.confidence
         );
 
-        // LOAD-BEARING ASSERTION (BC-2.16.004 lines 74/118):
-        // A HIGH D1 finding MUST carry Verdict::Likely (displays \"LIKELY\", serializes \"Likely\").
-        // This assertion currently FAILS because emit_d1_spoof_finding_impl hardcodes
-        // Verdict::Possible (src/analyzer/arp.rs:774) for all D1 findings.
-        // The test passes once the fix sets verdict=Verdict::Likely when confidence=High.
+        // Regression guard (BC-2.16.004 lines 74/118):
+        // A HIGH D1 finding MUST carry Verdict::Likely (displays "LIKELY", serializes "Likely").
+        // D-075 introduced the conditional in emit_d1_spoof_finding_impl that routes
+        // HIGH confidence to Verdict::Likely. This FAILS if that conditional is removed
+        // or a refactor reverts HIGH-confidence D1 findings to Verdict::Possible.
         assert_eq!(
             d1.verdict,
             Verdict::Likely,


### PR DESCRIPTION
## Summary

- Rewrites two comment blocks in `src/analyzer/arp.rs` that were left in RED / future-tense \"will pass once\" voice after D-075 merged.
- Both loci now describe the behaviour as a **regression guard** for an already-landed fix, using past-tense / present-tense prose consistent with a GREEN test.
- No logic, no tests, no public API changed — doc/comment text only.

## Loci

| Locus | Before | After |
|-------|--------|-------|
| Doc-comment block (~line 3093) | `"currently FAILS … will pass once the fix …"` | `"Regression guard for D-075 / BC-2.16.004 … This test FAILS if a future refactor …"` |
| Inline comment block (~line 3140) | `"currently FAILS … passes once the fix …"` | `"Regression guard (BC-2.16.004) … D-075 introduced … This FAILS if that conditional is removed …"` |

## CI Gates (all green in worktree)

- `cargo test --all-targets` — 0 failures
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo fmt --check` — clean

## Test plan

- [ ] CI lint/test/build passes on this PR
- [ ] Confirm no `cargo fmt --check` diff
- [ ] Confirm no clippy warnings