### PR TITLE
test(arp): add QinQ/MACsec decoder fixtures for ARP VLAN-offset path (#253)

### DIFF
--- a/tests/bc_2_16_e17_macsec_offset_tests.rs
+++ b/tests/bc_2_16_e17_macsec_offset_tests.rs
@@ -1,0 +1,960 @@
+//! MACsec ARP offset regression guards — synthetic frame harness.
+//!
+//! These tests guard that the lax-path ARP offset formula in `decode_packet`
+//! (src/decoder.rs) correctly handles IEEE 802.1AE (MACsec) link extensions
+//! for all reachable payload variants, and that Modified/Encrypted variants
+//! (opaque payload) are structurally unreachable from the ARP truncation path.
+//!
+//! ## Synthetic frames
+//!
+//! No public MACsec-over-ARP pcap exists.  All frames are constructed by hand
+//! using byte-exact layouts and etherparse's `MacsecHeader` builder.
+//! The empirical results (offset values, reachability) back the documented
+//! offset constants in BC-2.16.009 v1.8 and BC-2.16.015 v1.7 EC-009.
+//!
+//! ## What these tests guard
+//!
+//! ### V1 — no-SCI Unmodified, ARP truncated benign
+//!
+//! `test_BC_2_16_015_macsec_no_sci_unmodified_arp_truncated_offset_22`
+//!
+//!   MACsec header without SCI, Unmodified ptype: `header_len() == 8`
+//!   (6 SecTag + 2 next_EtherType).  ARP offset formula yields 14 + 8 = **22**.
+//!   ARP fixed header at offset 22 has `hlen=6` → classified as
+//!   `"truncated ARP frame"` (no false D11).
+//!
+//! ### V2 — no-SCI Unmodified, ARP malformed hlen=8
+//!
+//! `test_BC_2_16_009_macsec_no_sci_unmodified_arp_malformed_hlen8_routes_to_d11`
+//!
+//!   Same MACsec framing (offset 22).  ARP fixed header has `hlen=8` → formula
+//!   reads the malformed byte at the correct offset → D11 fires.
+//!
+//! ### V3 — SCI-present Unmodified, ARP truncated benign (spec backing test)
+//!
+//! `test_BC_2_16_015_macsec_sci_present_unmodified_arp_truncated_offset_30`
+//!
+//!   MACsec header with SCI, Unmodified ptype: `header_len() == 16`
+//!   (6 SecTag + 8 SCI + 2 next_EtherType).  ARP offset formula yields
+//!   14 + 16 = **30**.
+//!
+//!   THIS IS THE SPEC-BACKING TEST.  It empirically confirms the documented
+//!   offset=30 for SCI-present MACsec frames (BC-2.16.015 v1.7 EC-009).
+//!   A former off-by-8 risk existed: if `LaxLinkExtSlice::Macsec` returned
+//!   `header_len() == 8` (omitting the 8 SCI bytes), the decoder would compute
+//!   offset 22, peeking 8 bytes INTO the SCI field and producing a false D11.
+//!   This test guards that `header_len()` returns 16, making offset 30 correct.
+//!
+//! ### V4 — SCI-present Unmodified, ARP malformed hlen=8
+//!
+//! `test_BC_2_16_009_macsec_sci_present_unmodified_arp_malformed_hlen8_routes_to_d11`
+//!
+//!   Same SCI-present framing (offset 30).  ARP `hlen=8` → D11 fires at the
+//!   correct offset.
+//!
+//! ### V5 — no-SCI Modified, opaque payload (security-property guard)
+//!
+//! `test_BC_2_16_015_macsec_no_sci_modified_opaque_payload_unreachable`
+//!
+//!   Modified ptype (no inner EtherType): the lax parser does NOT reach
+//!   `stop_err==Layer::Arp`.  The decoder's ARP-truncation path is structurally
+//!   unreachable; the offset code never executes on ciphertext.
+//!
+//! ### V6 — SCI-present Modified, opaque payload (security-property guard)
+//!
+//! `test_BC_2_16_015_macsec_sci_present_modified_opaque_payload_unreachable`
+//!
+//!   Same security-property guard for the SCI-present Modified variant.
+//!
+//! ## Wire layouts
+//!
+//! ### 802.1AE SecTag (Unmodified, no SCI) — 8 bytes
+//! ```text
+//! [0]   TCI-AN byte: SC=0 (no SCI), E=0, C=0, AN=0
+//! [1]   SL byte: short_len = 0
+//! [2..6] PN: packet number (4 bytes, big-endian)
+//! [6..8] next_EtherType: 0x0806 (ARP)
+//! ```
+//!
+//! ### 802.1AE SecTag (Unmodified, SCI present) — 16 bytes
+//! ```text
+//! [0]   TCI-AN byte: SC=1 (SCI present), E=0, C=0, AN=0
+//! [1]   SL byte: short_len = 0
+//! [2..6] PN: packet number (4 bytes, big-endian)
+//! [6..14] SCI: 8 bytes
+//! [14..16] next_EtherType: 0x0806 (ARP)
+//! ```
+//!
+//! Behavioral contracts covered:
+//!   BC-2.16.009 PC3   malformed ARP MUST produce D11 regardless of MACsec framing
+//!   BC-2.16.015 EC-009 SCI-present MACsec ARP offset documented as 30
+//!
+//! DF-TEST-NAMESPACE-001: all tests wrapped in `mod macsec_offset`.
+//! DF-GREEN-DOC-TENSE-SWEEP: comments describe what the tests GUARD, written in
+//!   the tense of a passing (already-correct) test — no RED-phase stub language.
+
+#![allow(non_snake_case)]
+
+mod macsec_offset {
+    use etherparse::{
+        EtherType, LaxLinkExtSlice, LaxMacsecPayloadSlice, LaxSlicedPacket, MacsecAn, MacsecHeader,
+        MacsecPType, MacsecShortLen, err::Layer,
+    };
+    use pcap_file::DataLink;
+    use wirerust::analyzer::arp::ArpAnalyzer;
+    use wirerust::decoder::decode_packet;
+    use wirerust::findings::ThreatCategory;
+
+    // -------------------------------------------------------------------------
+    // Shared constants
+    // -------------------------------------------------------------------------
+
+    /// Ethernet2 header length in bytes.
+    const ETH2_LEN: usize = 14;
+
+    /// ARP fixed header length in bytes.
+    const ARP_FIXED_HDR_LEN: usize = 8;
+
+    /// ARP payload offset for a MACsec frame without SCI (Unmodified ptype).
+    ///
+    /// `header_len()` for no-SCI Unmodified = 6 SecTag + 2 next_EtherType = 8.
+    /// Offset = 14 + 8 = 22.  Backed empirically by V1 and V2.
+    const ARP_OFFSET_MACSEC_NO_SCI: usize = 22;
+
+    /// ARP payload offset for a MACsec frame with SCI present (Unmodified ptype).
+    ///
+    /// `header_len()` for SCI-present Unmodified = 6 SecTag + 8 SCI + 2 next_EtherType = 16.
+    /// Offset = 14 + 16 = 30.  This is the spec-documented value (BC-2.16.015 v1.7 EC-009),
+    /// empirically backed by V3 and V4.
+    const ARP_OFFSET_MACSEC_SCI: usize = 30;
+
+    // -------------------------------------------------------------------------
+    // Fixture builders
+    // -------------------------------------------------------------------------
+
+    /// Build a MACsec header using etherparse and serialize it.
+    ///
+    /// Returns `(serialized_bytes, declared_header_len)` where `declared_header_len`
+    /// is what `MacsecHeader::header_len()` reports and `serialized_bytes.len()`
+    /// equals that value.
+    fn build_macsec_header(ptype: MacsecPType, sci: Option<u64>) -> (Vec<u8>, usize) {
+        let hdr = MacsecHeader {
+            ptype,
+            endstation_id: false,
+            scb: false,
+            an: MacsecAn::ZERO,
+            short_len: MacsecShortLen::ZERO,
+            packet_nr: 1,
+            sci,
+        };
+        let declared_len = hdr.header_len();
+        (hdr.to_bytes().to_vec(), declared_len)
+    }
+
+    /// ARP fixed header with BENIGN fields — no variable section.
+    ///
+    /// `htype=0x0001` (Ethernet), `ptype=0x0800` (IPv4), `hlen=6`, `plen=4`,
+    /// `oper=1` (ARP Request).  Genuine snaplen truncation of a valid ARP frame:
+    /// the 20-byte variable section is absent.
+    fn arp_fixed_benign_truncated() -> [u8; ARP_FIXED_HDR_LEN] {
+        [
+            0x00, 0x01, // htype: 0x0001 (Ethernet)
+            0x08, 0x00, // ptype: 0x0800 (IPv4)
+            6,    // hlen: 6 — correct Ethernet MAC size
+            4,    // plen: 4 — correct IPv4 address size
+            0x00, 0x01, // oper: 1 (ARP Request)
+        ]
+    }
+
+    /// ARP fixed header with MALFORMED `hlen=8` — no variable section.
+    ///
+    /// `hlen=8` is not a valid Ethernet hardware-address length; it triggers D11
+    /// when read at the correct ARP offset.
+    fn arp_fixed_malformed_hlen8() -> [u8; ARP_FIXED_HDR_LEN] {
+        [
+            0x00, 0x01, // htype: 0x0001 (Ethernet — type field is valid)
+            0x08, 0x00, // ptype: 0x0800 (IPv4 — type field is valid)
+            8,    // hlen: 8 — BAD (non-Ethernet hardware-address length)
+            4,    // plen: 4 — correct IPv4 address size
+            0x00, 0x01, // oper: 1 (ARP Request)
+        ]
+    }
+
+    /// Build a complete Ethernet/MACsec/ARP frame.
+    ///
+    /// Returns `(frame_bytes, actual_arp_offset)` where `actual_arp_offset` is
+    /// the byte index in the returned slice at which the ARP fixed header begins.
+    fn build_macsec_arp_frame(macsec_hdr_bytes: &[u8], inner_arp: &[u8]) -> (Vec<u8>, usize) {
+        let mut frame = Vec::with_capacity(ETH2_LEN + macsec_hdr_bytes.len() + inner_arp.len());
+        // Ethernet header (EtherType 0x88E5 = MACsec / IEEE 802.1AE)
+        frame.extend_from_slice(&[0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF]); // dst MAC broadcast
+        frame.extend_from_slice(&[0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF]); // src MAC
+        frame.extend_from_slice(&[0x88, 0xE5]); // EtherType: 0x88E5 (MACsec)
+        let actual_arp_offset = ETH2_LEN + macsec_hdr_bytes.len();
+        frame.extend_from_slice(macsec_hdr_bytes);
+        frame.extend_from_slice(inner_arp);
+        (frame, actual_arp_offset)
+    }
+
+    /// Build a complete Ethernet/MACsec frame with an OPAQUE payload.
+    ///
+    /// Used for Modified/Encrypted variants where no inner EtherType is present.
+    /// Returns `(frame_bytes, notional_payload_offset)` — the notional offset is
+    /// provided for documentation only; the ARP-truncation path is unreachable
+    /// for these variants.
+    fn build_macsec_opaque_frame(macsec_hdr_bytes: &[u8]) -> (Vec<u8>, usize) {
+        let opaque_payload = [0xDE, 0xAD, 0xBE, 0xEF, 0xCA, 0xFE, 0xBA, 0xBE];
+        let mut frame =
+            Vec::with_capacity(ETH2_LEN + macsec_hdr_bytes.len() + opaque_payload.len());
+        frame.extend_from_slice(&[0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF]); // dst MAC broadcast
+        frame.extend_from_slice(&[0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF]); // src MAC
+        frame.extend_from_slice(&[0x88, 0xE5]); // EtherType: 0x88E5 (MACsec)
+        let notional_payload_offset = ETH2_LEN + macsec_hdr_bytes.len();
+        frame.extend_from_slice(macsec_hdr_bytes);
+        frame.extend_from_slice(&opaque_payload);
+        (frame, notional_payload_offset)
+    }
+
+    // -------------------------------------------------------------------------
+    // Internal helper: confirm lax parse is reachable at Layer::Arp
+    // -------------------------------------------------------------------------
+
+    /// Returns `(reachable, macsec_header_len_sum, macsec_payload_is_unmodified)`.
+    ///
+    /// `reachable` is true when `lax.stop_err == Layer::Arp`, meaning the lax
+    /// cursor walked through the MACsec header to an inner ARP layer but could
+    /// not fully decode it — exactly the condition that triggers the offset-peek
+    /// code in decoder.rs.
+    fn probe_lax_macsec(frame: &[u8]) -> (bool, usize, bool) {
+        let lax = LaxSlicedPacket::from_ethernet(frame)
+            .expect("LaxSlicedPacket::from_ethernet must not panic on any Ethernet-framed input");
+
+        let reachable = lax
+            .stop_err
+            .as_ref()
+            .is_some_and(|(_, layer)| *layer == Layer::Arp);
+
+        let header_len_sum: usize = lax.link_exts.iter().map(|e| e.header_len()).sum();
+
+        let payload_is_unmodified = lax.link_exts.iter().any(|ext| {
+            matches!(
+                ext,
+                LaxLinkExtSlice::Macsec(m)
+                    if matches!(m.payload, LaxMacsecPayloadSlice::Unmodified(_))
+            )
+        });
+
+        (reachable, header_len_sum, payload_is_unmodified)
+    }
+
+    // -------------------------------------------------------------------------
+    // V1 — no-SCI Unmodified, ARP truncated benign
+    // -------------------------------------------------------------------------
+
+    /// Guards that a MACsec frame without SCI (Unmodified ptype) carrying a
+    /// benign, snaplen-truncated ARP payload is classified as
+    /// `"truncated ARP frame"` and does NOT produce a false D11 finding.
+    ///
+    /// Wire layout (30 bytes total):
+    /// ```text
+    /// [0..14]  Ethernet header (EtherType=0x88E5)
+    /// [14..22] MACsec SecTag no-SCI Unmodified (6 SecTag + 2 next_EtherType(ARP))
+    /// [22..30] ARP fixed header: htype=0x0001, ptype=0x0800, hlen=6, plen=4, oper=1
+    /// ```
+    ///
+    /// `header_len()` = 8 → `arp_offset = 14 + 8 = 22`.  ARP fixed header at
+    /// offset 22 has valid `htype=0x0001`, `hlen=6` → genuine truncation, no D11.
+    ///
+    /// BC-2.16.015 PC-7b: genuine truncation behind MACsec must NOT produce D11.
+    #[test]
+    fn test_BC_2_16_015_macsec_no_sci_unmodified_arp_truncated_offset_22() {
+        // ---- Pre-conditions: MACsec header geometry ----
+        let (macsec_hdr_bytes, declared_len) =
+            build_macsec_header(MacsecPType::Unmodified(EtherType::ARP), None);
+        assert_eq!(
+            declared_len, 8,
+            "V1 pre-condition: MacsecHeader without SCI and Unmodified ptype must have \
+             header_len == 8 (6 SecTag + 2 next_EtherType). Got {}. \
+             etherparse changed MacsecHeader::header_len() — all MACsec offset \
+             assumptions in decoder.rs must be re-verified.",
+            declared_len
+        );
+        assert_eq!(
+            macsec_hdr_bytes.len(),
+            8,
+            "V1 pre-condition: serialized MACsec header must be 8 bytes. Got {}.",
+            macsec_hdr_bytes.len()
+        );
+
+        // ---- Build frame ----
+        let arp = arp_fixed_benign_truncated();
+        let (frame, actual_arp_offset) = build_macsec_arp_frame(&macsec_hdr_bytes, &arp);
+
+        assert_eq!(
+            frame.len(),
+            30,
+            "V1 fixture: frame must be 30 bytes (14 + 8 + 8). Got {}.",
+            frame.len()
+        );
+        assert_eq!(
+            actual_arp_offset, ARP_OFFSET_MACSEC_NO_SCI,
+            "V1 fixture: actual ARP offset must be {} (= 14 Ethernet + 8 MACsec). Got {}.",
+            ARP_OFFSET_MACSEC_NO_SCI, actual_arp_offset
+        );
+
+        // ---- Assert lax parse properties and offset formula ----
+        let (reachable, header_len_sum, payload_is_unmodified) = probe_lax_macsec(&frame);
+
+        assert!(
+            payload_is_unmodified,
+            "V1: MACsec payload must be Unmodified (inner EtherType readable). \
+             If Modified/Encrypted, the ARP truncation path would be unreachable — \
+             frame construction is wrong."
+        );
+        assert!(
+            reachable,
+            "V1: no-SCI Unmodified MACsec+ARP must be REACHABLE (lax.stop_err=Layer::Arp). \
+             The decoder's ARP offset-peek code requires this condition."
+        );
+        assert_eq!(
+            header_len_sum,
+            8,
+            "V1: Σ link_exts.header_len() must be 8 for no-SCI Unmodified MACsec. \
+             Got {}. Decoder would compute arp_offset = {} instead of {}.",
+            header_len_sum,
+            ETH2_LEN + header_len_sum,
+            ARP_OFFSET_MACSEC_NO_SCI
+        );
+
+        // ---- Assert the offset formula yields the spec constant ----
+        let computed_arp_offset = ETH2_LEN + header_len_sum;
+        assert_eq!(
+            computed_arp_offset, ARP_OFFSET_MACSEC_NO_SCI,
+            "V1: computed arp_offset must be {} (= 14 + 8). Got {}.",
+            ARP_OFFSET_MACSEC_NO_SCI, computed_arp_offset
+        );
+        assert_eq!(
+            computed_arp_offset, actual_arp_offset,
+            "V1: computed arp_offset {} must equal actual ARP byte position {} in the frame.",
+            computed_arp_offset, actual_arp_offset
+        );
+
+        // ---- Assert ARP bytes are readable at the computed offset ----
+        let htype =
+            u16::from_be_bytes([frame[computed_arp_offset], frame[computed_arp_offset + 1]]);
+        let hlen = frame[computed_arp_offset + 4];
+        assert_eq!(
+            htype, 0x0001,
+            "V1: ARP htype at computed offset {} must be 0x0001 (Ethernet). Got 0x{:04X}.",
+            computed_arp_offset, htype
+        );
+        assert_eq!(
+            hlen, 6,
+            "V1: ARP hlen at computed offset {} must be 6. Got {}. \
+             Offset formula is pointing at the wrong bytes.",
+            computed_arp_offset, hlen
+        );
+
+        // ---- decode_packet must return "truncated ARP frame", not D11 ----
+        let decode_result = decode_packet(&frame, DataLink::ETHERNET);
+        assert!(
+            decode_result.is_err(),
+            "V1: decode_packet must return Err for a truncated MACsec ARP frame. Got Ok."
+        );
+        let err_msg = decode_result.unwrap_err().to_string();
+
+        let mut analyzer = ArpAnalyzer::new(3, 50);
+        if err_msg.contains("Non-Ethernet/IPv4 ARP frame") {
+            analyzer.record_malformed(frame.len());
+        }
+        assert_eq!(
+            analyzer.malformed_findings, 0,
+            "BC-2.16.015 PC-7b V1: a no-SCI Unmodified MACsec frame carrying a benign \
+             truncated ARP (hlen=6 at offset {}) must NOT produce a D11 malformed finding. \
+             Got malformed_findings = {}. decode_packet error: '{}'. \
+             Expected: 'truncated ARP frame'.",
+            ARP_OFFSET_MACSEC_NO_SCI, analyzer.malformed_findings, err_msg
+        );
+        assert!(
+            err_msg.contains("truncated ARP frame"),
+            "BC-2.16.015 PC-7b V1: decode_packet must return 'truncated ARP frame'. \
+             Got: '{err_msg}'."
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // V2 — no-SCI Unmodified, ARP malformed hlen=8
+    // -------------------------------------------------------------------------
+
+    /// Guards that a MACsec frame without SCI (Unmodified ptype) carrying an ARP
+    /// fixed header with `hlen=8` is classified as `"Non-Ethernet/IPv4 ARP frame"`
+    /// and produces a D11 malformed finding.
+    ///
+    /// Wire layout: identical to V1 but ARP `hlen=8` at offset 22.
+    ///
+    /// BC-2.16.009 PC3: malformed ARP MUST produce D11 regardless of MACsec framing.
+    #[test]
+    fn test_BC_2_16_009_macsec_no_sci_unmodified_arp_malformed_hlen8_routes_to_d11() {
+        // ---- Pre-conditions ----
+        let (macsec_hdr_bytes, declared_len) =
+            build_macsec_header(MacsecPType::Unmodified(EtherType::ARP), None);
+        assert_eq!(
+            declared_len, 8,
+            "V2 pre-condition: no-SCI Unmodified header_len must be 8. Got {}.",
+            declared_len
+        );
+
+        // ---- Build frame ----
+        let arp = arp_fixed_malformed_hlen8();
+        let (frame, actual_arp_offset) = build_macsec_arp_frame(&macsec_hdr_bytes, &arp);
+
+        assert_eq!(
+            actual_arp_offset, ARP_OFFSET_MACSEC_NO_SCI,
+            "V2 fixture: actual ARP offset must be {}. Got {}.",
+            ARP_OFFSET_MACSEC_NO_SCI, actual_arp_offset
+        );
+
+        // ---- Assert lax parse properties and offset formula ----
+        let (reachable, header_len_sum, _) = probe_lax_macsec(&frame);
+
+        assert!(
+            reachable,
+            "V2: no-SCI Unmodified MACsec+ARP must be REACHABLE (lax.stop_err=Layer::Arp)."
+        );
+        assert_eq!(
+            header_len_sum, 8,
+            "V2: Σ link_exts.header_len() must be 8. Got {}.",
+            header_len_sum
+        );
+
+        let computed_arp_offset = ETH2_LEN + header_len_sum;
+        assert_eq!(
+            computed_arp_offset, ARP_OFFSET_MACSEC_NO_SCI,
+            "V2: computed arp_offset must be {}. Got {}.",
+            ARP_OFFSET_MACSEC_NO_SCI, computed_arp_offset
+        );
+        assert_eq!(
+            computed_arp_offset, actual_arp_offset,
+            "V2: computed arp_offset {} must equal actual ARP byte position {}.",
+            computed_arp_offset, actual_arp_offset
+        );
+
+        // ---- Assert hlen=8 is visible at the computed offset ----
+        let hlen = frame[computed_arp_offset + 4];
+        assert_eq!(
+            hlen, 8,
+            "V2: ARP hlen at computed offset {} must be 8 (malformed). Got {}. \
+             Offset formula is pointing at the wrong bytes.",
+            computed_arp_offset, hlen
+        );
+
+        // ---- decode_packet must route to D11 ----
+        let decode_result = decode_packet(&frame, DataLink::ETHERNET);
+        assert!(
+            decode_result.is_err(),
+            "V2: decode_packet must return Err for a malformed MACsec ARP frame. Got Ok."
+        );
+        let err_msg = decode_result.unwrap_err().to_string();
+
+        let routed_to_d11 = err_msg.contains("Non-Ethernet/IPv4 ARP frame");
+        let mut analyzer = ArpAnalyzer::new(3, 50);
+        if routed_to_d11 {
+            let findings = analyzer.record_malformed(frame.len());
+            assert!(
+                !findings.is_empty(),
+                "BC-2.16.009 PC3 V2: record_malformed must emit at least one D11 finding \
+                 for a genuinely malformed MACsec ARP frame (hlen=8 at offset {}). \
+                 Got 0 findings.",
+                computed_arp_offset + 4
+            );
+        }
+
+        assert!(
+            analyzer.malformed_findings >= 1,
+            "BC-2.16.009 PC3 V2: no-SCI Unmodified MACsec with ARP hlen=8 at offset {} \
+             must produce a D11 malformed finding. Got malformed_findings = {}. \
+             decode_packet error: '{}'.",
+            computed_arp_offset + 4,
+            analyzer.malformed_findings,
+            err_msg
+        );
+
+        // ---- D11 finding quality (parity with bc_2_16_qinq_macsec_offset_tests.rs) ----
+        if routed_to_d11 {
+            let mut analyzer2 = ArpAnalyzer::new(3, 50);
+            let d11_findings = analyzer2.record_malformed(frame.len());
+            let d11 = d11_findings
+                .first()
+                .expect("record_malformed must return at least one finding");
+            assert_eq!(
+                d11.category,
+                ThreatCategory::Anomaly,
+                "BC-2.16.009 QinQ Inv1: D11 finding must have category Anomaly. Got {:?}.",
+                d11.category
+            );
+            assert!(
+                d11.mitre_techniques.is_empty(),
+                "BC-2.16.009 QinQ Inv3: D11 finding must have empty mitre_techniques \
+                 (T0814 withheld per DF-VALIDATION-001). Got {:?}.",
+                d11.mitre_techniques
+            );
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // V3 — SCI-present Unmodified, ARP truncated benign (spec-backing test)
+    // -------------------------------------------------------------------------
+
+    /// Guards that a MACsec frame WITH SCI present (Unmodified ptype) carrying a
+    /// benign, snaplen-truncated ARP payload is classified as `"truncated ARP frame"`
+    /// and does NOT produce a false D11 finding.
+    ///
+    /// Wire layout (38 bytes total):
+    /// ```text
+    /// [0..14]  Ethernet header (EtherType=0x88E5)
+    /// [14..30] MACsec SecTag SCI-present Unmodified (6 SecTag + 8 SCI + 2 next_EtherType(ARP))
+    /// [30..38] ARP fixed header: htype=0x0001, ptype=0x0800, hlen=6, plen=4, oper=1
+    /// ```
+    ///
+    /// THIS IS THE SPEC-BACKING TEST for BC-2.16.015 v1.7 EC-009 (offset=30).
+    ///
+    /// `header_len()` for SCI-present Unmodified = 16 → `arp_offset = 14 + 16 = 30`.
+    /// The off-by-8 risk: if `LaxLinkExtSlice::Macsec` returned `header_len() == 8`
+    /// (omitting the 8 SCI bytes), the decoder would compute offset 22, peeking
+    /// into the SCI field and producing a false D11.  This test asserts
+    /// `header_len() == 16`, making offset 30 correct, and confirms that ARP bytes
+    /// at offset 30 are valid (htype=0x0001, hlen=6).
+    ///
+    /// BC-2.16.015 PC-7b: genuine truncation behind MACsec must NOT produce D11.
+    #[test]
+    fn test_BC_2_16_015_macsec_sci_present_unmodified_arp_truncated_offset_30() {
+        let sci_value: u64 = 0x0102_0304_0506_0708;
+
+        // ---- Pre-conditions: MACsec header geometry (SCI-present Unmodified = 16 bytes) ----
+        let (macsec_hdr_bytes, declared_len) =
+            build_macsec_header(MacsecPType::Unmodified(EtherType::ARP), Some(sci_value));
+        assert_eq!(
+            declared_len, 16,
+            "V3 pre-condition: MacsecHeader with SCI and Unmodified ptype must have \
+             header_len == 16 (6 SecTag + 8 SCI + 2 next_EtherType). Got {}. \
+             If 8 is returned, the SCI bytes are not counted — this is the off-by-8 risk.",
+            declared_len
+        );
+        assert_eq!(
+            macsec_hdr_bytes.len(),
+            16,
+            "V3 pre-condition: serialized SCI-present Unmodified MACsec header must be \
+             16 bytes. Got {}.",
+            macsec_hdr_bytes.len()
+        );
+
+        // ---- Build frame ----
+        let arp = arp_fixed_benign_truncated();
+        let (frame, actual_arp_offset) = build_macsec_arp_frame(&macsec_hdr_bytes, &arp);
+
+        assert_eq!(
+            frame.len(),
+            38,
+            "V3 fixture: frame must be 38 bytes (14 + 16 + 8). Got {}.",
+            frame.len()
+        );
+        assert_eq!(
+            actual_arp_offset, ARP_OFFSET_MACSEC_SCI,
+            "V3 fixture: actual ARP offset must be {} (= 14 Ethernet + 16 MACsec). Got {}. \
+             Frame construction is wrong — ARP bytes are not where expected.",
+            ARP_OFFSET_MACSEC_SCI, actual_arp_offset
+        );
+
+        // ---- Assert lax parse properties and offset formula ----
+        let (reachable, header_len_sum, payload_is_unmodified) = probe_lax_macsec(&frame);
+
+        assert!(
+            payload_is_unmodified,
+            "V3: MACsec payload must be Unmodified (inner EtherType readable for ARP parsing)."
+        );
+        assert!(
+            reachable,
+            "V3: SCI-present Unmodified MACsec+ARP must be REACHABLE (lax.stop_err=Layer::Arp). \
+             The ARP truncation path in decoder.rs requires this condition."
+        );
+
+        // CRITICAL ASSERTION: header_len_sum must be 16, not 8.
+        // If 8 is returned, the SCI bytes are omitted from the offset computation,
+        // producing arp_offset = 22 and reading 8 bytes into the SCI field as ARP
+        // header bytes — a false D11.  This assertion is the primary empirical
+        // backing for BC-2.16.015 v1.7 EC-009 offset=30.
+        assert_eq!(
+            header_len_sum, 16,
+            "V3 CRITICAL: Σ link_exts.header_len() must be 16 for SCI-present Unmodified \
+             MACsec (6 SecTag + 8 SCI + 2 next_EtherType). Got {}. \
+             If 8 is returned, the decoder computes arp_offset = 14 + 8 = 22 instead of \
+             14 + 16 = 30, reads into the SCI field as ARP bytes, and produces a false D11. \
+             This directly invalidates the spec-documented offset=30 in BC-2.16.015 v1.7 EC-009.",
+            header_len_sum
+        );
+
+        // ---- Assert the offset formula yields the spec constant ----
+        let computed_arp_offset = ETH2_LEN + header_len_sum;
+        assert_eq!(
+            computed_arp_offset, ARP_OFFSET_MACSEC_SCI,
+            "V3: computed arp_offset must be {} (= 14 + 16). Got {}. \
+             BC-2.16.015 v1.7 EC-009 documents offset=30 for SCI-present MACsec.",
+            ARP_OFFSET_MACSEC_SCI, computed_arp_offset
+        );
+        assert_eq!(
+            computed_arp_offset, actual_arp_offset,
+            "V3: computed arp_offset {} must equal actual ARP byte position {} in the frame. \
+             This confirms the offset formula is correct for SCI-present MACsec frames.",
+            computed_arp_offset, actual_arp_offset
+        );
+
+        // ---- Assert ARP bytes are readable at the computed offset ----
+        // Diagnostic: show what would be read at the WRONG offset (22) if SCI were omitted.
+        // At frame[22..30]: the 8 SCI bytes — not ARP bytes.  Reading those as ARP htype
+        // would produce a garbage value and a false D11.
+        let htype_at_wrong_offset = u16::from_be_bytes([frame[22], frame[23]]);
+        let htype_at_correct_offset = u16::from_be_bytes([
+            frame[ARP_OFFSET_MACSEC_SCI],
+            frame[ARP_OFFSET_MACSEC_SCI + 1],
+        ]);
+        assert_ne!(
+            htype_at_wrong_offset, 0x0001,
+            "V3 diagnostic: frame bytes at wrong offset 22 must NOT read as htype=0x0001 \
+             (they are SCI bytes). If they happen to be 0x0001 this diagnostic is inconclusive. \
+             Got 0x{:04X}.",
+            htype_at_wrong_offset
+        );
+        assert_eq!(
+            htype_at_correct_offset, 0x0001,
+            "V3: ARP htype at correct offset {} must be 0x0001 (Ethernet). Got 0x{:04X}. \
+             The offset formula is pointing at the wrong bytes.",
+            ARP_OFFSET_MACSEC_SCI, htype_at_correct_offset
+        );
+
+        let hlen = frame[ARP_OFFSET_MACSEC_SCI + 4];
+        assert_eq!(
+            hlen, 6,
+            "V3: ARP hlen at correct offset {} must be 6. Got {}. \
+             The offset formula is pointing at the wrong bytes.",
+            ARP_OFFSET_MACSEC_SCI, hlen
+        );
+
+        // ---- decode_packet must return "truncated ARP frame", not D11 ----
+        let decode_result = decode_packet(&frame, DataLink::ETHERNET);
+        assert!(
+            decode_result.is_err(),
+            "V3: decode_packet must return Err for a truncated MACsec ARP frame. Got Ok."
+        );
+        let err_msg = decode_result.unwrap_err().to_string();
+
+        let mut analyzer = ArpAnalyzer::new(3, 50);
+        if err_msg.contains("Non-Ethernet/IPv4 ARP frame") {
+            analyzer.record_malformed(frame.len());
+        }
+        assert_eq!(
+            analyzer.malformed_findings, 0,
+            "BC-2.16.015 PC-7b V3: a SCI-present Unmodified MACsec frame carrying a benign \
+             truncated ARP (hlen=6 at offset {}) must NOT produce a D11 malformed finding. \
+             Got malformed_findings = {}. decode_packet error: '{}'. \
+             Expected: 'truncated ARP frame'. \
+             If 'Non-Ethernet/IPv4 ARP frame' was returned, the ARP offset formula is \
+             reading the SCI bytes at offset 22 instead of the ARP bytes at offset 30.",
+            ARP_OFFSET_MACSEC_SCI, analyzer.malformed_findings, err_msg
+        );
+        assert!(
+            err_msg.contains("truncated ARP frame"),
+            "BC-2.16.015 PC-7b V3: decode_packet must return 'truncated ARP frame' for \
+             a genuinely-truncated SCI-present MACsec ARP frame. Got: '{err_msg}'."
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // V4 — SCI-present Unmodified, ARP malformed hlen=8
+    // -------------------------------------------------------------------------
+
+    /// Guards that a MACsec frame with SCI present (Unmodified ptype) carrying an
+    /// ARP fixed header with `hlen=8` is classified as `"Non-Ethernet/IPv4 ARP frame"`
+    /// and produces a D11 malformed finding.
+    ///
+    /// Wire layout: identical to V3 but ARP `hlen=8` at offset 30.
+    ///
+    /// BC-2.16.009 PC3: malformed ARP MUST produce D11 regardless of MACsec framing.
+    #[test]
+    fn test_BC_2_16_009_macsec_sci_present_unmodified_arp_malformed_hlen8_routes_to_d11() {
+        let sci_value: u64 = 0xDEAD_BEEF_CAFE_BABE;
+
+        // ---- Pre-conditions ----
+        let (macsec_hdr_bytes, declared_len) =
+            build_macsec_header(MacsecPType::Unmodified(EtherType::ARP), Some(sci_value));
+        assert_eq!(
+            declared_len, 16,
+            "V4 pre-condition: SCI-present Unmodified header_len must be 16. Got {}.",
+            declared_len
+        );
+
+        // ---- Build frame ----
+        let arp = arp_fixed_malformed_hlen8();
+        let (frame, actual_arp_offset) = build_macsec_arp_frame(&macsec_hdr_bytes, &arp);
+
+        assert_eq!(
+            actual_arp_offset, ARP_OFFSET_MACSEC_SCI,
+            "V4 fixture: actual ARP offset must be {}. Got {}.",
+            ARP_OFFSET_MACSEC_SCI, actual_arp_offset
+        );
+
+        // ---- Assert lax parse properties and offset formula ----
+        let (reachable, header_len_sum, _) = probe_lax_macsec(&frame);
+
+        assert!(
+            reachable,
+            "V4: SCI-present Unmodified MACsec+ARP must be REACHABLE (lax.stop_err=Layer::Arp)."
+        );
+        assert_eq!(
+            header_len_sum, 16,
+            "V4: Σ link_exts.header_len() must be 16 for SCI-present Unmodified. Got {}.",
+            header_len_sum
+        );
+
+        let computed_arp_offset = ETH2_LEN + header_len_sum;
+        assert_eq!(
+            computed_arp_offset, ARP_OFFSET_MACSEC_SCI,
+            "V4: computed arp_offset must be {}. Got {}.",
+            ARP_OFFSET_MACSEC_SCI, computed_arp_offset
+        );
+        assert_eq!(
+            computed_arp_offset, actual_arp_offset,
+            "V4: computed arp_offset {} must equal actual ARP byte position {}.",
+            computed_arp_offset, actual_arp_offset
+        );
+
+        // ---- Assert hlen=8 is visible at the computed offset ----
+        let hlen = frame[computed_arp_offset + 4];
+        assert_eq!(
+            hlen, 8,
+            "V4: ARP hlen at computed offset {} must be 8 (malformed). Got {}. \
+             Offset formula is pointing at the wrong bytes.",
+            computed_arp_offset, hlen
+        );
+
+        // ---- decode_packet must route to D11 ----
+        let decode_result = decode_packet(&frame, DataLink::ETHERNET);
+        assert!(
+            decode_result.is_err(),
+            "V4: decode_packet must return Err for a malformed SCI-present MACsec ARP frame. \
+             Got Ok."
+        );
+        let err_msg = decode_result.unwrap_err().to_string();
+
+        let routed_to_d11 = err_msg.contains("Non-Ethernet/IPv4 ARP frame");
+        let mut analyzer = ArpAnalyzer::new(3, 50);
+        if routed_to_d11 {
+            let findings = analyzer.record_malformed(frame.len());
+            assert!(
+                !findings.is_empty(),
+                "BC-2.16.009 PC3 V4: record_malformed must emit at least one D11 finding. \
+                 Got 0 findings."
+            );
+        }
+
+        assert!(
+            analyzer.malformed_findings >= 1,
+            "BC-2.16.009 PC3 V4: SCI-present Unmodified MACsec with ARP hlen=8 at offset {} \
+             must produce a D11 malformed finding. Got malformed_findings = {}. \
+             decode_packet error: '{}'.",
+            computed_arp_offset + 4,
+            analyzer.malformed_findings,
+            err_msg
+        );
+
+        // ---- D11 finding quality (parity with bc_2_16_qinq_macsec_offset_tests.rs) ----
+        if routed_to_d11 {
+            let mut analyzer2 = ArpAnalyzer::new(3, 50);
+            let d11_findings = analyzer2.record_malformed(frame.len());
+            let d11 = d11_findings
+                .first()
+                .expect("record_malformed must return at least one finding");
+            assert_eq!(
+                d11.category,
+                ThreatCategory::Anomaly,
+                "BC-2.16.009 Inv1 V4: D11 finding must have category Anomaly. Got {:?}.",
+                d11.category
+            );
+            assert!(
+                d11.mitre_techniques.is_empty(),
+                "BC-2.16.009 Inv3 V4: D11 finding must have empty mitre_techniques \
+                 (T0814 withheld per DF-VALIDATION-001). Got {:?}.",
+                d11.mitre_techniques
+            );
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // V5 — no-SCI Modified, opaque payload (security-property guard)
+    // -------------------------------------------------------------------------
+
+    /// Guards that a MACsec Modified frame (no-SCI, opaque payload) does NOT
+    /// reach `lax.stop_err == Layer::Arp`.  The decoder's ARP truncation path is
+    /// structurally unreachable; the offset-peek code never executes on ciphertext.
+    ///
+    /// Wire layout:
+    /// ```text
+    /// [0..14]  Ethernet header (EtherType=0x88E5)
+    /// [14..20] MACsec SecTag no-SCI Modified (6 bytes, no next_EtherType)
+    /// [20..28] Opaque payload (8 bytes — inner content not an ARP header)
+    /// ```
+    ///
+    /// Modified ptype omits the inner EtherType; `LaxMacsecPayloadSlice::Modified`
+    /// has an opaque payload, so the lax cursor cannot continue into an inner ARP
+    /// layer.  `stop_err` will NOT be `Layer::Arp`.
+    ///
+    /// This is a SECURITY-PROPERTY regression guard: if etherparse ever incorrectly
+    /// exposed the opaque payload as a readable inner ARP layer, the decoder would
+    /// attempt to interpret ciphertext as ARP bytes.  This test guards against that.
+    #[test]
+    fn test_BC_2_16_015_macsec_no_sci_modified_opaque_payload_unreachable() {
+        // ---- Pre-conditions ----
+        let (macsec_hdr_bytes, declared_len) = build_macsec_header(MacsecPType::Modified, None);
+        assert_eq!(
+            declared_len, 6,
+            "V5 pre-condition: no-SCI Modified header_len must be 6 (SecTag only, no \
+             next_EtherType). Got {}.",
+            declared_len
+        );
+
+        // ---- Build frame ----
+        let (frame, _notional_offset) = build_macsec_opaque_frame(&macsec_hdr_bytes);
+
+        // ---- Assert Modified payload is NOT reachable as Layer::Arp ----
+        let lax = LaxSlicedPacket::from_ethernet(&frame)
+            .expect("LaxSlicedPacket::from_ethernet must not panic on any Ethernet-framed input");
+
+        let reachable_as_arp = lax
+            .stop_err
+            .as_ref()
+            .is_some_and(|(_, layer)| *layer == Layer::Arp);
+
+        // Confirm payload is Modified/opaque.
+        let payload_is_modified = lax.link_exts.iter().any(|ext| {
+            matches!(
+                ext,
+                LaxLinkExtSlice::Macsec(m)
+                    if matches!(m.payload, LaxMacsecPayloadSlice::Modified { .. })
+            )
+        });
+        assert!(
+            payload_is_modified,
+            "V5: MACsec payload must be Modified/opaque. Got Unmodified — frame construction \
+             is wrong."
+        );
+
+        // SECURITY PROPERTY: the parser must NOT reach Layer::Arp for an opaque payload.
+        // If this assertion fails, etherparse has changed its behavior in a way that would
+        // allow the decoder to read opaque ciphertext bytes as ARP fields.
+        assert!(
+            !reachable_as_arp,
+            "BC-2.16.015 V5 SECURITY GUARD: Modified MACsec (opaque payload, no inner \
+             EtherType) must NOT reach lax.stop_err == Layer::Arp. \
+             If reachable, the decoder would attempt to read ciphertext as ARP bytes. \
+             lax.stop_err = {:?}. \
+             etherparse behavior change — all MACsec decoder safety assumptions must \
+             be re-verified.",
+            lax.stop_err
+        );
+
+        // Confirm offset_match semantics: no offset assertion is possible or needed
+        // for an unreachable variant.
+        assert_eq!(
+            lax.link_exts.len(),
+            1,
+            "V5: must have 1 Macsec link_ext. Got {}.",
+            lax.link_exts.len()
+        );
+        let header_len_sum: usize = lax.link_exts.iter().map(|e| e.header_len()).sum();
+        assert_eq!(
+            header_len_sum, 6,
+            "V5: Σ link_exts.header_len() must be 6 for no-SCI Modified. Got {}.",
+            header_len_sum
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // V6 — SCI-present Modified, opaque payload (security-property guard)
+    // -------------------------------------------------------------------------
+
+    /// Guards that a MACsec Modified frame WITH SCI present (opaque payload) does
+    /// NOT reach `lax.stop_err == Layer::Arp`.  Same security property as V5 but
+    /// for the SCI-present case.
+    ///
+    /// Wire layout:
+    /// ```text
+    /// [0..14]  Ethernet header (EtherType=0x88E5)
+    /// [14..28] MACsec SecTag SCI-present Modified (6 SecTag + 8 SCI = 14 bytes, no next_EtherType)
+    /// [28..36] Opaque payload (8 bytes)
+    /// ```
+    ///
+    /// BC-2.16.015: SCI-present Modified MACsec must remain unreachable from the
+    /// ARP truncation path.
+    #[test]
+    fn test_BC_2_16_015_macsec_sci_present_modified_opaque_payload_unreachable() {
+        let sci_value: u64 = 0x1122_3344_5566_7788;
+
+        // ---- Pre-conditions ----
+        let (macsec_hdr_bytes, declared_len) =
+            build_macsec_header(MacsecPType::Modified, Some(sci_value));
+        assert_eq!(
+            declared_len, 14,
+            "V6 pre-condition: SCI-present Modified header_len must be 14 (6 SecTag + \
+             8 SCI, no next_EtherType). Got {}.",
+            declared_len
+        );
+
+        // ---- Build frame ----
+        let (frame, _notional_offset) = build_macsec_opaque_frame(&macsec_hdr_bytes);
+
+        // ---- Assert SCI-present Modified payload is NOT reachable as Layer::Arp ----
+        let lax = LaxSlicedPacket::from_ethernet(&frame)
+            .expect("LaxSlicedPacket::from_ethernet must not panic on any Ethernet-framed input");
+
+        let reachable_as_arp = lax
+            .stop_err
+            .as_ref()
+            .is_some_and(|(_, layer)| *layer == Layer::Arp);
+
+        let payload_is_modified = lax.link_exts.iter().any(|ext| {
+            matches!(
+                ext,
+                LaxLinkExtSlice::Macsec(m)
+                    if matches!(m.payload, LaxMacsecPayloadSlice::Modified { .. })
+            )
+        });
+        assert!(
+            payload_is_modified,
+            "V6: MACsec payload must be Modified/opaque. Got Unmodified — frame construction \
+             is wrong."
+        );
+
+        // SECURITY PROPERTY: SCI-present Modified must also not reach Layer::Arp.
+        assert!(
+            !reachable_as_arp,
+            "BC-2.16.015 V6 SECURITY GUARD: SCI-present Modified MACsec (opaque payload) must \
+             NOT reach lax.stop_err == Layer::Arp. \
+             lax.stop_err = {:?}. \
+             etherparse behavior change — all MACsec decoder safety assumptions must \
+             be re-verified.",
+            lax.stop_err
+        );
+
+        assert_eq!(
+            lax.link_exts.len(),
+            1,
+            "V6: must have 1 Macsec link_ext. Got {}.",
+            lax.link_exts.len()
+        );
+        let header_len_sum: usize = lax.link_exts.iter().map(|e| e.header_len()).sum();
+        assert_eq!(
+            header_len_sum, 14,
+            "V6: Σ link_exts.header_len() must be 14 for SCI-present Modified. Got {}.",
+            header_len_sum
+        );
+    }
+}

--- a/tests/bc_2_16_e17_macsec_offset_tests.rs
+++ b/tests/bc_2_16_e17_macsec_offset_tests.rs
@@ -380,6 +380,51 @@ mod macsec_offset {
             "BC-2.16.015 PC-7b V1: decode_packet must return 'truncated ARP frame'. \
              Got: '{err_msg}'."
         );
+
+        // ---- Negative-offset diagnostic: guards against off-by-8 under-count bug ----
+        //
+        // If the decoder's header_len()-sum were wrong by 8 (e.g., MACsec header
+        // counted as 0 bytes instead of 8), it would compute arp_offset = 14 + 0 = 14
+        // and read frame[14..] as the ARP header — that is the SecTag's TCI-AN and SL
+        // bytes (both 0x00 for no-SCI, AN=0, short_len=0).
+        //
+        // By construction: frame[14] = TCI-AN = 0x00, frame[15] = SL = 0x00
+        //   → u16 BE = 0x0000, which is NOT a valid ARP htype (0x0001).
+        //   → frame[18] = PN byte 4 = 0x00, which is NOT a valid hlen (6).
+        //
+        // This assertion independently rules out an off-by-8 offset bug: if the
+        // decoder read at the wrong offset, it would NOT see valid ARP header fields
+        // and would return a different error (not "truncated ARP frame"), causing
+        // the primary assert above to fail.  This diagnostic makes V1 independently
+        // sufficient to pin the correct offset without relying on other variants.
+        const WRONG_OFFSET_V1: usize = ETH2_LEN; // = 14: off-by-8 under-count (no MACsec header)
+        let htype_at_wrong_offset_v1 =
+            u16::from_be_bytes([frame[WRONG_OFFSET_V1], frame[WRONG_OFFSET_V1 + 1]]);
+        let hlen_at_wrong_offset_v1 = frame[WRONG_OFFSET_V1 + 4];
+        assert_ne!(
+            htype_at_wrong_offset_v1,
+            0x0001,
+            "V1 negative-offset diagnostic: frame bytes at wrong offset {} (off-by-8 \
+             under-count) must NOT read as ARP htype=0x0001. By construction, frame[{}..{}] \
+             are the SecTag TCI-AN (0x00) and SL (0x00) bytes — u16 BE = 0x{:04X}. \
+             If this assertion fails, the diagnostic is inconclusive and the SCI fixture \
+             bytes changed — review the frame construction.",
+            WRONG_OFFSET_V1,
+            WRONG_OFFSET_V1,
+            WRONG_OFFSET_V1 + 2,
+            htype_at_wrong_offset_v1
+        );
+        assert_ne!(
+            hlen_at_wrong_offset_v1,
+            6,
+            "V1 negative-offset diagnostic: frame bytes at wrong offset {}+4={} (off-by-8 \
+             under-count) must NOT read as valid hlen=6. By construction, frame[{}] is the \
+             PN byte (0x00). Got {}.",
+            WRONG_OFFSET_V1,
+            WRONG_OFFSET_V1 + 4,
+            WRONG_OFFSET_V1 + 4,
+            hlen_at_wrong_offset_v1
+        );
     }
 
     // -------------------------------------------------------------------------
@@ -612,16 +657,42 @@ mod macsec_offset {
         // Diagnostic: show what would be read at the WRONG offset (22) if SCI were omitted.
         // At frame[22..30]: the 8 SCI bytes — not ARP bytes.  Reading those as ARP htype
         // would produce a garbage value and a false D11.
+        //
+        // OBS-1 HARDENING: The SCI value is sci_value = 0x0102_0304_0506_0708.
+        // SecTag occupies frame[14..20] (6 bytes: TCI-AN, SL, PN[4]).
+        // SCI occupies frame[20..28] (8 bytes, big-endian): 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08.
+        // Therefore frame[22] = SCI byte 2 = 0x03, frame[23] = SCI byte 3 = 0x04.
+        // u16 BE of frame[22..24] = 0x0304, which is pinned != 0x0001 by construction.
+        // The next_EtherType bytes at frame[26..28] = 0x08, 0x06.
+        //
+        // If a future test author changes sci_value, they MUST ensure frame[22..24] still
+        // does not equal 0x0001 (i.e., the SCI high bytes [2..4] must not be 0x00, 0x01).
+        // The assertion below is unconditional; there is no "inconclusive" path.
+        let sci_bytes_at_22_23: [u8; 2] = [frame[22], frame[23]];
+        assert_eq!(
+            sci_bytes_at_22_23,
+            [0x03, 0x04],
+            "V3 OBS-1 pre-condition: frame[22..24] must be SCI bytes 2-3 = [0x03, 0x04] \
+             (from sci_value=0x0102_0304_0506_0708). Got {:?}. \
+             If sci_value changed, verify that the new SCI bytes at positions [22..24] \
+             are still != 0x00, 0x01 (which would make the negative-offset diagnostic \
+             inconclusive). Recheck the frame layout and update this assertion.",
+            sci_bytes_at_22_23
+        );
         let htype_at_wrong_offset = u16::from_be_bytes([frame[22], frame[23]]);
         let htype_at_correct_offset = u16::from_be_bytes([
             frame[ARP_OFFSET_MACSEC_SCI],
             frame[ARP_OFFSET_MACSEC_SCI + 1],
         ]);
+        // This assert_ne is now unconditionally non-trivial: 0x0304 != 0x0001 is guaranteed
+        // by the sci_bytes_at_22_23 pre-condition assertion above.
         assert_ne!(
             htype_at_wrong_offset, 0x0001,
-            "V3 diagnostic: frame bytes at wrong offset 22 must NOT read as htype=0x0001 \
-             (they are SCI bytes). If they happen to be 0x0001 this diagnostic is inconclusive. \
-             Got 0x{:04X}.",
+            "V3 negative-offset diagnostic: frame bytes at wrong offset 22 (SCI bytes) \
+             must NOT read as ARP htype=0x0001. By construction frame[22..24] = [0x03, 0x04] \
+             (SCI value 0x0102_0304_0506_0708 bytes 2-3), giving htype=0x0304. \
+             Got 0x{:04X}. This is non-trivial: the SCI byte pre-condition above ensures \
+             this diagnostic is never inconclusive.",
             htype_at_wrong_offset
         );
         assert_eq!(

--- a/tests/bc_2_16_qinq_macsec_offset_tests.rs
+++ b/tests/bc_2_16_qinq_macsec_offset_tests.rs
@@ -1,0 +1,752 @@
+//! QinQ double-tagged and MACsec ARP frame offset regression guards.
+//!
+//! These tests guard that the lax-path ARP offset formula in `decode_packet`
+//! (src/decoder.rs) correctly handles stacked link extensions beyond the
+//! single-VLAN case already covered by bc_2_16_d078_vlan_offset_tests.rs.
+//!
+//! ## What these tests exercise
+//!
+//! ### Test 1 — QinQ benign truncated: no D11 false positive
+//!
+//! `test_BC_2_16_015_qinq_truncated_benign_arp_no_false_positive_d11`
+//!
+//!   A QinQ double-tagged (0x88a8 outer + 0x8100 inner) ARP frame with a valid
+//!   ARP fixed header (htype=0x0001, ptype=0x0800, hlen=6, plen=4) but NO
+//!   variable section (truncated before sender/target addresses).
+//!   ARP starts at offset 22 (14 Ethernet + 4 outer 802.1Q + 4 inner 802.1Q).
+//!
+//!   GUARDS: `lax.link_exts` contains TWO `Vlan` entries, each `header_len()==4`,
+//!   `Σ header_len() == 8`, decode result is `Err("truncated ARP frame")`, and
+//!   `malformed_findings == 0` (no false D11).
+//!
+//! ### Test 2 — QinQ malformed hlen=8: routes to D11
+//!
+//! `test_BC_2_16_009_qinq_malformed_hlen8_routes_to_d11`
+//!
+//!   Same QinQ double-tagged framing but with `hlen=8` (non-Ethernet
+//!   hardware-address length) in the ARP fixed header.
+//!
+//!   GUARDS: decode result is `Err("Non-Ethernet/IPv4 ARP frame")`,
+//!   `malformed_findings >= 1`, finding has `category == Anomaly`, and
+//!   `mitre_techniques` is empty (D11 quality parity with d078 tests).
+//!
+//! ### Test 3 — Offset-formula probe
+//!
+//! `test_BC_2_16_015_qinq_link_exts_offset_formula_pin`
+//!
+//!   Directly asserts the etherparse representation of QinQ frames: two separate
+//!   `Vlan` entries (no `VlanDouble` variant exists in etherparse 0.20.2), each
+//!   reporting `header_len() == 4`, summing to 8.  Also confirms single-VLAN
+//!   control gives `Σ == 4`.  This pins the etherparse data-model assumption so
+//!   a future version bump that changes the representation fails loudly.
+//!
+//! ### Test 4 — MACsec parse probe (OBSERVE, do not assert offset correctness)
+//!
+//! `test_BC_2_16_015_macsec_arp_lax_parse_probe`
+//!
+//!   Builds an Ethernet / MACsec(Unmodified, ptype=ARP) / ARP frame using
+//!   etherparse's `MacsecHeader` builder.  Runs `LaxSlicedPacket::from_ethernet`
+//!   and records the observed `link_exts` shape and `header_len()` value.
+//!
+//!   ASSERTS ONLY that the frame parses without panic (no crash guarantee).
+//!   Does NOT assert that the offset computed by the decoder is correct for
+//!   MACsec-encapsulated ARP.
+//!
+//!   IMPORTANT CAVEAT (see comment in test body):
+//!   The MACsec offset correctness is UNVERIFIED pending empirical confirmation
+//!   against real-world captures.  `header_len()` includes the 2-byte
+//!   `next_ether_type` field for `Unmodified` payloads (SecTag 6 + ET 2 = 8
+//!   without SCI), which may shift the ARP payload window unexpectedly.
+//!   Encrypted/modified MACsec payloads never expose a readable inner ARP, so
+//!   the decoder's truncation fallback (case c) would apply there anyway.
+//!
+//! ## Wire layouts
+//!
+//! ### QinQ benign truncated — 30 bytes total
+//! ```text
+//! [0..6]   dst MAC: FF:FF:FF:FF:FF:FF
+//! [6..12]  src MAC: AA:BB:CC:DD:EE:FF
+//! [12..14] outer EtherType: 0x88A8 (802.1ad S-Tag)
+//! [14..16] outer TCI: 0x0020 (VID=32)
+//! [16..18] inner EtherType: 0x8100 (802.1Q C-Tag)
+//! [18..20] inner TCI: 0x0064 (VID=100)
+//! [20..22] inner EtherType: 0x0806 (ARP)
+//! [22..30] ARP fixed header: htype=0x0001, ptype=0x0800, hlen=6, plen=4, oper=0x0001
+//! --- NO variable section ---
+//! ```
+//!
+//! ### QinQ malformed hlen=8 — 30 bytes total
+//! Identical framing but ARP fixed header has hlen=8 (BAD).
+//!
+//! Behavioral contracts covered:
+//!   BC-2.16.009 PC3   malformed ARP MUST produce D11 regardless of tag framing
+//!   BC-2.16.015 PC-7b genuine truncation behind QinQ tags MUST NOT produce D11
+//!
+//! DF-TEST-NAMESPACE-001: all tests wrapped in `mod qinq_macsec_offset`.
+//! DF-GREEN-DOC-TENSE-SWEEP: comments describe what the tests GUARD, written in
+//!   the tense of a passing (already-correct) test — no RED-phase stub language.
+
+#![allow(non_snake_case)]
+
+mod qinq_macsec_offset {
+    use etherparse::err::Layer;
+    use etherparse::{
+        EtherType, LaxLinkExtSlice, LaxSlicedPacket, MacsecAn, MacsecHeader, MacsecPType,
+        MacsecShortLen,
+    };
+    use pcap_file::DataLink;
+    use wirerust::analyzer::arp::ArpAnalyzer;
+    use wirerust::decoder::decode_packet;
+    use wirerust::findings::ThreatCategory;
+
+    // -------------------------------------------------------------------------
+    // Shared constants
+    // -------------------------------------------------------------------------
+
+    /// Ethernet2 header length in bytes.
+    const ETH2_LEN: usize = 14;
+
+    /// IEEE 802.1Q / 802.1ad single tag length in bytes (2 TCI + 2 inner EtherType).
+    const VLAN_TAG_LEN: usize = 4;
+
+    /// QinQ double-tag total length: outer (4) + inner (4) = 8.
+    const QINQ_TAGS_LEN: usize = VLAN_TAG_LEN * 2; // 8
+
+    /// ARP payload offset for a QinQ double-tagged Ethernet frame.
+    const ARP_OFFSET_QINQ: usize = ETH2_LEN + QINQ_TAGS_LEN; // 22
+
+    // -------------------------------------------------------------------------
+    // Fixture builders
+    // -------------------------------------------------------------------------
+
+    /// Build a QinQ double-tagged ARP frame with BENIGN inner ARP fixed header
+    /// (`htype=0x0001, ptype=0x0800, hlen=6, plen=4`) and NO variable section.
+    ///
+    /// Wire layout (30 bytes total):
+    /// ```text
+    /// [0..6]   dst MAC: FF:FF:FF:FF:FF:FF
+    /// [6..12]  src MAC: AA:BB:CC:DD:EE:FF
+    /// [12..14] outer EtherType: 0x88A8 (802.1ad S-Tag / Provider Bridging)
+    /// [14..16] outer TCI: 0x0020 (PCP=0, DEI=0, VID=32)
+    /// [16..18] inner EtherType: 0x8100 (802.1Q C-Tag)
+    /// [18..20] inner TCI: 0x0064 (PCP=0, DEI=0, VID=100)
+    /// [20..22] inner EtherType: 0x0806 (ARP)
+    /// [22..30] ARP fixed header: htype=0x0001, ptype=0x0800, hlen=6, plen=4, oper=0x0001
+    /// ```
+    ///
+    /// For hlen=6, plen=4 the ARP spec requires 28 bytes of ARP payload; only 8
+    /// are present (the fixed header only).  This is genuine snaplen truncation
+    /// of a valid Ethernet/IPv4 ARP frame behind two VLAN tags.
+    ///
+    /// etherparse 0.20.2 represents QinQ as TWO separate `LaxLinkExtSlice::Vlan`
+    /// entries (there is no `VlanDouble` variant), so `lax.link_exts.len() == 2`.
+    fn make_qinq_benign_truncated_arp() -> Vec<u8> {
+        let mut frame = Vec::with_capacity(30);
+        // Ethernet header (14 bytes)
+        frame.extend_from_slice(&[0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF]); // dst MAC broadcast
+        frame.extend_from_slice(&[0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF]); // src MAC
+        frame.extend_from_slice(&[0x88, 0xA8]); // EtherType: 802.1ad (S-Tag / QinQ outer)
+        // Outer 802.1ad tag (4 bytes)
+        frame.extend_from_slice(&[0x00, 0x20]); // outer TCI: PCP=0, DEI=0, VID=32
+        frame.extend_from_slice(&[0x81, 0x00]); // inner EtherType: 802.1Q C-Tag
+        // Inner 802.1Q tag (4 bytes)
+        frame.extend_from_slice(&[0x00, 0x64]); // inner TCI: PCP=0, DEI=0, VID=100
+        frame.extend_from_slice(&[0x08, 0x06]); // payload EtherType: ARP
+        // ARP fixed header (8 bytes) — BENIGN: hlen=6 (Ethernet), plen=4 (IPv4)
+        frame.extend_from_slice(&[0x00, 0x01]); // htype: Ethernet
+        frame.extend_from_slice(&[0x08, 0x00]); // ptype: IPv4
+        frame.push(6); // hlen: 6 — correct Ethernet MAC size
+        frame.push(4); // plen: 4 — correct IPv4 address size
+        frame.extend_from_slice(&[0x00, 0x01]); // oper: ARP Request
+        // No variable data section — 20 variable bytes missing.
+        assert_eq!(
+            frame.len(),
+            30,
+            "QinQ benign truncated fixture: total frame must be 30 bytes \
+             (14 Ethernet + 4 outer VLAN + 4 inner VLAN + 8 ARP fixed header)"
+        );
+        frame
+    }
+
+    /// Build a QinQ double-tagged ARP frame with a MALFORMED inner ARP fixed
+    /// header (`hlen=8`, non-Ethernet hardware-address length) and NO variable section.
+    ///
+    /// Wire layout (30 bytes total): identical framing as above, but ARP hlen=8(BAD).
+    fn make_qinq_malformed_arp_hlen8() -> Vec<u8> {
+        let mut frame = Vec::with_capacity(30);
+        // Ethernet header (14 bytes)
+        frame.extend_from_slice(&[0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF]); // dst MAC broadcast
+        frame.extend_from_slice(&[0x11, 0x22, 0x33, 0x44, 0x55, 0x66]); // src MAC
+        frame.extend_from_slice(&[0x88, 0xA8]); // EtherType: 802.1ad (S-Tag)
+        // Outer 802.1ad tag (4 bytes)
+        frame.extend_from_slice(&[0x00, 0x20]); // outer TCI: VID=32
+        frame.extend_from_slice(&[0x81, 0x00]); // inner EtherType: 802.1Q C-Tag
+        // Inner 802.1Q tag (4 bytes)
+        frame.extend_from_slice(&[0x00, 0x64]); // inner TCI: VID=100
+        frame.extend_from_slice(&[0x08, 0x06]); // payload EtherType: ARP
+        // ARP fixed header (8 bytes) — MALFORMED: hlen=8 (non-Ethernet)
+        frame.extend_from_slice(&[0x00, 0x01]); // htype: Ethernet (type field is OK)
+        frame.extend_from_slice(&[0x08, 0x00]); // ptype: IPv4 (type field is OK)
+        frame.push(8); // hlen: 8 — BAD (non-Ethernet hardware-address size)
+        frame.push(4); // plen: 4 — correct IPv4 address size
+        frame.extend_from_slice(&[0x00, 0x01]); // oper: ARP Request
+        // No variable data section.
+        assert_eq!(
+            frame.len(),
+            30,
+            "QinQ malformed truncated fixture: total frame must be 30 bytes \
+             (14 Ethernet + 4 outer VLAN + 4 inner VLAN + 8 ARP fixed header with hlen=8)"
+        );
+        frame
+    }
+
+    // -------------------------------------------------------------------------
+    // Probe helper
+    // -------------------------------------------------------------------------
+
+    /// Confirm a frame goes through the lax `None` arm with `stop_err=Layer::Arp`.
+    /// Returns `(lax_net_is_none, stop_is_arp, vlan_count)`.
+    fn probe_lax_arm_qinq(frame: &[u8]) -> (bool, bool, usize) {
+        let lax = LaxSlicedPacket::from_ethernet(frame)
+            .expect("LaxSlicedPacket::from_ethernet must succeed for any Ethernet-framed input");
+
+        let lax_net_is_none = lax.net.is_none();
+        let stop_is_arp = lax
+            .stop_err
+            .as_ref()
+            .is_some_and(|(_, layer)| *layer == Layer::Arp);
+        let vlan_count = lax
+            .link_exts
+            .iter()
+            .filter(|ext| matches!(ext, LaxLinkExtSlice::Vlan(_)))
+            .count();
+
+        (lax_net_is_none, stop_is_arp, vlan_count)
+    }
+
+    // -------------------------------------------------------------------------
+    // Test 1 — QinQ benign truncated: no false-positive D11
+    // -------------------------------------------------------------------------
+
+    /// Guards that a QinQ double-tagged, snaplen-truncated, otherwise-benign ARP
+    /// frame (valid Ethernet/IPv4 inner ARP fixed header, no variable section) is
+    /// classified as `"truncated ARP frame"` and does NOT produce a D11 malformed
+    /// finding.
+    ///
+    /// BC-2.16.015 PC-7b / D-078 VLAN-offset extension to QinQ:
+    ///
+    /// The lax `None` arm in `decode_packet` computes the ARP offset as
+    /// `14 + lax.link_exts.iter().map(|ext| ext.header_len()).sum()`.
+    /// For QinQ (outer 0x88A8 + inner 0x8100), etherparse 0.20.2 produces two
+    /// separate `LaxLinkExtSlice::Vlan` entries, each with `header_len() == 4`,
+    /// summing to 8 → `arp_offset = 22`.  The ARP fixed header at offset 22 has
+    /// valid fields (htype=0x0001, ptype=0x0800, hlen=6, plen=4), so the frame
+    /// is correctly classified as genuine truncation and no D11 is emitted.
+    #[test]
+    fn test_BC_2_16_015_qinq_truncated_benign_arp_no_false_positive_d11() {
+        // ---- Fixture ----
+        // 30-byte frame: 14 Ethernet + 4 outer VLAN (0x88A8, VID=32) +
+        // 4 inner VLAN (0x8100, VID=100) + 8 ARP fixed header (benign).
+        let frame = make_qinq_benign_truncated_arp();
+        assert_eq!(
+            frame.len(),
+            30,
+            "QinQ benign truncated fixture: frame must be 30 bytes"
+        );
+
+        // ---- Confirm lax parse properties ----
+        // The lax parser must see: net=None, stop_err=Layer::Arp, two Vlan link_exts.
+        let (lax_net_is_none, stop_is_arp, vlan_count) = probe_lax_arm_qinq(&frame);
+
+        assert!(
+            lax_net_is_none,
+            "BC-2.16.015 QinQ: lax.net must be None for a truncated QinQ ARP frame \
+             (only 8 bytes of ARP payload, 28 needed). Got Some — fixture or etherparse \
+             behavior changed."
+        );
+        assert!(
+            stop_is_arp,
+            "BC-2.16.015 QinQ: lax.stop_err must be Layer::Arp for a QinQ truncated ARP \
+             frame. Got different stop_err."
+        );
+        assert_eq!(
+            vlan_count, 2,
+            "BC-2.16.015 QinQ: lax.link_exts must contain exactly TWO Vlan entries for \
+             a QinQ double-tagged frame (outer 0x88A8 + inner 0x8100). \
+             etherparse 0.20.2 has no VlanDouble variant — QinQ is represented as two \
+             separate Vlan entries. Got {vlan_count} Vlan entries. \
+             If etherparse was upgraded and changed its representation, the offset \
+             formula in decoder.rs must be re-verified."
+        );
+
+        // ---- Verify the offset-formula sum directly ----
+        // This is the same computation the decoder performs; we check it here so a
+        // failure produces a precise diagnostic rather than an indirect D11 mismatch.
+        let lax = LaxSlicedPacket::from_ethernet(&frame).expect("lax parse must succeed");
+        let link_exts_sum: usize = lax.link_exts.iter().map(|e| e.header_len()).sum();
+        assert_eq!(
+            link_exts_sum,
+            QINQ_TAGS_LEN,
+            "BC-2.16.015 QinQ offset formula: Σ link_exts.header_len() must equal 8 \
+             for a QinQ double-tagged frame (2 × 4-byte VLAN tags). \
+             Got {link_exts_sum}. Decoder arp_offset would be {} instead of {}.",
+            ETH2_LEN + link_exts_sum,
+            ARP_OFFSET_QINQ
+        );
+
+        // ---- Verify the ARP fixed header is readable at the correct offset ----
+        let correct_htype =
+            u16::from_be_bytes([frame[ARP_OFFSET_QINQ], frame[ARP_OFFSET_QINQ + 1]]);
+        let correct_ptype =
+            u16::from_be_bytes([frame[ARP_OFFSET_QINQ + 2], frame[ARP_OFFSET_QINQ + 3]]);
+        let correct_hlen = frame[ARP_OFFSET_QINQ + 4];
+        let correct_plen = frame[ARP_OFFSET_QINQ + 5];
+        assert_eq!(
+            correct_htype, 0x0001,
+            "QinQ ARP htype at offset {ARP_OFFSET_QINQ} must be 0x0001"
+        );
+        assert_eq!(
+            correct_ptype, 0x0800,
+            "QinQ ARP ptype at offset {ARP_OFFSET_QINQ} must be 0x0800"
+        );
+        assert_eq!(
+            correct_hlen, 6,
+            "QinQ ARP hlen at offset {ARP_OFFSET_QINQ} must be 6"
+        );
+        assert_eq!(
+            correct_plen, 4,
+            "QinQ ARP plen at offset {ARP_OFFSET_QINQ} must be 4"
+        );
+
+        // ---- decode_packet must return Err ----
+        let decode_result = decode_packet(&frame, DataLink::ETHERNET);
+        assert!(
+            decode_result.is_err(),
+            "BC-2.16.015 QinQ: decode_packet must return Err for a truncated QinQ ARP \
+             frame. Got Ok."
+        );
+
+        let err_msg = decode_result.unwrap_err().to_string();
+
+        // ---- PRIMARY GUARD: no false-positive D11 ----
+        // After the D-078 VLAN-offset fix (which handles QinQ via the generic
+        // link_exts sum), decode_packet returns "truncated ARP frame" (not
+        // the D11 trigger) for a benign QinQ truncated ARP frame.
+        let mut analyzer = ArpAnalyzer::new(3, 50);
+        let routed_to_d11 = err_msg.contains("Non-Ethernet/IPv4 ARP frame");
+        if routed_to_d11 {
+            analyzer.record_malformed(frame.len());
+        }
+
+        assert_eq!(
+            analyzer.malformed_findings, 0,
+            "BC-2.16.015 PC-7b QinQ: a QinQ double-tagged truncated benign ARP frame \
+             (htype=0x0001, ptype=0x0800, hlen=6, plen=4 at offset {ARP_OFFSET_QINQ}, \
+             no variable section) must NOT produce a D11 malformed finding. \
+             Got malformed_findings = {}. \
+             decode_packet error: '{err_msg}'. \
+             Expected: 'truncated ARP frame' (genuine truncation, no D11). \
+             If 'Non-Ethernet/IPv4 ARP frame' was returned, the ARP offset formula \
+             in decoder.rs is NOT summing link_exts correctly for QinQ — \
+             THIS IS A PRODUCTION BUG.",
+            analyzer.malformed_findings
+        );
+
+        assert!(
+            err_msg.contains("truncated ARP frame"),
+            "BC-2.16.015 PC-7b QinQ: decode_packet must return 'truncated ARP frame' \
+             for a genuinely-truncated QinQ benign ARP frame. Got: '{err_msg}'. \
+             If 'Non-Ethernet/IPv4 ARP frame' was returned, the ARP offset formula \
+             is reading the wrong bytes — THIS IS A PRODUCTION BUG."
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Test 2 — QinQ malformed hlen=8: routes to D11
+    // -------------------------------------------------------------------------
+
+    /// Guards that a QinQ double-tagged, truncated, GENUINELY MALFORMED ARP frame
+    /// (`hlen=8`, non-Ethernet hardware-address length) is classified as
+    /// `"Non-Ethernet/IPv4 ARP frame"` and produces a D11 malformed finding.
+    ///
+    /// BC-2.16.009 PC3 / D-078 VLAN-offset extension to QinQ:
+    ///
+    /// The lax `None` arm reads the ARP fixed header at offset 22 (14 + 8 for two
+    /// 4-byte VLAN tags) and finds `hlen=8 ≠ 6`, correctly routing to D11.
+    /// Finding quality assertions mirror the single-VLAN malformed case in
+    /// bc_2_16_d078_vlan_offset_tests.rs.
+    #[test]
+    fn test_BC_2_16_009_qinq_malformed_hlen8_routes_to_d11() {
+        // ---- Fixture ----
+        // 30-byte frame: 14 Ethernet + 4 outer VLAN + 4 inner VLAN +
+        // 8 ARP fixed header with hlen=8 (BAD).
+        let frame = make_qinq_malformed_arp_hlen8();
+        assert_eq!(
+            frame.len(),
+            30,
+            "QinQ malformed fixture: frame must be 30 bytes"
+        );
+
+        // ---- Confirm lax parse properties ----
+        let (lax_net_is_none, stop_is_arp, vlan_count) = probe_lax_arm_qinq(&frame);
+
+        assert!(
+            lax_net_is_none,
+            "BC-2.16.009 QinQ: lax.net must be None for a malformed QinQ ARP frame."
+        );
+        assert!(
+            stop_is_arp,
+            "BC-2.16.009 QinQ: lax.stop_err must be Layer::Arp for a QinQ ARP frame."
+        );
+        assert_eq!(
+            vlan_count, 2,
+            "BC-2.16.009 QinQ: lax.link_exts must contain exactly TWO Vlan entries \
+             for a QinQ double-tagged frame. Got {vlan_count}."
+        );
+
+        // ---- Verify inner ARP hlen at the correct QinQ offset ----
+        let inner_hlen = frame[ARP_OFFSET_QINQ + 4]; // ARP hlen byte
+        assert_eq!(
+            inner_hlen,
+            8,
+            "Fixture pre-condition: inner ARP hlen at offset {} must be 8 (BAD). \
+             Got {}. Fixture layout may be wrong.",
+            ARP_OFFSET_QINQ + 4,
+            inner_hlen
+        );
+
+        // ---- decode_packet must return Err ----
+        let decode_result = decode_packet(&frame, DataLink::ETHERNET);
+        assert!(
+            decode_result.is_err(),
+            "BC-2.16.009 QinQ: decode_packet must return Err for a malformed QinQ ARP \
+             frame. Got Ok."
+        );
+
+        let err_msg = decode_result.unwrap_err().to_string();
+
+        // ---- Simulate main.rs routing and assert D11 IS emitted ----
+        let mut analyzer = ArpAnalyzer::new(3, 50);
+        let routed_to_d11 = err_msg.contains("Non-Ethernet/IPv4 ARP frame");
+        if routed_to_d11 {
+            let findings = analyzer.record_malformed(frame.len());
+            assert!(
+                !findings.is_empty(),
+                "BC-2.16.009 PC3 QinQ: record_malformed must emit at least one D11 finding \
+                 for a genuinely malformed QinQ ARP frame (hlen=8 at offset {}). \
+                 Got 0 findings.",
+                ARP_OFFSET_QINQ + 4
+            );
+        }
+
+        assert!(
+            analyzer.malformed_findings >= 1,
+            "BC-2.16.009 PC3 QinQ: a QinQ double-tagged truncated ARP frame with genuinely \
+             malformed inner fields (hlen=8 at offset {}) must produce a D11 malformed \
+             finding. Got malformed_findings = {}. \
+             decode_packet error: '{err_msg}'.",
+            ARP_OFFSET_QINQ + 4,
+            analyzer.malformed_findings
+        );
+
+        // ---- D11 finding quality assertions (parity with d078 malformed-case tests) ----
+        if routed_to_d11 {
+            let mut analyzer2 = ArpAnalyzer::new(3, 50);
+            let d11_findings = analyzer2.record_malformed(frame.len());
+            let d11 = d11_findings
+                .first()
+                .expect("record_malformed must return at least one finding");
+
+            assert_eq!(
+                d11.category,
+                ThreatCategory::Anomaly,
+                "BC-2.16.009 QinQ Inv1: D11 finding must have category Anomaly. \
+                 Got {:?}",
+                d11.category
+            );
+            assert!(
+                d11.mitre_techniques.is_empty(),
+                "BC-2.16.009 QinQ Inv3: D11 finding must have empty mitre_techniques \
+                 (T0814 withheld per DF-VALIDATION-001). Got {:?}",
+                d11.mitre_techniques
+            );
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Test 3 — Offset-formula probe: pin etherparse QinQ representation
+    // -------------------------------------------------------------------------
+
+    /// Guards that etherparse 0.20.2 represents QinQ (outer 0x88A8 + inner 0x8100)
+    /// as two separate `LaxLinkExtSlice::Vlan` entries — NOT a single `VlanDouble`
+    /// variant (which does not exist in this version) — and that the per-entry
+    /// `header_len()` is 4, summing to 8.  Also confirms the single-VLAN
+    /// control case gives `Σ == 4`.
+    ///
+    /// This test pins the etherparse data-model assumption that the ARP offset
+    /// formula in decoder.rs relies on.  If a future etherparse version introduces
+    /// a `VlanDouble` variant (with a different `header_len()`) or changes the
+    /// per-tag length, this test will fail loudly before any production bug can
+    /// appear silently.
+    #[test]
+    fn test_BC_2_16_015_qinq_link_exts_offset_formula_pin() {
+        // ---- QinQ frame: two Vlan entries ----
+        let qinq_frame = make_qinq_benign_truncated_arp();
+        let lax_qinq =
+            LaxSlicedPacket::from_ethernet(&qinq_frame).expect("QinQ lax parse must not fail");
+
+        // Assert etherparse represents QinQ as exactly two Vlan entries.
+        assert_eq!(
+            lax_qinq.link_exts.len(),
+            2,
+            "etherparse 0.20.2 QinQ representation: lax.link_exts must have exactly 2 entries \
+             (one per VLAN tag). Got {}. If etherparse changed its representation, the offset \
+             formula in decoder.rs must be re-verified.",
+            lax_qinq.link_exts.len()
+        );
+
+        // Assert both entries are Vlan (not any hypothetical VlanDouble).
+        for (i, ext) in lax_qinq.link_exts.iter().enumerate() {
+            assert!(
+                matches!(ext, LaxLinkExtSlice::Vlan(_)),
+                "etherparse 0.20.2 QinQ: link_exts[{i}] must be Vlan variant. \
+                 Got a different variant. If a VlanDouble or similar was introduced, \
+                 decoder.rs header_len() delegation must be re-verified."
+            );
+        }
+
+        // Assert per-entry header_len == 4 (2-byte TCI + 2-byte inner EtherType).
+        for (i, ext) in lax_qinq.link_exts.iter().enumerate() {
+            assert_eq!(
+                ext.header_len(),
+                VLAN_TAG_LEN,
+                "etherparse 0.20.2 QinQ: link_exts[{i}].header_len() must be 4. \
+                 Got {}. This would invalidate the offset formula sum in decoder.rs.",
+                ext.header_len()
+            );
+        }
+
+        // Assert the sum equals QINQ_TAGS_LEN == 8.
+        let qinq_sum: usize = lax_qinq.link_exts.iter().map(|e| e.header_len()).sum();
+        assert_eq!(
+            qinq_sum,
+            QINQ_TAGS_LEN,
+            "etherparse 0.20.2 QinQ offset formula: Σ link_exts.header_len() must equal \
+             8 for a QinQ double-tagged frame. Got {qinq_sum}. \
+             This DIRECTLY affects the ARP offset computation in decoder.rs: \
+             arp_offset = 14 + {qinq_sum} = {} instead of the correct {}.",
+            ETH2_LEN + qinq_sum,
+            ARP_OFFSET_QINQ
+        );
+
+        // ---- Single-VLAN control: confirm Σ == 4 ----
+        // Build a minimal single-VLAN frame (same as d078 tests) to confirm the
+        // control case is unchanged by this test suite.
+        let mut single_vlan_frame = Vec::with_capacity(26);
+        single_vlan_frame.extend_from_slice(&[0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF]);
+        single_vlan_frame.extend_from_slice(&[0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF]);
+        single_vlan_frame.extend_from_slice(&[0x81, 0x00]); // EtherType: 802.1Q
+        single_vlan_frame.extend_from_slice(&[0x00, 0x64]); // TCI: VID=100
+        single_vlan_frame.extend_from_slice(&[0x08, 0x06]); // inner EtherType: ARP
+        // ARP fixed header (benign, truncated)
+        single_vlan_frame.extend_from_slice(&[0x00, 0x01, 0x08, 0x00, 6, 4, 0x00, 0x01]);
+
+        let lax_single = LaxSlicedPacket::from_ethernet(&single_vlan_frame)
+            .expect("single-VLAN lax parse must not fail");
+        let single_sum: usize = lax_single.link_exts.iter().map(|e| e.header_len()).sum();
+
+        assert_eq!(
+            single_sum, VLAN_TAG_LEN,
+            "etherparse 0.20.2 single-VLAN control: Σ link_exts.header_len() must equal \
+             4 for a single-tagged frame. Got {single_sum}."
+        );
+
+        assert_eq!(
+            lax_single.link_exts.len(),
+            1,
+            "etherparse 0.20.2 single-VLAN control: lax.link_exts must have exactly \
+             1 entry. Got {}.",
+            lax_single.link_exts.len()
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Test 4 — MACsec probe (OBSERVE ONLY — offset correctness unverified)
+    // -------------------------------------------------------------------------
+
+    /// MACsec ARP lax parse probe — OBSERVE and record etherparse behavior only.
+    ///
+    /// Builds an Ethernet / MACsec(Unmodified, ptype=ARP) / ARP frame using
+    /// etherparse's `MacsecHeader` builder with a minimal SecTag (no SCI, ptype
+    /// Unmodified(ARP)) and verifies only that:
+    ///   1. `LaxSlicedPacket::from_ethernet` does not panic (no crash guarantee).
+    ///   2. `lax.link_exts` contains exactly one `Macsec` entry.
+    ///   3. The observed `header_len()` value is recorded via the assertion message.
+    ///
+    /// IMPORTANT — OFFSET CORRECTNESS IS UNVERIFIED:
+    ///
+    /// The MACsec `header_len()` for an Unmodified payload without SCI is 8:
+    ///
+    ///   - 6 bytes: SecTag (TCI-AN + SL + PN, 4-byte packet number)
+    ///   - 2 bytes: next EtherType (present only for Unmodified payloads)
+    ///   - Total: 6 + 2 = 8 bytes (no SCI; with SCI it would be 6 + 8 + 2 = 16)
+    ///
+    /// This means the decoder would compute `arp_offset = 14 + 8 = 22` for this
+    /// specific MACsec variant, placing the ARP payload at offset 22.  However:
+    ///
+    ///   a) We have not verified this against real-world MACsec+ARP captures.
+    ///   b) With SCI present, `header_len() = 16` → `arp_offset = 30`.
+    ///   c) Modified/encrypted MACsec payloads are opaque — no inner ARP is
+    ///      readable — so the decoder's case (c) truncation fallback applies
+    ///      there regardless of offset.  In that case `lax.net` would be None
+    ///      with a MACsec stop_err, not an ARP stop_err, so the lax None arm's
+    ///      ARP truncation branch would not be reached.
+    ///
+    /// The goal of this test is to SURFACE any discrepancy, not to hide it.
+    /// DO NOT strengthen assertions here to cover offset correctness until
+    /// real-world MACsec+ARP capture data confirms the expected offset value.
+    ///
+    /// If constructing a MACsec frame that etherparse parses as a Macsec
+    /// link_ext proves impossible (e.g., etherparse rejects the byte sequence),
+    /// the frame-construction failure is itself a diagnostic finding and the test
+    /// documents it in the assertion message.
+    #[test]
+    fn test_BC_2_16_015_macsec_arp_lax_parse_probe() {
+        // ---- Build the MACsec header bytes ----
+        // Minimal SecTag: no SCI, ptype=Unmodified(ARP), short_len=0 (unknown length),
+        // packet_nr=1, an=0, endstation_id=false, scb=false.
+        //
+        // For Unmodified ptype without SCI:
+        //   header_len = 6 (SecTag) + 2 (next EtherType) = 8 bytes.
+        // The 2-byte next EtherType field is ARP (0x0806) and is part of the header.
+        // After the header, the ARP payload begins immediately.
+        let macsec_hdr = MacsecHeader {
+            ptype: MacsecPType::Unmodified(EtherType::ARP),
+            endstation_id: false,
+            scb: false,
+            an: MacsecAn::ZERO,
+            short_len: MacsecShortLen::ZERO,
+            packet_nr: 1,
+            sci: None, // no SCI → header is 6 + 2 = 8 bytes
+        };
+        let macsec_hdr_bytes = macsec_hdr.to_bytes();
+
+        // Computed expected header_len for documentation purposes.
+        // With sci=None and ptype=Unmodified: 6 + 0 + 2 = 8.
+        let expected_hdr_len = macsec_hdr.header_len();
+        assert_eq!(
+            expected_hdr_len, 8,
+            "MACsec probe pre-condition: MacsecHeader without SCI and Unmodified ptype \
+             must have header_len == 8 (6 SecTag + 2 next EtherType). Got {}. \
+             etherparse changed its MacsecHeader::header_len() formula — all MACsec \
+             offset assumptions in decoder.rs must be re-verified.",
+            expected_hdr_len
+        );
+
+        // ---- Build the truncated ARP fixed header ----
+        // Valid benign fields, no variable section.
+        let arp_fixed: [u8; 8] = [
+            0x00, 0x01, // htype: Ethernet
+            0x08, 0x00, // ptype: IPv4
+            6,    // hlen: 6
+            4,    // plen: 4
+            0x00, 0x01, // oper: Request
+        ];
+
+        // ---- Assemble the full frame ----
+        // Layout: 14 Ethernet + macsec_hdr (8 bytes) + arp_fixed (8 bytes) = 30 bytes.
+        // Note: the outer EtherType in the Ethernet header is 0x88E5 (MACsec).
+        // The MACsec header's Unmodified ptype encodes the inner EtherType (ARP=0x0806)
+        // as the last 2 bytes of the MACsec header, not as a separate field.
+        let mut frame = Vec::new();
+        // Ethernet header (14 bytes)
+        frame.extend_from_slice(&[0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF]); // dst MAC broadcast
+        frame.extend_from_slice(&[0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF]); // src MAC
+        frame.extend_from_slice(&[0x88, 0xE5]); // EtherType: 0x88E5 (MACsec / IEEE 802.1AE)
+        // MACsec SecTag + next EtherType (8 bytes)
+        frame.extend_from_slice(&macsec_hdr_bytes);
+        // ARP fixed header — truncated (no variable section)
+        frame.extend_from_slice(&arp_fixed);
+
+        let expected_frame_len = ETH2_LEN + expected_hdr_len + arp_fixed.len();
+        assert_eq!(
+            frame.len(),
+            expected_frame_len,
+            "MACsec probe: frame must be {expected_frame_len} bytes. Got {}.",
+            frame.len()
+        );
+
+        // ---- Run lax parse — assert no panic ----
+        // SAFETY GUARANTEE ONLY: this test asserts the parser does not panic.
+        // It does NOT assert offset correctness or D11 classification.
+        let lax = LaxSlicedPacket::from_ethernet(&frame)
+            .expect("LaxSlicedPacket::from_ethernet must not panic on any Ethernet-framed input");
+
+        // ---- Observe and record the link_exts shape ----
+        let macsec_count = lax
+            .link_exts
+            .iter()
+            .filter(|ext| matches!(ext, LaxLinkExtSlice::Macsec(_)))
+            .count();
+
+        let observed_macsec_hdr_len: Option<usize> = lax.link_exts.iter().find_map(|ext| {
+            if let LaxLinkExtSlice::Macsec(m) = ext {
+                Some(m.header.header_len())
+            } else {
+                None
+            }
+        });
+
+        let link_exts_sum: usize = lax.link_exts.iter().map(|e| e.header_len()).sum();
+
+        // Assert the MACsec frame produces exactly one Macsec entry in link_exts.
+        // If this assertion fails, document why (e.g., etherparse rejected the
+        // MACsec header entirely and set stop_err instead of populating link_exts).
+        assert_eq!(
+            macsec_count,
+            1,
+            "MACsec probe: lax.link_exts must contain exactly ONE Macsec entry for \
+             a frame with EtherType 0x88E5 and a valid MacsecHeader (Unmodified, no SCI). \
+             Got {macsec_count} Macsec entries. \
+             lax.stop_err = {:?}. \
+             lax.link_exts.len() = {}. \
+             This may indicate that etherparse rejected the constructed MACsec frame — \
+             check the frame bytes and MacsecHeader serialization.",
+            lax.stop_err,
+            lax.link_exts.len()
+        );
+
+        // Assert the observed header_len matches the expected value (8).
+        // This pins the formula: 6 SecTag + 2 next_EtherType (Unmodified, no SCI).
+        //
+        // IMPORTANT: this assertion verifies only the HEADER parse, not offset
+        // correctness end-to-end.  The decoder uses `lax.link_exts.header_len()`
+        // to add to the base offset; if etherparse reports 8, the decoder computes
+        // arp_offset = 14 + 8 = 22, which is consistent with the actual ARP
+        // position in this frame.  But this has NOT been validated against a real
+        // capture — the SecTag may be parsed differently in production frames.
+        let observed = observed_macsec_hdr_len.unwrap_or(0);
+        assert_eq!(
+            observed, expected_hdr_len,
+            "MACsec probe: observed LaxMacsecSlice header_len ({observed}) must equal \
+             the pre-computed MacsecHeader::header_len ({expected_hdr_len}). \
+             If they differ, LaxMacsecSlice and MacsecHeader disagree on how many \
+             bytes the SecTag occupies — this is a critical etherparse invariant \
+             violation that would break the decoder offset formula."
+        );
+
+        // Record the full observed state for diagnostic purposes.
+        // These values inform future work when real MACsec+ARP captures are available.
+        //
+        //   Observed link_exts_sum  : {link_exts_sum}
+        //   Observed macsec hdr_len : {observed}
+        //   lax.net                 : {:?}
+        //   lax.stop_err            : {:?}
+        //
+        // UNVERIFIED: whether arp_offset = 14 + link_exts_sum correctly points to
+        // the ARP payload in real-world MACsec+ARP frames.  Encrypted/modified
+        // MACsec payloads are always opaque and would never produce an ARP stop_err,
+        // so decoder case (c) already handles those safely.
+        let _ = (link_exts_sum, &lax.net, &lax.stop_err); // suppress unused-variable warnings
+    }
+}

--- a/tests/bc_2_16_qinq_macsec_offset_tests.rs
+++ b/tests/bc_2_16_qinq_macsec_offset_tests.rs
@@ -40,7 +40,7 @@
 //!   control gives `Σ == 4`.  This pins the etherparse data-model assumption so
 //!   a future version bump that changes the representation fails loudly.
 //!
-//! ### Test 4 — MACsec parse probe (OBSERVE, do not assert offset correctness)
+//! ### Test 4 — MACsec parse probe (observe-only for this file; offset asserted in e17 file)
 //!
 //! `test_BC_2_16_015_macsec_arp_lax_parse_probe`
 //!
@@ -48,17 +48,20 @@
 //!   etherparse's `MacsecHeader` builder.  Runs `LaxSlicedPacket::from_ethernet`
 //!   and records the observed `link_exts` shape and `header_len()` value.
 //!
-//!   ASSERTS ONLY that the frame parses without panic (no crash guarantee).
-//!   Does NOT assert that the offset computed by the decoder is correct for
-//!   MACsec-encapsulated ARP.
+//!   ASSERTS: no panic, exactly one `Macsec` entry in `link_exts`, and the
+//!   observed `header_len()` equals the pre-computed `MacsecHeader::header_len()`
+//!   value (8 without SCI, 16 with SCI).  Offset correctness — that
+//!   `arp_offset = 14 + link_exts_sum` correctly positions the ARP payload —
+//!   is synthetically asserted in `bc_2_16_e17_macsec_offset_tests.rs`
+//!   (`test_BC_2_16_015_macsec_no_sci_unmodified_arp_truncated_offset_22` and
+//!   `test_BC_2_16_015_macsec_sci_present_unmodified_arp_truncated_offset_30`).
 //!
-//!   IMPORTANT CAVEAT (see comment in test body):
-//!   The MACsec offset correctness is UNVERIFIED pending empirical confirmation
-//!   against real-world captures.  `header_len()` includes the 2-byte
-//!   `next_ether_type` field for `Unmodified` payloads (SecTag 6 + ET 2 = 8
-//!   without SCI), which may shift the ARP payload window unexpectedly.
-//!   Encrypted/modified MACsec payloads never expose a readable inner ARP, so
-//!   the decoder's truncation fallback (case c) would apply there anyway.
+//!   What remains unverified is the existence/behavior of MACsec-over-ARP in
+//!   REAL on-wire captured traffic (BC-2.16.009/015 EC-009 part c).  That gap
+//!   is a real-world fixture gap, not an offset-formula gap.  This probe is
+//!   intentionally observe-only within this file so that MACsec shape/no-panic
+//!   coverage lives here and offset-correctness assertions live exclusively in
+//!   the e17 file, keeping the two concerns cleanly separated.
 //!
 //! ## Wire layouts
 //!
@@ -571,40 +574,43 @@ mod qinq_macsec_offset {
     }
 
     // -------------------------------------------------------------------------
-    // Test 4 — MACsec probe (OBSERVE ONLY — offset correctness unverified)
+    // Test 4 — MACsec probe (observe-only shape guard; offset asserted in e17 file)
     // -------------------------------------------------------------------------
 
-    /// MACsec ARP lax parse probe — OBSERVE and record etherparse behavior only.
+    /// MACsec ARP lax parse probe — no-panic and shape regression guard.
     ///
     /// Builds an Ethernet / MACsec(Unmodified, ptype=ARP) / ARP frame using
     /// etherparse's `MacsecHeader` builder with a minimal SecTag (no SCI, ptype
-    /// Unmodified(ARP)) and verifies only that:
-    ///   1. `LaxSlicedPacket::from_ethernet` does not panic (no crash guarantee).
+    /// Unmodified(ARP)) and guards:
+    ///   1. `LaxSlicedPacket::from_ethernet` does not panic.
     ///   2. `lax.link_exts` contains exactly one `Macsec` entry.
-    ///   3. The observed `header_len()` value is recorded via the assertion message.
+    ///   3. The observed `header_len()` matches `MacsecHeader::header_len()` (8 without SCI).
     ///
-    /// IMPORTANT — OFFSET CORRECTNESS IS UNVERIFIED:
+    /// ### Offset arithmetic — synthetic assertions live in the e17 file
     ///
     /// The MACsec `header_len()` for an Unmodified payload without SCI is 8:
     ///
     ///   - 6 bytes: SecTag (TCI-AN + SL + PN, 4-byte packet number)
     ///   - 2 bytes: next EtherType (present only for Unmodified payloads)
-    ///   - Total: 6 + 2 = 8 bytes (no SCI; with SCI it would be 6 + 8 + 2 = 16)
+    ///   - Total: 6 + 2 = 8 bytes (no SCI; with SCI: 6 + 8 + 2 = 16)
     ///
-    /// This means the decoder would compute `arp_offset = 14 + 8 = 22` for this
-    /// specific MACsec variant, placing the ARP payload at offset 22.  However:
+    /// The decoder therefore computes `arp_offset = 14 + 8 = 22` (no SCI) or
+    /// `arp_offset = 14 + 16 = 30` (SCI present).  These offset values are
+    /// synthetically asserted in `bc_2_16_e17_macsec_offset_tests.rs`:
+    ///   - `test_BC_2_16_015_macsec_no_sci_unmodified_arp_truncated_offset_22`
+    ///   - `test_BC_2_16_015_macsec_sci_present_unmodified_arp_truncated_offset_30`
     ///
-    ///   a) We have not verified this against real-world MACsec+ARP captures.
-    ///   b) With SCI present, `header_len() = 16` → `arp_offset = 30`.
-    ///   c) Modified/encrypted MACsec payloads are opaque — no inner ARP is
-    ///      readable — so the decoder's case (c) truncation fallback applies
-    ///      there regardless of offset.  In that case `lax.net` would be None
-    ///      with a MACsec stop_err, not an ARP stop_err, so the lax None arm's
-    ///      ARP truncation branch would not be reached.
+    /// This probe is intentionally observe-only for offset within this file so that
+    /// offset-correctness assertions are owned by the e17 file, not duplicated here.
     ///
-    /// The goal of this test is to SURFACE any discrepancy, not to hide it.
-    /// DO NOT strengthen assertions here to cover offset correctness until
-    /// real-world MACsec+ARP capture data confirms the expected offset value.
+    /// ### Remaining real-world gap (EC-009 part c)
+    ///
+    /// What is NOT yet verified is the existence and behavior of MACsec-over-ARP
+    /// in REAL on-wire captured traffic (BC-2.16.009/015 EC-009 part c).  That is
+    /// a real-world fixture gap, not an offset-formula gap.  Modified/encrypted
+    /// MACsec payloads are opaque — no inner ARP is readable — so the decoder's
+    /// truncation fallback applies there regardless of offset; `lax.net` would be
+    /// None with a MACsec stop_err, not an ARP stop_err.
     ///
     /// If constructing a MACsec frame that etherparse parses as a Macsec
     /// link_ext proves impossible (e.g., etherparse rejects the byte sequence),
@@ -719,12 +725,12 @@ mod qinq_macsec_offset {
         // Assert the observed header_len matches the expected value (8).
         // This pins the formula: 6 SecTag + 2 next_EtherType (Unmodified, no SCI).
         //
-        // IMPORTANT: this assertion verifies only the HEADER parse, not offset
-        // correctness end-to-end.  The decoder uses `lax.link_exts.header_len()`
-        // to add to the base offset; if etherparse reports 8, the decoder computes
-        // arp_offset = 14 + 8 = 22, which is consistent with the actual ARP
-        // position in this frame.  But this has NOT been validated against a real
-        // capture — the SecTag may be parsed differently in production frames.
+        // This assertion guards the HEADER parse.  The decoder uses
+        // `lax.link_exts.header_len()` to compute `arp_offset = 14 + 8 = 22`,
+        // which is consistent with the actual ARP position in this synthetic frame.
+        // The full end-to-end offset correctness (offset 22 no-SCI / offset 30 SCI)
+        // is asserted in bc_2_16_e17_macsec_offset_tests.rs.  What remains an open
+        // gap is validation against REAL on-wire MACsec+ARP captures (EC-009 part c).
         let observed = observed_macsec_hdr_len.unwrap_or(0);
         assert_eq!(
             observed, expected_hdr_len,
@@ -736,17 +742,18 @@ mod qinq_macsec_offset {
         );
 
         // Record the full observed state for diagnostic purposes.
-        // These values inform future work when real MACsec+ARP captures are available.
+        // Synthetic offset assertions (22 no-SCI / 30 SCI) are owned by
+        // bc_2_16_e17_macsec_offset_tests.rs and confirmed green there.
         //
         //   Observed link_exts_sum  : {link_exts_sum}
         //   Observed macsec hdr_len : {observed}
         //   lax.net                 : {:?}
         //   lax.stop_err            : {:?}
         //
-        // UNVERIFIED: whether arp_offset = 14 + link_exts_sum correctly points to
-        // the ARP payload in real-world MACsec+ARP frames.  Encrypted/modified
-        // MACsec payloads are always opaque and would never produce an ARP stop_err,
-        // so decoder case (c) already handles those safely.
+        // Remaining gap: real on-wire MACsec+ARP captures (EC-009 part c) are not
+        // yet available.  Encrypted/modified MACsec payloads are always opaque and
+        // would never produce an ARP stop_err, so decoder case (c) handles those
+        // safely regardless.
         let _ = (link_exts_sum, &lax.net, &lax.stop_err); // suppress unused-variable warnings
     }
 }

--- a/tests/bc_2_16_qinq_macsec_offset_tests.rs
+++ b/tests/bc_2_16_qinq_macsec_offset_tests.rs
@@ -362,6 +362,57 @@ mod qinq_macsec_offset {
              If 'Non-Ethernet/IPv4 ARP frame' was returned, the ARP offset formula \
              is reading the wrong bytes — THIS IS A PRODUCTION BUG."
         );
+
+        // ---- Negative-offset diagnostic: guards against off-by-4 and off-by-8 under-count bugs ----
+        //
+        // If the decoder's link_exts header_len()-sum were wrong, it would compute the
+        // wrong ARP offset and read non-ARP bytes as the ARP header:
+        //
+        //   • off-by-8 (both VLAN tags omitted, sum=0):  arp_offset = 14 + 0 = 14
+        //     frame[14..16] = outer TCI = 0x00, 0x20 → htype = 0x0020 (NOT 0x0001)
+        //     frame[14+4]   = frame[18] = inner TCI high byte = 0x00 (NOT valid hlen 6)
+        //
+        //   • off-by-4 (one VLAN tag omitted, sum=4):    arp_offset = 14 + 4 = 18
+        //     frame[18..20] = inner TCI = 0x00, 0x64 → htype = 0x0064 (NOT 0x0001)
+        //     frame[18+4]   = frame[22] = ARP htype high byte = 0x00 (NOT valid hlen 6)
+        //
+        // Both wrong-offset values are known by construction from make_qinq_benign_truncated_arp().
+        // These assertions make this test independently sufficient to pin the offset formula
+        // without relying on Test 3 (the offset-formula probe).
+        const WRONG_OFFSET_OFF8: usize = ETH2_LEN; // 14: both VLAN tags omitted
+        const WRONG_OFFSET_OFF4: usize = ETH2_LEN + VLAN_TAG_LEN; // 18: one VLAN tag omitted
+
+        // off-by-8: frame[14..16] = outer TCI bytes = 0x00, 0x20
+        let htype_at_wrong_off8 =
+            u16::from_be_bytes([frame[WRONG_OFFSET_OFF8], frame[WRONG_OFFSET_OFF8 + 1]]);
+        assert_ne!(
+            htype_at_wrong_off8,
+            0x0001,
+            "QinQ negative-offset diagnostic (off-by-8): frame bytes at wrong offset {} \
+             (both VLAN tags omitted) must NOT read as ARP htype=0x0001. \
+             By construction frame[{}..{}] = outer TCI [0x00, 0x20] → htype=0x0020. \
+             Got 0x{:04X}. If this fails, the frame fixture changed; update this assertion.",
+            WRONG_OFFSET_OFF8,
+            WRONG_OFFSET_OFF8,
+            WRONG_OFFSET_OFF8 + 2,
+            htype_at_wrong_off8
+        );
+
+        // off-by-4: frame[18..20] = inner TCI bytes = 0x00, 0x64
+        let htype_at_wrong_off4 =
+            u16::from_be_bytes([frame[WRONG_OFFSET_OFF4], frame[WRONG_OFFSET_OFF4 + 1]]);
+        assert_ne!(
+            htype_at_wrong_off4,
+            0x0001,
+            "QinQ negative-offset diagnostic (off-by-4): frame bytes at wrong offset {} \
+             (one VLAN tag omitted) must NOT read as ARP htype=0x0001. \
+             By construction frame[{}..{}] = inner TCI [0x00, 0x64] → htype=0x0064. \
+             Got 0x{:04X}. If this fails, the frame fixture changed; update this assertion.",
+            WRONG_OFFSET_OFF4,
+            WRONG_OFFSET_OFF4,
+            WRONG_OFFSET_OFF4 + 2,
+            htype_at_wrong_off4
+        );
     }
 
     // -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes #253.

Adds test coverage for the QinQ (double 802.1Q / 0x88a8) and MACsec ARP decoder offset path that was fixed in D-078 but not yet exercised beyond the single-VLAN case.

**This PR is TEST-ONLY. No `src/` production code was changed.**

---

## Change Type

- [x] Test coverage (no production code changed)

---

## The 4 Tests

| Test name | What it guards | BC |
|---|---|---|
| `test_BC_2_16_015_qinq_truncated_benign_arp_no_false_positive_d11` | QinQ benign-truncated ARP (htype=1, ptype=0x800, hlen=6) classifies as `"truncated ARP frame"`, **zero D11 false positives** (CWE-693 evasion guard) | BC-2.16.015 PC-7b |
| `test_BC_2_16_009_qinq_malformed_hlen8_routes_to_d11` | Same QinQ framing with hlen=8 (non-Ethernet) **must** produce a D11 malformed finding | BC-2.16.009 PC3 |
| `test_BC_2_16_015_qinq_link_exts_offset_formula_pin` | Pins etherparse 0.20.2 QinQ data-model assumption: two separate `Vlan` entries (no `VlanDouble`), each `header_len()==4`, Σ==8. Fails loudly if a future etherparse version changes the representation before decoder.rs is updated. | BC-2.16.015 |
| `test_BC_2_16_015_macsec_arp_lax_parse_probe` | MACsec PROBE ONLY — asserts no panic on `LaxSlicedPacket::from_ethernet`; records observed `link_exts` shape and `header_len()`. **Does NOT assert offset correctness.** | BC-2.16.015 |

---

## MACsec Correctness Caveat

Test 4 is explicitly probe-only. The MACsec ARP offset correctness is **documented-not-asserted**, pending empirical confirmation against real-world MACsec+ARP captures. The test body contains a detailed caveat comment explaining:
- Why `header_len()` includes the 2-byte `next_ether_type` field for `Unmodified` payloads (SecTag 6 + ET 2 = 8 without SCI)
- Why encrypted/modified MACsec payloads are always opaque (decoder case-c truncation applies regardless)
- What would be needed to strengthen the assertion

---

## Demo Recording

**Intentionally skipped.** This is a test-only change to an internal decoder path with no user-facing or observable behavior. There is no UI, CLI output, or observable artifact to record.

---

## Validation

DF-VALIDATION-001 (CLAUDE.md policy): GENUINE/OPEN, validated at `.factory/research/issue-253-qinq-macsec-validation.md` (factory-artifacts branch).

All 4 tests pass locally. `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` are clean.

---

## Architecture Changes

```mermaid
graph TD
    A[tests/bc_2_16_qinq_macsec_offset_tests.rs] -->|imports| B[wirerust::decoder::decode_packet]
    A -->|imports| C[wirerust::analyzer::arp::ArpAnalyzer]
    A -->|imports| D[etherparse::LaxSlicedPacket]
    B -->|already fixed| E[D-078 VLAN offset formula\nlax.link_exts.iter().map header_len sum]
```

## Spec Traceability

```mermaid
flowchart LR
    BC1["BC-2.16.015 PC-7b\nQinQ truncation must not D11"] --> T1["test_BC_2_16_015_qinq_truncated_benign_arp\n_no_false_positive_d11"]
    BC2["BC-2.16.009 PC3\nmalformed ARP must D11\nregardless of tag framing"] --> T2["test_BC_2_16_009_qinq_malformed\n_hlen8_routes_to_d11"]
    BC3["BC-2.16.015\netherparse model pin"] --> T3["test_BC_2_16_015_qinq_link_exts\n_offset_formula_pin"]
    BC4["BC-2.16.015\nMACsec probe"] --> T4["test_BC_2_16_015_macsec_arp\n_lax_parse_probe"]
    T1 --> Code["src/decoder.rs\nlax link_exts offset formula\n(no changes this PR)"]
    T2 --> Code
```

---

## Pre-Merge Checklist

- [x] Test-only PR — no production code changed
- [x] All 4 new tests pass (`cargo test bc_2_16_qinq_macsec`)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] DF-VALIDATION-001 validated
- [x] MACsec caveat documented in test body
- [x] Demo recording consciously skipped (test-only, no observable behavior)
- [ ] CI passing
- [ ] PR review approved