### PR TITLE
refactor(reporter): replace TerminalReporter render bools with FindingsRender enum (#62)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1637,7 +1637,7 @@ dependencies = [
 
 [[package]]
 name = "wirerust"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wirerust"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2024"
 rust-version = "1.91"
 description = "Fast PCAP forensics and network triage CLI tool"

--- a/docs/adr/0003-reporting-pipeline-layering.md
+++ b/docs/adr/0003-reporting-pipeline-layering.md
@@ -360,6 +360,222 @@ Wireshark model and avoids the syslog anti-pattern.
 
 ---
 
+## Render-Mode Enum (Issue #62 — v0.9.0)
+
+**Status of this subsection:** Accepted (F2 spec evolution 2026-06-17; F3 scope correction 2026-06-18)
+
+### Context
+
+v0.8.0 shipped `TerminalReporter` with four boolean fields:
+
+```rust
+pub struct TerminalReporter {
+    pub use_color: bool,
+    pub show_mitre_grouping: bool,
+    pub show_hosts_breakdown: bool,
+    pub collapse_findings: bool,
+}
+```
+
+The issue #62 trigger condition ("when a 3rd render flag is added") fired when STORY-118
+(issue #259) added `collapse_findings`. Two concrete illegal-state violations resulted:
+
+1. **Nonsensical combination** (`show_mitre_grouping = true && collapse_findings = true`)
+   is a representable struct value. The type permits it; the code silently ignores
+   `collapse_findings` when `show_mitre_grouping` is true (dispatch-order enforcement only).
+   The BC-2.11.025 invariant is encoded in comments and dispatch order, not the type system.
+
+2. **Inert-value comment** at `main.rs` `run_summary`: `collapse_findings: true` with a
+   comment explaining the value does not matter. The type cannot express "irrelevant in this
+   context."
+
+### Decision
+
+**Replace `show_mitre_grouping: bool` and `collapse_findings: bool` with
+`render: FindingsRender` — a three-variant enum that makes the mutually-exclusive
+rendering modes unrepresentable as invalid combinations.**
+
+```rust
+/// Governs which rendering path the FINDINGS section uses.
+///
+/// Replaces `show_mitre_grouping: bool` + `collapse_findings: bool`
+/// from v0.8.0. The previous struct admitted `show_mitre_grouping = true
+/// && collapse_findings = true`, which was silently handled by dispatch
+/// order but was never a valid state.
+///
+/// BC-2.11.013 (Grouped), BC-2.11.025–028 (FlatCollapsed), default (FlatExpanded).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FindingsRender {
+    /// Group findings by MITRE tactic (`--mitre` flag).
+    /// Corresponds to the previous `show_mitre_grouping = true`.
+    Grouped,
+    /// Collapse repeated findings into counted groups (default, v0.8.0+).
+    /// Corresponds to the previous `collapse_findings = true, show_mitre_grouping = false`.
+    FlatCollapsed,
+    /// One display line per raw finding (pre-v0.8.0 behavior, `--no-collapse`).
+    /// Corresponds to the previous `collapse_findings = false, show_mitre_grouping = false`.
+    FlatExpanded,
+}
+
+pub struct TerminalReporter {
+    pub use_color: bool,
+    pub show_hosts_breakdown: bool,
+    pub render: FindingsRender,
+}
+```
+
+### Rationale: Illegal-State Elimination is the Primary Driver
+
+The decisive justification is **illegal-state elimination** — making the
+`show_mitre_grouping = true && collapse_findings = true` combination unrepresentable at the
+type level. Rust's `match` exhaustiveness then enforces that every call site handles all
+three modes explicitly, replacing the fragile `if/else if` dispatch chain.
+
+The Clippy `fn_params_excessive_bools` lint (`max-fn-params-bools` default: `3`) provides
+corroborating tooling consensus (the current four bools exceed the machine-enforced
+threshold) but is not the primary driver. The illegal-state argument is decisive on its own:
+two mutually-exclusive bools encode `2^2 = 4` representable states, of which only 3 are
+valid. The enum encodes exactly 3 states and no others.
+
+This is confirmed by external research (`.factory/research/issue-62-enum-modes-design-validation.md`):
+- Rust API Guidelines C-NEWTYPE recommends deliberate types when invariants exist.
+- "Parse, don't validate" (Alexis King): enums over bool-pairs when combinations matter.
+- Clippy's machine-enforced default threshold verified directly against rust-lang.org docs.
+
+### Why Orthogonal Flags Stay as Bools
+
+`use_color` and `show_hosts_breakdown` are **orthogonal** — all four combinations are valid
+and meaningful:
+
+- `use_color` applies uniformly across every output section (headers, findings, warnings).
+  It is controlled by `--no-color` and terminal detection, independent of how findings are
+  grouped. It is not part of the findings-render axis.
+- `show_hosts_breakdown` gates the HOSTS section, which is rendered before the FINDINGS
+  section and is independent of it. It is used by the `summary` subcommand, which never
+  renders a FINDINGS section at all — making `FindingsRender` irrelevant for that path.
+
+Folding either into `FindingsRender` would be a category error: it would create combinations
+that are semantically incoherent (e.g., `FindingsRender::GroupedWithColor`) and would
+introduce new illegal states rather than eliminating them.
+
+The hybrid design — one enum for the mutually-exclusive axis, two bools for orthogonal
+toggles — is confirmed as the idiomatic Rust recommendation by research Q3: "Keep genuinely
+orthogonal booleans as separate, clearly-named fields while extracting only the
+mutually-exclusive axis into an enum."
+
+### Migration Map
+
+Every construction site translates old bool pairs to enum variants as follows:
+
+| Old fields | New field | Notes |
+|-----------|-----------|-------|
+| `show_mitre_grouping: true, collapse_findings: false` | `render: FindingsRender::Grouped` | — |
+| `show_mitre_grouping: true, collapse_findings: true` | `render: FindingsRender::Grouped` | Was previously nonsensical; grouped wins per dispatch order |
+| `show_mitre_grouping: false, collapse_findings: true` | `render: FindingsRender::FlatCollapsed` | — |
+| `show_mitre_grouping: false, collapse_findings: false` | `render: FindingsRender::FlatExpanded` | Pre-v0.8.0 behavior |
+
+The `--mitre` / `--no-collapse` → bool resolution stays at the `main()` call site
+(`src/main.rs` lines 79-80), unchanged by this refactor:
+
+```rust
+// main() call site — unchanged:
+*mitre,                              // → show_mitre_grouping: bool
+collapse_findings_from_flag(*no_collapse),  // → collapse_findings: bool
+```
+
+Inside `run_analyze`, the in-scope parameters are `show_mitre_grouping: bool` and
+`collapse_findings: bool` (function signature `src/main.rs` lines 107-108).
+The `run_analyze` signature is unchanged. The bool → enum translation at the
+`TerminalReporter` construction site (`src/main.rs` ~line 373) becomes:
+
+```rust
+// at the TerminalReporter construction site inside run_analyze;
+// show_mitre_grouping and collapse_findings are the in-scope params:
+render: if show_mitre_grouping {
+    FindingsRender::Grouped
+} else if collapse_findings {
+    FindingsRender::FlatCollapsed
+} else {
+    FindingsRender::FlatExpanded
+},
+```
+
+`collapse_findings_from_flag` is unchanged. `show_mitre_grouping` is `true` exactly
+when `*mitre` is `true`; `collapse_findings` is `true` exactly when `!no_collapse`
+is `true`. The observable behavior is identical to the migration table above.
+
+The `run_summary` inert-value site (`collapse_findings: true` with comment) becomes
+`render: FindingsRender::FlatCollapsed` — structurally expressing "if this reporter
+were ever used to render findings, it would use the v0.8.0 default."
+
+### Semver Consequence: v0.8.x → v0.9.0
+
+Removing the public fields `show_mitre_grouping` and `collapse_findings` and adding the
+public field `render: FindingsRender` is a **breaking change** to the public struct API.
+Under Cargo's SemVer model and RFC 1105, removing or replacing a reachable public field is
+classified as a major (breaking) change. For a `0.y.z` crate, the `y` component is the
+breaking component; `0.8.x → 0.9.0` is therefore the correct and required version bump.
+
+This is confirmed by research Q4 (verified directly against `doc.rust-lang.org/cargo/
+reference/semver.html` and RFC 1105). The caret specifier `"0.8.x"` in `Cargo.toml`
+resolves to `>=0.8.x, <0.9.0`, so consumers pinned in the 0.8.x line will not auto-receive
+0.9.0 — the intended containment behavior for a breaking change.
+
+The `cargo-semver-checks` `struct_field_missing` lint will fire as expected when run against
+the 0.8.x baseline. This is correct, not a defect. The recommendation from research is to
+run `cargo-semver-checks` in the release flow to make the classification machine-visible.
+
+### `Default` Derive: Deliberate Omission
+
+`Default` is **NOT derived** on `FindingsRender`. Rationale:
+
+RFC 3107 permits `#[derive(Default)]` with `#[default]` on a unit variant. The natural
+candidate would be `FlatCollapsed` (matching today's default `analyze` behavior). However:
+
+- Deriving `Default` makes the default variant part of the public stability commitment.
+  Changing it post-0.9.0 would be a silent behavioral break not caught by the compiler or
+  `cargo-semver-checks`.
+- The current codebase has exactly two construction paths (`run_analyze` and `run_summary`),
+  both of which set `render` explicitly. There is no site that would benefit from a
+  `Default::default()` call — all sites carry enough context to pick the correct variant.
+- Explicit construction is preferable here: `render: FindingsRender::FlatCollapsed` at each
+  site documents the intent, whereas `Default::default()` would obscure which variant is
+  being selected.
+
+If a future caller needs a default (e.g., a test helper builder pattern), `Default` can be
+added then as a documented, deliberate API commitment. It is backwards-compatible to add
+`Default` in a later minor release; it is not backwards-compatible to change the default
+variant after the fact.
+
+### Binding Rule
+
+> **Rule 5 (render-mode type):** `TerminalReporter`'s findings rendering mode MUST be
+> expressed as `FindingsRender`. Adding a new rendering mode requires adding a new variant
+> to `FindingsRender` and updating all exhaustive `match` arms. A bool field on
+> `TerminalReporter` that encodes a mutually-exclusive rendering mode is prohibited; such a
+> field MUST be folded into `FindingsRender` or a successor enum. Orthogonal toggles
+> (properties that do not create illegal states when combined with existing fields) MAY
+> remain as bool fields.
+
+### Alternatives Considered
+
+**Pre-split for STORY-119 (grouped-mode collapse):** Add `GroupedCollapsed` and
+`GroupedExpanded` variants now, anticipating a future feature. Rejected as YAGNI — the
+STORY-119 cycle will have its own F1/F2 and can amend the enum at that time. The current
+three-variant enum exactly models the current three modes with no phantom states.
+
+**Builder / typestate pattern:** A `TerminalReporterBuilder` with typestate enforcement.
+Warranted for multi-step construction with cross-field invariants. Rejected: `TerminalReporter`
+construction is one-shot mode selection with no sequenced protocol. A plain enum is the
+correct, minimal tool.
+
+**Remain as bools, add documentation only:** The existing dispatch-order invariant is already
+documented in comments and BCs. Rejected: the illegal state is still constructible; the
+compiler provides no enforcement; new contributors can silently violate the invariant. The
+type-system fix is strictly superior.
+
+---
+
 ## Validation
 
 This decision was validated through targeted Perplexity queries on 2026-04-08:

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,7 +37,7 @@ use wirerust::reassembly::{ReassemblyConfig, TcpReassembler};
 use wirerust::reporter::Reporter;
 use wirerust::reporter::csv::CsvReporter;
 use wirerust::reporter::json::JsonReporter;
-use wirerust::reporter::terminal::TerminalReporter;
+use wirerust::reporter::terminal::{FindingsRender, TerminalReporter};
 use wirerust::summary::Summary;
 
 fn main() -> Result<()> {
@@ -372,14 +372,19 @@ fn run_analyze(
         _ => {
             let reporter = TerminalReporter {
                 use_color,
-                show_mitre_grouping,
                 // `analyze` does not expose a per-host breakdown flag —
                 // that is `summary`-subcommand-only (LESSON-P1.03).
                 show_hosts_breakdown: false,
-                // BC-2.11.028: `collapse_findings = !no_collapse`.
-                // Wired from `--no-collapse` flag: true → collapse OFF; false → collapse ON.
-                // Mirrors exactly how `*mitre` becomes `show_mitre_grouping`.
-                collapse_findings,
+                // BC-2.11.028: three-way render mode selection.
+                // show_mitre_grouping wins over collapse_findings (same precedence as
+                // the pre-v0.9.0 if-chain dispatch order).
+                render: if show_mitre_grouping {
+                    FindingsRender::Grouped
+                } else if collapse_findings {
+                    FindingsRender::FlatCollapsed
+                } else {
+                    FindingsRender::FlatExpanded
+                },
             };
             reporter.render(&summary, &all_findings, &analyzer_summaries)
         }
@@ -438,13 +443,10 @@ fn run_summary(
         _ => {
             let reporter = TerminalReporter {
                 use_color,
-                show_mitre_grouping: false,
                 show_hosts_breakdown,
-                // BC-2.11.028 invariant 4: `run_summary` emits no FINDINGS section;
-                // this value is inert. Set to `true` for completeness (Rust requires
-                // all struct fields to be initialized). Collapse is analyze-scoped;
-                // run_summary emits no FINDINGS section (BC-2.11.028 invariant 4).
-                collapse_findings: true,
+                // BC-2.11.028 invariant 4: render field is inert for run_summary — no FINDINGS section.
+                // FlatCollapsed expresses the v0.8.0 default intent for any hypothetical future use.
+                render: FindingsRender::FlatCollapsed,
             };
             reporter.render(&summary, &[], &[])
         }

--- a/src/reporter/terminal.rs
+++ b/src/reporter/terminal.rs
@@ -2,10 +2,13 @@
 //!
 //! Renders the capture summary, per-host breakdown (gated by
 //! `show_hosts_breakdown` per LESSON-P1.03), protocols, services,
-//! findings, and per-analyzer detail tables for TTY output. Optional
-//! MITRE-tactic grouping (`show_mitre_grouping`) reorganizes the
-//! FINDINGS section by MITRE ATT&CK tactic and expands each finding's
-//! MITRE line with the technique name from [`crate::mitre`].
+//! findings, and per-analyzer detail tables for TTY output. The
+//! `render: FindingsRender` field selects among three mutually-exclusive
+//! FINDINGS rendering modes: `Grouped` (MITRE tactic grouping, `--mitre`),
+//! `FlatCollapsed` (default v0.8.0+), and `FlatExpanded` (`--no-collapse`).
+//! MITRE-tactic grouping reorganizes the FINDINGS section by MITRE ATT&CK
+//! tactic and expands each finding's MITRE line with the technique name from
+//! [`crate::mitre`].
 //!
 //! Per ADR 0003 (`docs/adr/0003-reporting-pipeline-layering.md`), every
 //! attacker-controlled string (Finding `summary`/`evidence`, analyzer
@@ -88,11 +91,27 @@ struct CollapseKey {
     summary: String,
 }
 
+/// Render mode for the FINDINGS section of a terminal report.
+///
+/// Encodes the three mutually-exclusive rendering modes as a single enum,
+/// eliminating the impossible state `show_mitre_grouping = true &&
+/// collapse_findings = true` that existed in v0.8.0.
+/// ADR-0003 Binding Rule 5 — Render-Mode Enum (Issue #62 — v0.9.0).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FindingsRender {
+    /// Group findings by MITRE tactic (`--mitre` flag).
+    /// Corresponds to the previous `show_mitre_grouping = true`.
+    Grouped,
+    /// Collapse repeated findings into counted groups (default, v0.8.0+).
+    /// Corresponds to the previous `collapse_findings = true, show_mitre_grouping = false`.
+    FlatCollapsed,
+    /// One display line per raw finding (pre-v0.8.0 behavior, `--no-collapse`).
+    /// Corresponds to the previous `collapse_findings = false, show_mitre_grouping = false`.
+    FlatExpanded,
+}
+
 pub struct TerminalReporter {
     pub use_color: bool,
-    /// When true, regroup the FINDINGS section by MITRE tactic and expand
-    /// the per-finding MITRE line to include the technique name.
-    pub show_mitre_grouping: bool,
     /// When true, render a per-host breakdown section listing each
     /// unique source/destination IP observed in the capture. Wired
     /// from the `summary` subcommand's `--hosts` flag — see
@@ -100,14 +119,10 @@ pub struct TerminalReporter {
     /// always-present `Hosts: N` count line in the header is shown
     /// regardless; this gate only controls the expanded itemized list.
     pub show_hosts_breakdown: bool,
-    /// When true (the default), repeated findings sharing the same
-    /// `(category, verdict, confidence, summary)` four-tuple are collapsed
-    /// into a single display group with a ` (xN)` count suffix (N≥2).
-    /// Singletons (N=1) render byte-identically to pre-v0.8.0 output.
-    /// Collapse applies ONLY in flat mode (`show_mitre_grouping = false`).
-    /// Wired from `--no-collapse` flag: `collapse_findings = !no_collapse`.
-    /// BC-2.11.025 / BC-2.11.026 / BC-2.11.027 / BC-2.11.028.
-    pub collapse_findings: bool,
+    /// Render mode for the FINDINGS section. Controls mutual exclusion between
+    /// MITRE grouping, flat-collapsed, and flat-expanded rendering.
+    /// ADR-0003 Binding Rule 5; BC-2.11.025 / BC-2.11.026 / BC-2.11.027 / BC-2.11.028.
+    pub render: FindingsRender,
 }
 
 impl Reporter for TerminalReporter {
@@ -184,23 +199,27 @@ impl Reporter for TerminalReporter {
         // Findings
         if !findings.is_empty() {
             out.push_str(&self.section("FINDINGS"));
-            if self.show_mitre_grouping {
-                // Grouped (--mitre) path: structurally suffix-free per BC-2.11.025
-                // invariant 5. STORY-118 does NOT modify this path — collapse applies
-                // only in flat mode. render_finding_prefix stays unchanged.
-                self.render_findings_grouped(&mut out, findings);
-            } else if self.collapse_findings {
-                // Flat + collapse path (STORY-118 / BC-2.11.025 / BC-2.11.026 /
-                // BC-2.11.027): groups findings by CollapseKey in first-occurrence
-                // order, renders each group with optional (xN) suffix and up to K=3
-                // sampled evidence lines.
-                self.render_findings_collapsed(&mut out, findings);
-            } else {
-                // Per ADR 0003: the Finding struct stores raw bytes; the
-                // terminal reporter is responsible for escaping untrusted
-                // content (summary + evidence) before writing to a TTY.
-                for f in findings {
-                    self.render_finding_flat(&mut out, f);
+            match self.render {
+                FindingsRender::Grouped => {
+                    // Grouped (--mitre) path: structurally suffix-free per BC-2.11.025
+                    // invariant 5. Collapse does not apply — impossible state eliminated
+                    // by type. render_finding_prefix stays unchanged.
+                    self.render_findings_grouped(&mut out, findings);
+                }
+                FindingsRender::FlatCollapsed => {
+                    // Flat + collapse path (STORY-118 / BC-2.11.025 / BC-2.11.026 /
+                    // BC-2.11.027): groups findings by CollapseKey in first-occurrence
+                    // order, renders each group with optional (xN) suffix and up to K=3
+                    // sampled evidence lines.
+                    self.render_findings_collapsed(&mut out, findings);
+                }
+                FindingsRender::FlatExpanded => {
+                    // Per ADR 0003: the Finding struct stores raw bytes; the
+                    // terminal reporter is responsible for escaping untrusted
+                    // content (summary + evidence) before writing to a TTY.
+                    for f in findings {
+                        self.render_finding_flat(&mut out, f);
+                    }
                 }
             }
             out.push('\n');

--- a/tests/bc_2_09_100_multitag_tests.rs
+++ b/tests/bc_2_09_100_multitag_tests.rs
@@ -35,7 +35,7 @@ use wirerust::mitre::{MitreTactic, technique_name, technique_tactic};
 use wirerust::reporter::Reporter;
 use wirerust::reporter::csv::CsvReporter;
 use wirerust::reporter::json::JsonReporter;
-use wirerust::reporter::terminal::TerminalReporter;
+use wirerust::reporter::terminal::{FindingsRender, TerminalReporter};
 use wirerust::summary::Summary;
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -689,10 +689,9 @@ fn test_BC_2_11_001_mitre_attack_version_constant_has_f4_pin_flag_comment() {
 fn make_terminal(mitre_grouping: bool) -> TerminalReporter {
     TerminalReporter {
         use_color: false,
-        show_mitre_grouping: mitre_grouping,
         show_hosts_breakdown: false,
-        // STORY-118: new field; false = pre-v0.8.0 non-collapse path
-        collapse_findings: false,
+        // STORY-120: parameterized — mitre_grouping ? Grouped : FlatExpanded
+        render: if mitre_grouping { FindingsRender::Grouped } else { FindingsRender::FlatExpanded },
     }
 }
 

--- a/tests/bc_2_09_100_multitag_tests.rs
+++ b/tests/bc_2_09_100_multitag_tests.rs
@@ -691,7 +691,11 @@ fn make_terminal(mitre_grouping: bool) -> TerminalReporter {
         use_color: false,
         show_hosts_breakdown: false,
         // STORY-120: parameterized — mitre_grouping ? Grouped : FlatExpanded
-        render: if mitre_grouping { FindingsRender::Grouped } else { FindingsRender::FlatExpanded },
+        render: if mitre_grouping {
+            FindingsRender::Grouped
+        } else {
+            FindingsRender::FlatExpanded
+        },
     }
 }
 
@@ -762,7 +766,7 @@ fn test_BC_2_11_015_terminal_unknown_id_lands_in_uncategorized() {
 
 /// BC-2.11.017 postcondition, AC-002 (STORY-101):
 /// Two-technique finding renders as `"MITRE: T1692.001, T0836"` (comma-space join).
-/// Flat view (show_mitre_grouping=false).
+/// Flat view (render=FindingsRender::FlatExpanded).
 #[test]
 fn test_BC_2_11_017_terminal_renders_multi_id_mitre_string() {
     let f = make_finding_multitag(vec!["T1692.001", "T0836"]);

--- a/tests/dnp3_f5_remediation_tests.rs
+++ b/tests/dnp3_f5_remediation_tests.rs
@@ -993,7 +993,7 @@ mod f5_ics_impact_display {
     use wirerust::findings::{Confidence, Finding, ThreatCategory, Verdict};
     use wirerust::mitre::{MitreTactic, all_tactics_in_report_order};
     use wirerust::reporter::Reporter;
-    use wirerust::reporter::terminal::TerminalReporter;
+    use wirerust::reporter::terminal::{FindingsRender, TerminalReporter};
     use wirerust::summary::Summary;
 
     // -----------------------------------------------------------------------
@@ -1069,10 +1069,9 @@ mod f5_ics_impact_display {
     fn mitre_reporter() -> TerminalReporter {
         TerminalReporter {
             use_color: false,
-            show_mitre_grouping: true,
             show_hosts_breakdown: false,
-            // STORY-118: new field; false here — grouped mode does not apply collapse.
-            collapse_findings: false,
+            // STORY-120: render = FindingsRender::Grouped (grouped helper)
+            render: FindingsRender::Grouped,
         }
     }
 

--- a/tests/reporter_terminal_tests.rs
+++ b/tests/reporter_terminal_tests.rs
@@ -3959,144 +3959,252 @@ mod story_118 {
 // ---------------------------------------------------------------------------
 
 mod story_120 {
-    // Inherit the allow(non_snake_case) from the file-level attribute so
-    // test_BC_* names compile without a separate inner attribute.
-    //
-    // Imports are unused now (todo!() bodies) but will be needed by the
-    // implementer during GREEN. Suppress the lint so the file remains clean
-    // under `cargo check --all-targets` with RUSTFLAGS=-Dwarnings.
-    #![allow(unused_imports)]
-
     use wirerust::findings::{Confidence, Finding, ThreatCategory, Verdict};
     use wirerust::reporter::Reporter;
-    use wirerust::reporter::terminal::TerminalReporter;
+    use wirerust::reporter::terminal::{FindingsRender, TerminalReporter};
     use wirerust::summary::Summary;
+
+    fn make_finding_s120(summary: impl Into<String>) -> Finding {
+        Finding {
+            category: ThreatCategory::Anomaly,
+            verdict: Verdict::Inconclusive,
+            confidence: Confidence::Low,
+            summary: summary.into(),
+            evidence: vec![],
+            mitre_techniques: vec![],
+            source_ip: None,
+            timestamp: None,
+            direction: None,
+        }
+    }
+
+    fn make_mitre_finding_s120(summary: impl Into<String>) -> Finding {
+        Finding {
+            category: ThreatCategory::Anomaly,
+            verdict: Verdict::Likely,
+            confidence: Confidence::High,
+            summary: summary.into(),
+            evidence: vec![],
+            mitre_techniques: vec!["T1046".to_string()],
+            source_ip: None,
+            timestamp: None,
+            direction: None,
+        }
+    }
 
     // -----------------------------------------------------------------------
     // AC-001 — FindingsRender derives Debug, Clone, Copy, PartialEq, Eq
     // (traces to BC-2.11.025 invariant 5, BC-2.11.013 invariant 4)
-    //
-    // Intended assertion (implementer fills in during GREEN):
-    //   - Confirm `FindingsRender` satisfies `Debug + Clone + Copy + PartialEq + Eq`
-    //     by asserting equality, cloning, and debug-formatting all three variants.
-    //   - Assert the enum has exactly three variants (Grouped, FlatCollapsed,
-    //     FlatExpanded) and that `Default` is NOT derived (no Default impl).
     // -----------------------------------------------------------------------
+
+    /// AC-001 (BC-2.11.025 invariant 5, BC-2.11.013 invariant 4):
+    /// FindingsRender satisfies Debug + Clone + Copy + PartialEq + Eq.
+    /// The enum has exactly three variants and no Default impl.
     #[test]
     fn test_findings_render_derives_debug_clone_copy_partialeq_eq() {
-        // RED: FindingsRender does not exist yet — todo!() panics to satisfy Red Gate.
-        // GREEN: replace with:
-        //   let a = FindingsRender::Grouped;
-        //   let b = a;                          // Copy
-        //   let c = a.clone();                  // Clone
-        //   assert_eq!(a, b);                   // PartialEq + Eq
-        //   let _ = format!("{a:?}");           // Debug
-        //   assert_ne!(a, FindingsRender::FlatCollapsed);
-        //   assert_ne!(a, FindingsRender::FlatExpanded);
-        todo!(
-            "AC-001: verify FindingsRender derives Debug+Clone+Copy+PartialEq+Eq \
-             and has exactly three variants; implement after enum is defined"
-        )
+        let a = FindingsRender::Grouped;
+        let b = a; // Copy
+        let c = a.clone(); // Clone
+        assert_eq!(a, b, "PartialEq + Eq: Grouped == copied Grouped");
+        assert_eq!(a, c, "PartialEq + Eq: Grouped == cloned Grouped");
+        let _ = format!("{a:?}"); // Debug — would panic if not implemented
+
+        // All three variants are distinct.
+        assert_ne!(
+            FindingsRender::Grouped,
+            FindingsRender::FlatCollapsed,
+            "Grouped != FlatCollapsed"
+        );
+        assert_ne!(
+            FindingsRender::Grouped,
+            FindingsRender::FlatExpanded,
+            "Grouped != FlatExpanded"
+        );
+        assert_ne!(
+            FindingsRender::FlatCollapsed,
+            FindingsRender::FlatExpanded,
+            "FlatCollapsed != FlatExpanded"
+        );
+
+        // Debug formats include the variant name.
+        assert!(format!("{:?}", FindingsRender::Grouped).contains("Grouped"));
+        assert!(format!("{:?}", FindingsRender::FlatCollapsed).contains("FlatCollapsed"));
+        assert!(format!("{:?}", FindingsRender::FlatExpanded).contains("FlatExpanded"));
     }
 
     // -----------------------------------------------------------------------
     // AC-002 — TerminalReporter struct has exactly 3 fields after refactor
     // (traces to BC-2.11.028 precondition 3 — struct shape governs render wiring)
-    //
-    // Intended assertion (implementer fills in during GREEN):
-    //   - Construct TerminalReporter with exactly {use_color, show_hosts_breakdown,
-    //     render} and verify it compiles (struct-literal exhaustiveness is the gate).
-    //   - Assert that neither `show_mitre_grouping` nor `collapse_findings` appear
-    //     as fields (any reference to them is a compile error after STORY-120).
     // -----------------------------------------------------------------------
+
+    /// AC-002 (BC-2.11.028 precondition 3):
+    /// TerminalReporter has exactly 3 fields: use_color, show_hosts_breakdown, render.
+    /// This test compiles only if the struct has exactly those fields — any reference
+    /// to removed fields show_mitre_grouping or collapse_findings is a compile error.
     #[test]
     fn test_BC_2_11_028_struct_has_exactly_three_fields_post_refactor() {
-        // RED: the struct still has four bool fields; the intended three-field
-        // construction (with render: FindingsRender) does not compile yet.
-        // GREEN: replace with a TerminalReporter literal using only:
-        //   use_color, show_hosts_breakdown, render: FindingsRender::FlatExpanded
-        // and assert that cargo check passes (the compile itself is the assertion).
-        todo!(
-            "AC-002: verify TerminalReporter has exactly 3 fields \
-             (use_color, show_hosts_breakdown, render: FindingsRender); \
-             implement after struct is refactored"
-        )
+        // The struct literal below is the test: it compiles if and only if exactly
+        // these three fields exist on TerminalReporter (Rust requires all fields in a
+        // struct literal; extra fields are also a compile error).
+        let r = TerminalReporter {
+            use_color: false,
+            show_hosts_breakdown: false,
+            render: FindingsRender::FlatExpanded,
+        };
+        // The struct renders fine (behavioral sanity).
+        let out = r.render(&Summary::new(), &[], &[]);
+        assert!(
+            out.contains("WIRERUST TRIAGE REPORT"),
+            "three-field TerminalReporter renders a valid report; got: {out}"
+        );
     }
 
     // -----------------------------------------------------------------------
     // AC-003 — Dispatch is an exhaustive match over FindingsRender
     // (traces to BC-2.11.019 invariant 7)
-    //
-    // Intended assertion (implementer fills in during GREEN):
-    //   - Render through all three FindingsRender variants with the same input
-    //     and assert each reaches the correct rendering path:
-    //       Grouped      → output contains "## " tactic header (grouped path)
-    //       FlatCollapsed → output contains "(x3)" suffix for N=3 identical findings
-    //       FlatExpanded  → output does NOT contain "(x" and has 3 individual lines
-    //   - Relies on exhaustive match compile-time guarantee (no arm can be omitted).
     // -----------------------------------------------------------------------
+
+    /// AC-003 (BC-2.11.019 invariant 7):
+    /// All three FindingsRender arms are reachable and route to the correct rendering path.
+    ///   Grouped       → MITRE tactic header "## " in output
+    ///   FlatCollapsed → "(x3)" suffix for N=3 identical findings
+    ///   FlatExpanded  → 3 individual header lines, no "(x" suffix
     #[test]
     fn test_BC_2_11_019_findings_dispatch_match_exhaustive() {
-        // RED: FindingsRender does not exist; todo!() panics to satisfy Red Gate.
-        // GREEN: replace with three reporter constructions using each variant
-        // and behavioral assertions for each rendering path.
-        todo!(
-            "AC-003: verify all three FindingsRender arms are reachable and route \
-             to the correct rendering helper; implement after match dispatch is added"
-        )
+        // Three identical-key findings with a known MITRE technique for the Grouped path.
+        let findings: Vec<Finding> = (0..3)
+            .map(|_| make_mitre_finding_s120("dispatch-test"))
+            .collect();
+
+        // Grouped arm: calls render_findings_grouped → emits "## " tactic header.
+        let grouped_out = TerminalReporter {
+            use_color: false,
+            show_hosts_breakdown: false,
+            render: FindingsRender::Grouped,
+        }
+        .render(&Summary::new(), &findings, &[]);
+        assert!(
+            grouped_out.contains("## "),
+            "AC-003: Grouped arm must emit a tactic header (## ...); got:\n{grouped_out}"
+        );
+
+        // FlatCollapsed arm: calls render_findings_collapsed → emits "(x3)" suffix.
+        let collapsed_out = TerminalReporter {
+            use_color: false,
+            show_hosts_breakdown: false,
+            render: FindingsRender::FlatCollapsed,
+        }
+        .render(&Summary::new(), &findings, &[]);
+        assert!(
+            collapsed_out.contains("(x3)"),
+            "AC-003: FlatCollapsed arm must emit '(x3)' for 3 identical-key findings; \
+             got:\n{collapsed_out}"
+        );
+
+        // FlatExpanded arm: iterates render_finding_flat → 3 individual header lines, no (x.
+        let expanded_out = TerminalReporter {
+            use_color: false,
+            show_hosts_breakdown: false,
+            render: FindingsRender::FlatExpanded,
+        }
+        .render(&Summary::new(), &findings, &[]);
+        assert!(
+            !expanded_out.contains("(x"),
+            "AC-003: FlatExpanded arm must not emit (xN) suffix; got:\n{expanded_out}"
+        );
+        let header_count = expanded_out.matches("dispatch-test").count();
+        assert_eq!(
+            header_count, 3,
+            "AC-003: FlatExpanded arm must emit 3 individual finding lines; \
+             found {header_count} in:\n{expanded_out}"
+        );
+
+        // All three outputs are mutually distinct.
+        assert_ne!(grouped_out, collapsed_out, "AC-003: Grouped != FlatCollapsed output");
+        assert_ne!(grouped_out, expanded_out, "AC-003: Grouped != FlatExpanded output");
+        assert_ne!(collapsed_out, expanded_out, "AC-003: FlatCollapsed != FlatExpanded output");
     }
 
     // -----------------------------------------------------------------------
-    // AC-004 — Impossible state (Grouped + collapsed simultaneously)
-    //          is structurally unrepresentable after STORY-120
+    // AC-004 — Impossible state (Grouped + collapsed) is structurally unrepresentable
     // (traces to BC-2.11.025 invariant 5)
-    //
-    // Intended assertion (implementer fills in during GREEN):
-    //   - Confirm that `FindingsRender::Grouped` on N=100 identical-key findings
-    //     produces NO "(xN)" suffix anywhere in the output (collapse path not
-    //     reachable from the Grouped arm — the impossible state is gone by type).
-    //   - This corresponds to the former `mitre_collapse_reporter` construction
-    //     (show_mitre_grouping=true, collapse_findings=true) which now maps to
-    //     render: FindingsRender::Grouped cleanly.
     // -----------------------------------------------------------------------
+
+    /// AC-004 (BC-2.11.025 invariant 5):
+    /// FindingsRender::Grouped on N=100 identical-key findings produces no "(xN)" suffix.
+    /// The impossible state (show_mitre_grouping=true && collapse_findings=true) is
+    /// eliminated by type — FindingsRender::Grouped structurally excludes the collapse path.
     #[test]
     fn test_BC_2_11_025_grouped_mode_bypasses_collapse_structurally() {
-        // RED: FindingsRender does not exist; todo!() panics to satisfy Red Gate.
-        // GREEN: construct TerminalReporter { render: FindingsRender::Grouped, ... },
-        // render 100 identical-key findings, and assert no "(x" suffix appears.
-        todo!(
-            "AC-004: verify FindingsRender::Grouped never emits (xN) suffix — \
-             impossible state (Grouped + collapsed) is structurally unrepresentable; \
-             implement after enum and match dispatch are in place"
-        )
+        let findings: Vec<Finding> = (0..100)
+            .map(|_| make_mitre_finding_s120("grouped-collapse-impossible"))
+            .collect();
+
+        let out = TerminalReporter {
+            use_color: false,
+            show_hosts_breakdown: false,
+            render: FindingsRender::Grouped,
+        }
+        .render(&Summary::new(), &findings, &[]);
+
+        assert!(
+            !out.contains("(x"),
+            "AC-004: FindingsRender::Grouped must never emit (xN) suffix — \
+             impossible state is structurally unrepresentable; got:\n{out}"
+        );
+        // Grouped mode emits tactic headers (confirming the Grouped path ran, not collapsed).
+        assert!(
+            out.contains("## "),
+            "AC-004: FindingsRender::Grouped must emit tactic section headers; got:\n{out}"
+        );
     }
 
     // -----------------------------------------------------------------------
-    // AC-005 — run_analyze construction site wired correctly in main.rs
+    // AC-005 — render field wiring: FlatCollapsed vs FlatExpanded polarity
     // (traces to BC-2.11.028 postconditions 1–2, invariant 1)
-    //
-    // Intended assertion (implementer fills in during GREEN):
-    //   - Using FindingsRender::FlatCollapsed (collapse ON) vs FindingsRender::FlatExpanded
-    //     (collapse OFF) on N=3 identical-key findings produces different output
-    //     (FlatCollapsed emits "(x3)", FlatExpanded does not) — proving the render
-    //     field is wired correctly to the rendering path.
-    //   - This mirrors the run_analyze wiring intent:
-    //       render: if show_mitre_grouping { Grouped }
-    //               else if collapse_findings { FlatCollapsed }
-    //               else { FlatExpanded }
-    //   - Structural polarity test: FlatCollapsed != FlatExpanded output.
     // -----------------------------------------------------------------------
+
+    /// AC-005 (BC-2.11.028 postconditions 1–2, invariant 1):
+    /// FindingsRender::FlatCollapsed produces "(x3)" for 3 identical-key findings;
+    /// FindingsRender::FlatExpanded does not — proving the render field is wired
+    /// correctly to the rendering path. Mirrors the run_analyze construction intent.
     #[test]
     fn test_BC_2_11_028_flag_wired_to_render_field_post_enum() {
-        // RED: FindingsRender does not exist; todo!() panics to satisfy Red Gate.
-        // GREEN: construct two reporters — one with render: FindingsRender::FlatCollapsed
-        // and one with render: FindingsRender::FlatExpanded — render N=3 identical
-        // findings, and assert FlatCollapsed produces "(x3)" while FlatExpanded does not.
-        // Also assert the two outputs differ (polarity test mirrors run_analyze wiring).
-        todo!(
-            "AC-005: verify render: FindingsRender::FlatCollapsed produces collapse \
-             and FlatExpanded does not — proving the run_analyze wiring intent; \
-             implement after enum construction sites are updated"
-        )
+        let findings: Vec<Finding> = (0..3)
+            .map(|_| make_finding_s120("WiredTestPostEnum"))
+            .collect();
+
+        // FlatCollapsed → collapse active → "(x3)" suffix.
+        let out_collapsed = TerminalReporter {
+            use_color: false,
+            show_hosts_breakdown: false,
+            render: FindingsRender::FlatCollapsed,
+        }
+        .render(&Summary::new(), &findings, &[]);
+        assert!(
+            out_collapsed.contains("(x3)"),
+            "AC-005: FindingsRender::FlatCollapsed must produce '(x3)' for 3 identical \
+             findings; got:\n{out_collapsed}"
+        );
+
+        // FlatExpanded → collapse inactive → no "(x" suffix, 3 individual lines.
+        let out_expanded = TerminalReporter {
+            use_color: false,
+            show_hosts_breakdown: false,
+            render: FindingsRender::FlatExpanded,
+        }
+        .render(&Summary::new(), &findings, &[]);
+        assert!(
+            !out_expanded.contains("(x"),
+            "AC-005: FindingsRender::FlatExpanded must not produce (xN) suffix; \
+             got:\n{out_expanded}"
+        );
+
+        // Polarity: FlatCollapsed != FlatExpanded output for N≥2 identical-key input.
+        assert_ne!(
+            out_collapsed, out_expanded,
+            "AC-005: FlatCollapsed and FlatExpanded must produce different output \
+             for N≥2 identical-key findings"
+        );
     }
 }

--- a/tests/reporter_terminal_tests.rs
+++ b/tests/reporter_terminal_tests.rs
@@ -42,7 +42,7 @@ use wirerust::analyzer::AnalysisSummary;
 use wirerust::decoder::{ParsedPacket, Protocol, TransportInfo};
 use wirerust::findings::{Confidence, Finding, ThreatCategory, Verdict};
 use wirerust::reporter::Reporter;
-use wirerust::reporter::terminal::TerminalReporter;
+use wirerust::reporter::terminal::{FindingsRender, TerminalReporter};
 use wirerust::summary::Summary;
 
 // ---------------------------------------------------------------------------
@@ -70,9 +70,8 @@ fn make_finding(summary: impl Into<String>) -> Finding {
 fn plain_reporter() -> TerminalReporter {
     TerminalReporter {
         use_color: false,
-        show_mitre_grouping: false,
         show_hosts_breakdown: false,
-        collapse_findings: false,
+        render: FindingsRender::FlatExpanded,
     }
 }
 
@@ -661,9 +660,8 @@ mod story_078 {
     fn mitre_reporter() -> TerminalReporter {
         TerminalReporter {
             use_color: false,
-            show_mitre_grouping: true,
             show_hosts_breakdown: false,
-            collapse_findings: false,
+            render: FindingsRender::Grouped,
         }
     }
 
@@ -1788,9 +1786,8 @@ mod story_118 {
     fn collapse_reporter() -> TerminalReporter {
         TerminalReporter {
             use_color: false,
-            show_mitre_grouping: false,
             show_hosts_breakdown: false,
-            collapse_findings: true,
+            render: FindingsRender::FlatCollapsed,
         }
     }
 
@@ -1798,9 +1795,8 @@ mod story_118 {
     fn collapse_reporter_color() -> TerminalReporter {
         TerminalReporter {
             use_color: true,
-            show_mitre_grouping: false,
             show_hosts_breakdown: false,
-            collapse_findings: true,
+            render: FindingsRender::FlatCollapsed,
         }
     }
 
@@ -1808,9 +1804,8 @@ mod story_118 {
     fn mitre_collapse_reporter() -> TerminalReporter {
         TerminalReporter {
             use_color: false,
-            show_mitre_grouping: true,
             show_hosts_breakdown: false,
-            collapse_findings: true,
+            render: FindingsRender::Grouped,
         }
     }
 
@@ -3342,12 +3337,11 @@ mod story_118 {
             })
             .collect();
 
-        // Reporter with collapse_findings = true → produces "(x3)".
+        // Reporter with render = FindingsRender::FlatCollapsed → produces "(x3)".
         let reporter_on = TerminalReporter {
             use_color: false,
-            show_mitre_grouping: false,
             show_hosts_breakdown: false,
-            collapse_findings: true,
+            render: FindingsRender::FlatCollapsed,
         };
         let out_on = reporter_on.render(&Summary::new(), &findings, &[]);
         assert!(
@@ -3355,12 +3349,11 @@ mod story_118 {
             "BC-2.11.028 inv1: collapse_findings=true must produce '(x3)' suffix; got:\n{out_on}"
         );
 
-        // Reporter with collapse_findings = false → no collapse, no suffix.
+        // Reporter with render = FindingsRender::FlatExpanded → no collapse, no suffix.
         let reporter_off = TerminalReporter {
             use_color: false,
-            show_mitre_grouping: false,
             show_hosts_breakdown: false,
-            collapse_findings: false,
+            render: FindingsRender::FlatExpanded,
         };
         let out_off = reporter_off.render(&Summary::new(), &findings, &[]);
         assert!(
@@ -3944,5 +3937,166 @@ mod story_118 {
             "BC-2.11.026 supplementary: members[1] technique 'T1036' must not appear when \
              members[0].mitre_techniques=[]; got:\n{out}"
         );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// STORY-120 RED gate stubs
+//
+// These tests exercise new behaviors introduced by the FindingsRender enum
+// migration (STORY-120). All bodies are `todo!()` — they compile but panic
+// at runtime, satisfying the Red Gate density check (≥50% todo!() bodies).
+//
+// The implementer replaces each todo!() with real assertions during GREEN
+// after defining `pub enum FindingsRender { Grouped, FlatCollapsed,
+// FlatExpanded }` and updating `TerminalReporter` to use `render:
+// FindingsRender` in place of `show_mitre_grouping: bool` and
+// `collapse_findings: bool`.
+//
+// DO NOT reference the `FindingsRender` type here — it does not yet exist.
+// Construction sites remain as `todo!()` prose descriptions so the file
+// compiles against the current (pre-enum) struct shape.
+// ---------------------------------------------------------------------------
+
+mod story_120 {
+    // Inherit the allow(non_snake_case) from the file-level attribute so
+    // test_BC_* names compile without a separate inner attribute.
+    //
+    // Imports are unused now (todo!() bodies) but will be needed by the
+    // implementer during GREEN. Suppress the lint so the file remains clean
+    // under `cargo check --all-targets` with RUSTFLAGS=-Dwarnings.
+    #![allow(unused_imports)]
+
+    use wirerust::findings::{Confidence, Finding, ThreatCategory, Verdict};
+    use wirerust::reporter::Reporter;
+    use wirerust::reporter::terminal::TerminalReporter;
+    use wirerust::summary::Summary;
+
+    // -----------------------------------------------------------------------
+    // AC-001 — FindingsRender derives Debug, Clone, Copy, PartialEq, Eq
+    // (traces to BC-2.11.025 invariant 5, BC-2.11.013 invariant 4)
+    //
+    // Intended assertion (implementer fills in during GREEN):
+    //   - Confirm `FindingsRender` satisfies `Debug + Clone + Copy + PartialEq + Eq`
+    //     by asserting equality, cloning, and debug-formatting all three variants.
+    //   - Assert the enum has exactly three variants (Grouped, FlatCollapsed,
+    //     FlatExpanded) and that `Default` is NOT derived (no Default impl).
+    // -----------------------------------------------------------------------
+    #[test]
+    fn test_findings_render_derives_debug_clone_copy_partialeq_eq() {
+        // RED: FindingsRender does not exist yet — todo!() panics to satisfy Red Gate.
+        // GREEN: replace with:
+        //   let a = FindingsRender::Grouped;
+        //   let b = a;                          // Copy
+        //   let c = a.clone();                  // Clone
+        //   assert_eq!(a, b);                   // PartialEq + Eq
+        //   let _ = format!("{a:?}");           // Debug
+        //   assert_ne!(a, FindingsRender::FlatCollapsed);
+        //   assert_ne!(a, FindingsRender::FlatExpanded);
+        todo!(
+            "AC-001: verify FindingsRender derives Debug+Clone+Copy+PartialEq+Eq \
+             and has exactly three variants; implement after enum is defined"
+        )
+    }
+
+    // -----------------------------------------------------------------------
+    // AC-002 — TerminalReporter struct has exactly 3 fields after refactor
+    // (traces to BC-2.11.028 precondition 3 — struct shape governs render wiring)
+    //
+    // Intended assertion (implementer fills in during GREEN):
+    //   - Construct TerminalReporter with exactly {use_color, show_hosts_breakdown,
+    //     render} and verify it compiles (struct-literal exhaustiveness is the gate).
+    //   - Assert that neither `show_mitre_grouping` nor `collapse_findings` appear
+    //     as fields (any reference to them is a compile error after STORY-120).
+    // -----------------------------------------------------------------------
+    #[test]
+    fn test_BC_2_11_028_struct_has_exactly_three_fields_post_refactor() {
+        // RED: the struct still has four bool fields; the intended three-field
+        // construction (with render: FindingsRender) does not compile yet.
+        // GREEN: replace with a TerminalReporter literal using only:
+        //   use_color, show_hosts_breakdown, render: FindingsRender::FlatExpanded
+        // and assert that cargo check passes (the compile itself is the assertion).
+        todo!(
+            "AC-002: verify TerminalReporter has exactly 3 fields \
+             (use_color, show_hosts_breakdown, render: FindingsRender); \
+             implement after struct is refactored"
+        )
+    }
+
+    // -----------------------------------------------------------------------
+    // AC-003 — Dispatch is an exhaustive match over FindingsRender
+    // (traces to BC-2.11.019 invariant 7)
+    //
+    // Intended assertion (implementer fills in during GREEN):
+    //   - Render through all three FindingsRender variants with the same input
+    //     and assert each reaches the correct rendering path:
+    //       Grouped      → output contains "## " tactic header (grouped path)
+    //       FlatCollapsed → output contains "(x3)" suffix for N=3 identical findings
+    //       FlatExpanded  → output does NOT contain "(x" and has 3 individual lines
+    //   - Relies on exhaustive match compile-time guarantee (no arm can be omitted).
+    // -----------------------------------------------------------------------
+    #[test]
+    fn test_BC_2_11_019_findings_dispatch_match_exhaustive() {
+        // RED: FindingsRender does not exist; todo!() panics to satisfy Red Gate.
+        // GREEN: replace with three reporter constructions using each variant
+        // and behavioral assertions for each rendering path.
+        todo!(
+            "AC-003: verify all three FindingsRender arms are reachable and route \
+             to the correct rendering helper; implement after match dispatch is added"
+        )
+    }
+
+    // -----------------------------------------------------------------------
+    // AC-004 — Impossible state (Grouped + collapsed simultaneously)
+    //          is structurally unrepresentable after STORY-120
+    // (traces to BC-2.11.025 invariant 5)
+    //
+    // Intended assertion (implementer fills in during GREEN):
+    //   - Confirm that `FindingsRender::Grouped` on N=100 identical-key findings
+    //     produces NO "(xN)" suffix anywhere in the output (collapse path not
+    //     reachable from the Grouped arm — the impossible state is gone by type).
+    //   - This corresponds to the former `mitre_collapse_reporter` construction
+    //     (show_mitre_grouping=true, collapse_findings=true) which now maps to
+    //     render: FindingsRender::Grouped cleanly.
+    // -----------------------------------------------------------------------
+    #[test]
+    fn test_BC_2_11_025_grouped_mode_bypasses_collapse_structurally() {
+        // RED: FindingsRender does not exist; todo!() panics to satisfy Red Gate.
+        // GREEN: construct TerminalReporter { render: FindingsRender::Grouped, ... },
+        // render 100 identical-key findings, and assert no "(x" suffix appears.
+        todo!(
+            "AC-004: verify FindingsRender::Grouped never emits (xN) suffix — \
+             impossible state (Grouped + collapsed) is structurally unrepresentable; \
+             implement after enum and match dispatch are in place"
+        )
+    }
+
+    // -----------------------------------------------------------------------
+    // AC-005 — run_analyze construction site wired correctly in main.rs
+    // (traces to BC-2.11.028 postconditions 1–2, invariant 1)
+    //
+    // Intended assertion (implementer fills in during GREEN):
+    //   - Using FindingsRender::FlatCollapsed (collapse ON) vs FindingsRender::FlatExpanded
+    //     (collapse OFF) on N=3 identical-key findings produces different output
+    //     (FlatCollapsed emits "(x3)", FlatExpanded does not) — proving the render
+    //     field is wired correctly to the rendering path.
+    //   - This mirrors the run_analyze wiring intent:
+    //       render: if show_mitre_grouping { Grouped }
+    //               else if collapse_findings { FlatCollapsed }
+    //               else { FlatExpanded }
+    //   - Structural polarity test: FlatCollapsed != FlatExpanded output.
+    // -----------------------------------------------------------------------
+    #[test]
+    fn test_BC_2_11_028_flag_wired_to_render_field_post_enum() {
+        // RED: FindingsRender does not exist; todo!() panics to satisfy Red Gate.
+        // GREEN: construct two reporters — one with render: FindingsRender::FlatCollapsed
+        // and one with render: FindingsRender::FlatExpanded — render N=3 identical
+        // findings, and assert FlatCollapsed produces "(x3)" while FlatExpanded does not.
+        // Also assert the two outputs differ (polarity test mirrors run_analyze wiring).
+        todo!(
+            "AC-005: verify render: FindingsRender::FlatCollapsed produces collapse \
+             and FlatExpanded does not — proving the run_analyze wiring intent; \
+             implement after enum construction sites are updated"
+        )
     }
 }

--- a/tests/reporter_terminal_tests.rs
+++ b/tests/reporter_terminal_tests.rs
@@ -691,7 +691,7 @@ mod story_078 {
     // -----------------------------------------------------------------------
 
     /// AC-001 (BC-2.11.013 postcondition 2):
-    /// When `show_mitre_grouping = true`, tactic section headers appear in the
+    /// When `render = FindingsRender::Grouped`, tactic section headers appear in the
     /// order returned by `all_tactics_in_report_order()`.  Only sections with at
     /// least one finding are emitted.
     ///
@@ -1006,7 +1006,7 @@ mod story_078 {
     // -----------------------------------------------------------------------
 
     /// AC-008 (BC-2.11.016 postcondition 1):
-    /// When `show_mitre_grouping = true` and a finding has a known technique ID
+    /// When `render = FindingsRender::Grouped` and a finding has a known technique ID
     /// (e.g., "T1036"), the MITRE line reads `MITRE: T1036 \u{2014} Masquerading`
     /// (U+2014 em-dash, not ASCII "--").
     ///
@@ -1081,8 +1081,8 @@ mod story_078 {
     // -----------------------------------------------------------------------
 
     /// AC-010 (BC-2.11.017 postcondition 1):
-    /// When `show_mitre_grouping = false` (default), a finding with
-    /// `mitre_technique = "T1036"` produces the MITRE line `MITRE: T1036`
+    /// When `render != FindingsRender::Grouped` (FlatExpanded or FlatCollapsed), a finding
+    /// with `mitre_technique = "T1036"` produces the MITRE line `MITRE: T1036`
     /// with no em-dash, no technique name, and no `(unknown)` label.
     ///
     /// Discriminating assertions:
@@ -1095,14 +1095,14 @@ mod story_078 {
     /// inv1/2: render_finding_flat never calls technique_name() / technique_tactic().
     #[test]
     fn test_BC_2_11_017_default_mode_bare_mitre_id() {
-        // Canonical test vector: mitre="T1036", show_mitre_grouping=false.
+        // Canonical test vector: mitre="T1036", render=FlatExpanded.
         let f = make_mitre_finding(
             "flat-finding",
             Verdict::Likely,
             Confidence::High,
             Some("T1036"),
         );
-        // Use plain_reporter() (show_mitre_grouping = false).
+        // Use plain_reporter() (render=FindingsRender::FlatExpanded).
         let out = plain_reporter().render(&Summary::new(), &[f], &[]);
 
         // Bare MITRE ID must be present.
@@ -2060,7 +2060,7 @@ mod story_118 {
         );
     }
 
-    /// AC-005: show_mitre_grouping=true suppresses collapse; no (xN) suffix anywhere.
+    /// AC-005: render=FindingsRender::Grouped suppresses collapse; no (xN) suffix anywhere.
     ///
     /// This guards the invariant that grouped (--mitre) mode is structurally
     /// suffix-free. FAILS if a future change applies the collapse pass inside
@@ -2070,7 +2070,7 @@ mod story_118 {
     /// that grouped mode does not).
     #[test]
     fn test_BC_2_11_025_grouped_mode_bypasses_collapse() {
-        // BC-2.11.025 invariant 5: when show_mitre_grouping=true, collapse does NOT run.
+        // BC-2.11.025 invariant 5: when render=FindingsRender::Grouped, collapse does NOT run.
         // 100 identical-key findings in mitre+collapse reporter → no (xN) suffix.
         let findings: Vec<Finding> = (0..100)
             .map(|_| {
@@ -2382,7 +2382,7 @@ mod story_118 {
             vec![],
         );
 
-        // Collapse reporter (collapse_findings=true) with a single finding.
+        // Collapse reporter (render=FindingsRender::FlatCollapsed) with a single finding.
         let out_collapse =
             collapse_reporter().render(&Summary::new(), std::slice::from_ref(&f), &[]);
 
@@ -2392,7 +2392,7 @@ mod story_118 {
             "BC-2.11.026 pc2/inv2: singleton must render with no (xN) suffix; got:\n{out_collapse}"
         );
 
-        // Output must be byte-identical to the pre-v0.8.0 path (collapse_findings=false).
+        // Output must be byte-identical to the pre-v0.8.0 path (render=FindingsRender::FlatExpanded).
         let out_no_collapse = plain_reporter().render(&Summary::new(), &[f], &[]);
         assert_eq!(
             out_collapse, out_no_collapse,
@@ -3210,15 +3210,14 @@ mod story_118 {
 
     /// AC-018 (part 1): --no-collapse restores one-line-per-finding; no (xN) suffix.
     ///
-    /// This guards the opt-out path: with collapse_findings=false, 5 identical-key
+    /// This guards the opt-out path: with render=FindingsRender::FlatExpanded, 5 identical-key
     /// findings render as 5 individual header lines. Also includes a contrast assertion
     /// that the collapse path (render_findings_collapsed) is implemented — verified by
-    /// checking that collapse_findings=true produces a different (collapsed) result.
-    /// FAILS if collapse_findings=false collapses, or if render_findings_collapsed is not
-    /// yet implemented.
+    /// checking that render=FindingsRender::FlatCollapsed produces a different (collapsed) result.
+    /// FAILS if FlatExpanded collapses, or if render_findings_collapsed is not yet implemented.
     #[test]
     fn test_BC_2_11_028_no_collapse_flag_one_line_per_finding() {
-        // BC-2.11.028 pc2: collapse_findings=false → one header per finding, no suffix.
+        // BC-2.11.028 pc2: render=FindingsRender::FlatExpanded → one header per finding, no suffix.
         let findings: Vec<Finding> = (0..5)
             .map(|_| {
                 make_collapse_finding(
@@ -3232,7 +3231,7 @@ mod story_118 {
             })
             .collect();
 
-        // plain_reporter() has collapse_findings=false.
+        // plain_reporter() has render=FindingsRender::FlatExpanded.
         let out = plain_reporter().render(&Summary::new(), &findings, &[]);
 
         // 5 individual header lines, not 1 collapsed group.
@@ -3249,7 +3248,7 @@ mod story_118 {
             "BC-2.11.028 pc2: collapse_findings=false must produce no (xN) suffix; got:\n{out}"
         );
 
-        // Contrast assertion: collapse_findings=true on the same input MUST produce
+        // Contrast assertion: render=FindingsRender::FlatCollapsed on the same input MUST produce
         // a collapsed group with (x5) — verifying the opt-out contrast is meaningful.
         let out_collapse = collapse_reporter().render(&Summary::new(), &findings, &[]);
         assert!(
@@ -3262,7 +3261,7 @@ mod story_118 {
     /// AC-018 (part 2): default vs. opt-out outputs are observably different.
     ///
     /// This guards that the two modes produce distinct output for the same input.
-    /// FAILS if a future change makes collapse_findings=true and collapse_findings=false
+    /// FAILS if a future change makes FindingsRender::FlatCollapsed and FindingsRender::FlatExpanded
     /// produce identical output (meaning either both collapse or neither does).
     #[test]
     fn test_BC_2_11_028_default_vs_opt_out_output_difference() {
@@ -3312,17 +3311,17 @@ mod story_118 {
         );
     }
 
-    /// AC-019: --no-collapse flag is wired: no_collapse=true → collapse_findings=false.
+    /// AC-019: --no-collapse flag is wired: no_collapse=true → render=FindingsRender::FlatExpanded.
     ///
-    /// This guards the structural wiring between the CLI flag and the reporter field.
-    /// FAILS if the collapse_findings field does not exist, or if its polarity is
-    /// reversed (collapse_findings: no_collapse instead of !no_collapse).
+    /// This guards the structural wiring between the CLI flag and the render field.
+    /// FAILS if FlatCollapsed and FlatExpanded produce identical output, or if the
+    /// render variant is mis-wired to the wrong rendering path.
     #[test]
     fn test_BC_2_11_028_flag_wired_to_reporter_field() {
         // BC-2.11.028 pc1 / invariant 1: structural wiring test.
-        // collapse_findings=true → collapse active (v0.8.0 default).
-        // collapse_findings=false → collapse inactive (--no-collapse opt-out).
-        // Verify the field exists and the logic is correct by behavioral contrast.
+        // render=FindingsRender::FlatCollapsed → collapse active (v0.8.0 default).
+        // render=FindingsRender::FlatExpanded → collapse inactive (--no-collapse opt-out).
+        // Verify the render field is wired correctly by behavioral contrast.
 
         let findings: Vec<Finding> = (0..3)
             .map(|_| {
@@ -3533,15 +3532,15 @@ mod story_118 {
 
     /// AC-027: --no-collapse flag has no observable effect on JSON or CSV output.
     ///
-    /// This guards that the collapse_findings field on TerminalReporter does not leak
-    /// into the JSON/CSV reporters. FAILS if main.rs is refactored to pre-filter the
-    /// findings slice based on the --no-collapse flag before passing to all reporters.
+    /// This guards that the render field (FindingsRender::FlatCollapsed) on TerminalReporter
+    /// does not leak into the JSON/CSV reporters. FAILS if main.rs is refactored to pre-filter
+    /// the findings slice based on the --no-collapse flag before passing to all reporters.
     #[test]
     fn test_BC_2_11_029_no_collapse_flag_json_invariant() {
         use wirerust::reporter::json::JsonReporter;
 
-        // BC-2.11.029 pc5: JSON output must be identical regardless of collapse_findings.
-        // The collapse_findings field belongs to TerminalReporter only.
+        // BC-2.11.029 pc5: JSON output must be identical regardless of render variant.
+        // The render field belongs to TerminalReporter only.
         let findings: Vec<Finding> = (0..5)
             .map(|_| {
                 make_collapse_finding(
@@ -3556,7 +3555,7 @@ mod story_118 {
             .collect();
 
         // JsonReporter does not have a collapse_findings field — it is unaffected.
-        // Both collapse=true and collapse=false terminal renders must produce the SAME
+        // Both FlatCollapsed and FlatExpanded terminal renders must produce the SAME
         // JSON output when the same slice is passed to JsonReporter.
         let json_out = JsonReporter.render(&Summary::new(), &findings, &[]);
         let json: serde_json::Value =
@@ -3649,7 +3648,7 @@ mod story_118 {
     // -----------------------------------------------------------------------
 
     /// AC-005 (BC-2.11.013): grouped mode (--mitre) is structurally suffix-free
-    /// regardless of `collapse_findings` flag; 0 (xN) suffixes in any volume.
+    /// regardless of render variant; 0 (xN) suffixes in any volume.
     ///
     /// This guards the invariant that render_findings_grouped is never modified by
     /// STORY-118. Also includes a contrast assertion that flat collapse produces a
@@ -3659,7 +3658,7 @@ mod story_118 {
     #[test]
     fn test_BC_2_11_013_grouped_mode_suffix_free() {
         // BC-2.11.013 invariant 4: grouped mode is structurally suffix-free.
-        // 50 identical-key findings with collapse_findings=true AND show_mitre_grouping=true.
+        // 50 identical-key findings with FindingsRender::FlatCollapsed AND FindingsRender::Grouped.
         let findings: Vec<Finding> = (0..50)
             .map(|_| {
                 make_collapse_finding(
@@ -3764,7 +3763,7 @@ mod story_118 {
     // BC-2.11.019 — Section Order Unchanged with Collapse (1 test)
     // -----------------------------------------------------------------------
 
-    /// AC-025: overall section order is unchanged when collapse_findings=true.
+    /// AC-025: overall section order is unchanged when render=FindingsRender::FlatCollapsed.
     /// Only the FINDINGS body content changes.
     ///
     /// This guards that the collapse feature does not reorder or drop the top-level
@@ -3941,21 +3940,15 @@ mod story_118 {
 }
 
 // ---------------------------------------------------------------------------
-// STORY-120 RED gate stubs
+// STORY-120 GREEN gate tests
 //
 // These tests exercise new behaviors introduced by the FindingsRender enum
-// migration (STORY-120). All bodies are `todo!()` — they compile but panic
-// at runtime, satisfying the Red Gate density check (≥50% todo!() bodies).
+// migration (STORY-120). All todo!() stubs have been replaced with real
+// assertions by the GREEN implementer.
 //
-// The implementer replaces each todo!() with real assertions during GREEN
-// after defining `pub enum FindingsRender { Grouped, FlatCollapsed,
-// FlatExpanded }` and updating `TerminalReporter` to use `render:
-// FindingsRender` in place of `show_mitre_grouping: bool` and
-// `collapse_findings: bool`.
-//
-// DO NOT reference the `FindingsRender` type here — it does not yet exist.
-// Construction sites remain as `todo!()` prose descriptions so the file
-// compiles against the current (pre-enum) struct shape.
+// `TerminalReporter` now uses `render: FindingsRender` (a three-variant enum)
+// in place of the two removed bool fields. The FindingsRender enum is now
+// defined in src/reporter/terminal.rs and imported below.
 // ---------------------------------------------------------------------------
 
 mod story_120 {
@@ -4004,7 +3997,7 @@ mod story_120 {
     fn test_findings_render_derives_debug_clone_copy_partialeq_eq() {
         let a = FindingsRender::Grouped;
         let b = a; // Copy
-        let c = a.clone(); // Clone
+        let c = Clone::clone(&a); // Clone (explicit form avoids clone_on_copy lint)
         assert_eq!(a, b, "PartialEq + Eq: Grouped == copied Grouped");
         assert_eq!(a, c, "PartialEq + Eq: Grouped == cloned Grouped");
         let _ = format!("{a:?}"); // Debug — would panic if not implemented
@@ -4040,7 +4033,7 @@ mod story_120 {
     /// AC-002 (BC-2.11.028 precondition 3):
     /// TerminalReporter has exactly 3 fields: use_color, show_hosts_breakdown, render.
     /// This test compiles only if the struct has exactly those fields — any reference
-    /// to removed fields show_mitre_grouping or collapse_findings is a compile error.
+    /// to the removed fields is a compile error.
     #[test]
     fn test_BC_2_11_028_struct_has_exactly_three_fields_post_refactor() {
         // The struct literal below is the test: it compiles if and only if exactly
@@ -4120,9 +4113,18 @@ mod story_120 {
         );
 
         // All three outputs are mutually distinct.
-        assert_ne!(grouped_out, collapsed_out, "AC-003: Grouped != FlatCollapsed output");
-        assert_ne!(grouped_out, expanded_out, "AC-003: Grouped != FlatExpanded output");
-        assert_ne!(collapsed_out, expanded_out, "AC-003: FlatCollapsed != FlatExpanded output");
+        assert_ne!(
+            grouped_out, collapsed_out,
+            "AC-003: Grouped != FlatCollapsed output"
+        );
+        assert_ne!(
+            grouped_out, expanded_out,
+            "AC-003: Grouped != FlatExpanded output"
+        );
+        assert_ne!(
+            collapsed_out, expanded_out,
+            "AC-003: FlatCollapsed != FlatExpanded output"
+        );
     }
 
     // -----------------------------------------------------------------------
@@ -4132,7 +4134,7 @@ mod story_120 {
 
     /// AC-004 (BC-2.11.025 invariant 5):
     /// FindingsRender::Grouped on N=100 identical-key findings produces no "(xN)" suffix.
-    /// The impossible state (show_mitre_grouping=true && collapse_findings=true) is
+    /// The impossible state (FindingsRender::Grouped + FlatCollapsed simultaneously) is
     /// eliminated by type — FindingsRender::Grouped structurally excludes the collapse path.
     #[test]
     fn test_BC_2_11_025_grouped_mode_bypasses_collapse_structurally() {

--- a/tests/reporter_tests.rs
+++ b/tests/reporter_tests.rs
@@ -5,7 +5,7 @@ use wirerust::reassembly::flow::FlowKey;
 use wirerust::reassembly::handler::{Direction, StreamAnalyzer, StreamHandler};
 use wirerust::reporter::Reporter;
 use wirerust::reporter::json::JsonReporter;
-use wirerust::reporter::terminal::TerminalReporter;
+use wirerust::reporter::terminal::{FindingsRender, TerminalReporter};
 use wirerust::summary::Summary;
 
 #[test]
@@ -448,10 +448,8 @@ fn test_terminal_hosts_breakdown_off_by_default() {
     let summary = make_summary_with_two_hosts();
     let reporter = TerminalReporter {
         use_color: false,
-        show_mitre_grouping: false,
         show_hosts_breakdown: false,
-        // STORY-118: new field; false = pre-v0.8.0 non-collapse path
-        collapse_findings: false,
+        render: FindingsRender::FlatExpanded,
     };
     let out = reporter.render(&summary, &[], &[]);
     assert!(
@@ -472,10 +470,8 @@ fn test_terminal_hosts_breakdown_lists_each_host_when_enabled() {
     let summary = make_summary_with_two_hosts();
     let reporter = TerminalReporter {
         use_color: false,
-        show_mitre_grouping: false,
         show_hosts_breakdown: true,
-        // STORY-118: new field; false = pre-v0.8.0 non-collapse path
-        collapse_findings: false,
+        render: FindingsRender::FlatExpanded,
     };
     let out = reporter.render(&summary, &[], &[]);
     assert!(
@@ -523,10 +519,8 @@ fn test_json_reporter_skipped_packets_zero_by_default() {
 fn test_terminal_reporter_shows_skipped_when_nonzero() {
     let reporter = TerminalReporter {
         use_color: false,
-        show_mitre_grouping: false,
         show_hosts_breakdown: false,
-        // STORY-118: new field; false = pre-v0.8.0 non-collapse path
-        collapse_findings: false,
+        render: FindingsRender::FlatExpanded,
     };
     let mut summary = Summary::new();
     summary.skipped_packets = 5;
@@ -542,10 +536,8 @@ fn test_terminal_reporter_shows_skipped_when_nonzero() {
 fn test_terminal_reporter_hides_skipped_when_zero() {
     let reporter = TerminalReporter {
         use_color: false,
-        show_mitre_grouping: false,
         show_hosts_breakdown: false,
-        // STORY-118: new field; false = pre-v0.8.0 non-collapse path
-        collapse_findings: false,
+        render: FindingsRender::FlatExpanded,
     };
     let summary = Summary::new();
 
@@ -564,10 +556,8 @@ fn test_terminal_reporter_escapes_esc_bytes_in_summary() {
     // reporter is responsible for this escaping.
     let reporter = TerminalReporter {
         use_color: false,
-        show_mitre_grouping: false,
         show_hosts_breakdown: false,
-        // STORY-118: new field; false = pre-v0.8.0 non-collapse path
-        collapse_findings: false,
+        render: FindingsRender::FlatExpanded,
     };
     let summary = Summary::new();
     let findings = vec![Finding {
@@ -644,10 +634,8 @@ fn test_output_sanitization_layering_contract() {
     // Layer 2: terminal reporter escapes on display.
     let terminal_output = TerminalReporter {
         use_color: false,
-        show_mitre_grouping: false,
         show_hosts_breakdown: false,
-        // STORY-118: new field; false = pre-v0.8.0 non-collapse path
-        collapse_findings: false,
+        render: FindingsRender::FlatExpanded,
     }
     .render(&Summary::new(), std::slice::from_ref(&finding), &[]);
     assert!(
@@ -752,10 +740,8 @@ fn test_terminal_reporter_escapes_control_bytes_in_analyzer_summaries() {
 
     let output = TerminalReporter {
         use_color: false,
-        show_mitre_grouping: false,
         show_hosts_breakdown: false,
-        // STORY-118: new field; false = pre-v0.8.0 non-collapse path
-        collapse_findings: false,
+        render: FindingsRender::FlatExpanded,
     }
     .render(
         &Summary::new(),
@@ -861,10 +847,8 @@ fn test_http_finding_c1_csi_escaped_by_terminal_reporter() {
     // Render through terminal reporter — no raw C1 bytes in output.
     let output = TerminalReporter {
         use_color: false,
-        show_mitre_grouping: false,
         show_hosts_breakdown: false,
-        // STORY-118: new field; false = pre-v0.8.0 non-collapse path
-        collapse_findings: false,
+        render: FindingsRender::FlatExpanded,
     }
     .render(&Summary::new(), &findings, &[]);
     assert!(
@@ -948,10 +932,8 @@ fn test_http_analyzer_summary_c1_csi_escaped_by_terminal_reporter() {
     // Render through terminal reporter — no raw C1 bytes in output.
     let output = TerminalReporter {
         use_color: false,
-        show_mitre_grouping: false,
         show_hosts_breakdown: false,
-        // STORY-118: new field; false = pre-v0.8.0 non-collapse path
-        collapse_findings: false,
+        render: FindingsRender::FlatExpanded,
     }
     .render(
         &Summary::new(),
@@ -1000,10 +982,8 @@ fn mitre_grouping_emits_tactic_headers_in_canonical_order() {
     ];
     let reporter = TerminalReporter {
         use_color: false,
-        show_mitre_grouping: true,
         show_hosts_breakdown: false,
-        // STORY-118: new field; false = pre-v0.8.0 non-collapse path
-        collapse_findings: false,
+        render: FindingsRender::Grouped,
     };
     let out = reporter.render(&Summary::new(), &findings, &[]);
     // Anchor on the `## ` header prefix so future summary/evidence text
@@ -1035,10 +1015,8 @@ fn mitre_grouping_sorts_within_tactic_by_verdict_then_confidence() {
     ];
     let reporter = TerminalReporter {
         use_color: false,
-        show_mitre_grouping: true,
         show_hosts_breakdown: false,
-        // STORY-118: new field; false = pre-v0.8.0 non-collapse path
-        collapse_findings: false,
+        render: FindingsRender::Grouped,
     };
     let out = reporter.render(&Summary::new(), &findings, &[]);
     let p1 = out.find("first").expect("first missing");
@@ -1070,10 +1048,8 @@ fn mitre_grouping_buckets_none_and_unknown_under_uncategorized() {
     ];
     let reporter = TerminalReporter {
         use_color: false,
-        show_mitre_grouping: true,
         show_hosts_breakdown: false,
-        // STORY-118: new field; false = pre-v0.8.0 non-collapse path
-        collapse_findings: false,
+        render: FindingsRender::Grouped,
     };
     let out = reporter.render(&Summary::new(), &findings, &[]);
     let uncat_pos = out
@@ -1105,10 +1081,8 @@ fn mitre_grouping_expands_per_finding_line_with_technique_name() {
     )];
     let reporter = TerminalReporter {
         use_color: false,
-        show_mitre_grouping: true,
         show_hosts_breakdown: false,
-        // STORY-118: new field; false = pre-v0.8.0 non-collapse path
-        collapse_findings: false,
+        render: FindingsRender::Grouped,
     };
     let out = reporter.render(&Summary::new(), &findings, &[]);
     assert!(
@@ -1127,10 +1101,8 @@ fn default_rendering_unchanged_when_mitre_flag_off() {
     )];
     let reporter = TerminalReporter {
         use_color: false,
-        show_mitre_grouping: false,
         show_hosts_breakdown: false,
-        // STORY-118: new field; false = pre-v0.8.0 non-collapse path
-        collapse_findings: false,
+        render: FindingsRender::FlatExpanded,
     };
     let out = reporter.render(&Summary::new(), &findings, &[]);
     assert!(out.contains("MITRE: T1046"));
@@ -1154,10 +1126,8 @@ fn mitre_grouping_preserves_emission_order_when_verdict_and_confidence_tie() {
     ];
     let reporter = TerminalReporter {
         use_color: false,
-        show_mitre_grouping: true,
         show_hosts_breakdown: false,
-        // STORY-118: new field; false = pre-v0.8.0 non-collapse path
-        collapse_findings: false,
+        render: FindingsRender::Grouped,
     };
     let out = reporter.render(&Summary::new(), &findings, &[]);
     let pa = out.find("alpha").expect("alpha missing");
@@ -1191,10 +1161,8 @@ fn mitre_grouping_keeps_known_and_unknown_ids_in_separate_buckets() {
     ];
     let reporter = TerminalReporter {
         use_color: false,
-        show_mitre_grouping: true,
         show_hosts_breakdown: false,
-        // STORY-118: new field; false = pre-v0.8.0 non-collapse path
-        collapse_findings: false,
+        render: FindingsRender::Grouped,
     };
     let out = reporter.render(&Summary::new(), &findings, &[]);
     let discovery_pos = out.find("## Discovery").expect("Discovery header missing");
@@ -2475,10 +2443,8 @@ fn test_story_070_ec001_full_pipeline_esc_in_uri() {
     // Layer 2: terminal reporter escapes to \u{1b} form.
     let terminal_out = TerminalReporter {
         use_color: false,
-        show_mitre_grouping: false,
         show_hosts_breakdown: false,
-        // STORY-118: new field; false = pre-v0.8.0 non-collapse path
-        collapse_findings: false,
+        render: FindingsRender::FlatExpanded,
     }
     .render(&Summary::new(), std::slice::from_ref(&finding), &[]);
     assert!(


### PR DESCRIPTION
# [STORY-120] TerminalReporter FindingsRender Enum Migration (v0.9.0)

**Epic:** E-8 — TerminalReporter Render-Mode Refactor
**Mode:** feature
**Convergence:** CONVERGED after 3 adversarial passes (fresh-context triple, frozen corpus 864de05; all CLEAN, zero MEDIUM+)

![Tests](https://img.shields.io/badge/tests-408%2F408-brightgreen)
![Coverage](https://img.shields.io/badge/coverage-passing-brightgreen)
![Adversarial](https://img.shields.io/badge/adversarial-3%2F3%20CLEAN-green)
![Semver](https://img.shields.io/badge/semver-v0.9.0%20breaking-orange)

Closes #62. Replaces the two-bool `show_mitre_grouping`/`collapse_findings` fields on
`TerminalReporter` with a single `pub enum FindingsRender { Grouped, FlatCollapsed, FlatExpanded }`,
making the previously-representable illegal state (`show_mitre_grouping = true &&
collapse_findings = true`) structurally unrepresentable. The FINDINGS dispatch `if`-chain
becomes an exhaustive `match`. All 28 construction sites across 6 files are migrated. Terminal
output is byte-identical — this is a pure refactor. Cargo.toml bumps to v0.9.0 (breaking public
struct-field change per RFC 1105; expected `struct_field_missing` via cargo-semver-checks).

---

## Architecture Changes

```mermaid
graph TD
    CLI["src/cli.rs<br/>--mitre / --no-collapse flags<br/>(unchanged)"]
    MAIN["src/main.rs<br/>run_analyze / run_summary<br/>(2 construction sites updated)"]
    ENUM["FindingsRender enum<br/>(NEW — src/reporter/terminal.rs)"]
    REPORTER["TerminalReporter struct<br/>render: FindingsRender<br/>(replaces 2 bool fields)"]
    DISPATCH["render() dispatch<br/>match self.render<br/>(replaces if-chain)"]
    GROUPED["render_findings_grouped()<br/>(unchanged)"]
    COLLAPSED["render_findings_collapsed()<br/>(unchanged)"]
    FLAT["render_finding_flat()<br/>(unchanged)"]

    CLI -->|bool params| MAIN
    MAIN -->|TerminalReporter { render: ... }| REPORTER
    ENUM -.->|new type| REPORTER
    REPORTER --> DISPATCH
    DISPATCH -->|Grouped arm| GROUPED
    DISPATCH -->|FlatCollapsed arm| COLLAPSED
    DISPATCH -->|FlatExpanded arm| FLAT

    style ENUM fill:#90EE90
    style DISPATCH fill:#90EE90
```

<details>
<summary><strong>Architecture Decision Record — ADR-0003 Binding Rule 5</strong></summary>

### ADR: Render-Mode Enum (Issue #62 — v0.9.0)

**Context:** v0.8.0 shipped `TerminalReporter` with four boolean fields. Issue #62's
trigger condition ("when a 3rd render flag is added") fired when STORY-118 added
`collapse_findings`. Two illegal-state violations resulted: (1) `show_mitre_grouping =
true && collapse_findings = true` is a representable struct value silently handled only
by dispatch order; (2) `run_summary` has an inert `collapse_findings: true` with a comment
explaining the value does not matter.

**Decision:** Replace `show_mitre_grouping: bool` + `collapse_findings: bool` with
`render: FindingsRender` — a three-variant enum that makes the mutually-exclusive
rendering modes unrepresentable as invalid combinations.

**Rationale:** Rust's enum + exhaustive match makes impossible states unrepresentable.
The compiler enforces exhaustiveness; no arm can be forgotten. Adding a future variant
forces all call sites to handle it.

**Alternatives Considered:**
1. Keep bools, add a validation assertion — rejected because: the invariant remains
   comment-only; the type still permits the illegal state.
2. Use a separate `RenderMode` newtype wrapping an integer — rejected because: less
   readable than a named enum, no compiler-enforced exhaustiveness.

**Consequences:**
- Positive: impossible state eliminated at the type level; match is exhaustive by
  construction; 28 construction sites are trivially correct by Rust's struct-literal
  exhaustiveness check.
- Trade-off: breaking semver change (v0.8.x → v0.9.0); `cargo-semver-checks` fires
  `struct_field_missing` — this is expected and documented.

</details>

---

## Story Dependencies

```mermaid
graph LR
    S118["STORY-118<br/>✅ merged<br/>(collapse_findings bool added)"]
    S120["STORY-120<br/>🔄 this PR<br/>(FindingsRender enum)"]
    S119["STORY-119<br/>⏸ deferred<br/>(grouped-mode collapse)"]

    S118 --> S120
    S120 --> S119

    style S120 fill:#FFD700
    style S118 fill:#90EE90
    style S119 fill:#lightgrey
```

**depends_on:** `[]` — STORY-120 refactors `TerminalReporter` already shipped in STORY-077/078/118. No new build-order predecessor.

**blocks:** `[STORY-119]` — STORY-119 (grouped-mode collapse, deferred/unscheduled) builds on the `FindingsRender` enum; no scheduling constraint today.

---

## Spec Traceability

```mermaid
flowchart LR
    BC010["BC-2.11.010<br/>escape invariant"]
    BC013["BC-2.11.013<br/>MITRE grouping order"]
    BC017["BC-2.11.017<br/>default flat rendering"]
    BC019["BC-2.11.019<br/>section order"]
    BC025["BC-2.11.025<br/>flat collapse groups"]
    BC028["BC-2.11.028<br/>--no-collapse flag wiring"]

    AC001["AC-001<br/>FindingsRender enum defined"]
    AC002["AC-002<br/>struct has 3 fields"]
    AC003["AC-003<br/>exhaustive match dispatch"]
    AC004["AC-004<br/>impossible state gone"]
    AC005["AC-005<br/>run_analyze wired correctly"]
    AC007["AC-007<br/>28 construction sites"]

    T001["test_findings_render_derives_*"]
    T003["test_BC_2_11_019_findings_dispatch_match_exhaustive"]
    T004["test_BC_2_11_025_grouped_mode_bypasses_collapse"]
    T005["test_BC_2_11_028_flag_wired_to_reporter_field"]

    SRC["src/reporter/terminal.rs"]

    BC013 --> AC001
    BC025 --> AC001
    BC028 --> AC002
    BC019 --> AC003
    BC013 --> AC004
    BC025 --> AC004
    BC028 --> AC005
    BC028 --> AC007

    AC001 --> T001
    AC003 --> T003
    AC004 --> T004
    AC005 --> T005

    T001 --> SRC
    T003 --> SRC
    T004 --> SRC
    T005 --> SRC
```

**Full BC traceability:** 12 SS-11 BCs (BC-2.11.010/013/014/015/016/017/019/025/026/027/028/029) all re-anchored to `FindingsRender` enum vocabulary. Every AC cites a BC trace clause. See STORY-120.md for complete BC ↔ AC cross-check.

---

## Test Evidence

### Coverage Summary

| Metric | Value | Threshold | Status |
|--------|-------|-----------|--------|
| Unit tests | 408/408 pass | 100% | PASS |
| New story_120 tests | 5 new (AC-001..AC-005) | — | PASS |
| Regressions | 0 | 0 | PASS |
| Clippy warnings | 0 | 0 | PASS |
| fmt violations | 0 | 0 | PASS |

### Test Flow

```mermaid
graph LR
    Unit["408 unit+integration tests<br/>(cargo test --all-targets)"]
    Story["5 new mod story_120 tests<br/>(AC-001..AC-005)"]
    Clippy["cargo clippy -D warnings<br/>CLEAN"]
    Fmt["cargo fmt --check<br/>CLEAN"]
    Check["cargo check --all-targets<br/>28 sites exhaustiveness gate"]

    Unit -->|408/408 PASS| Pass1["PASS"]
    Story -->|5/5 PASS| Pass2["PASS"]
    Clippy --> Pass3["PASS"]
    Fmt --> Pass4["PASS"]
    Check -->|zero compile errors| Pass5["PASS"]

    style Pass1 fill:#90EE90
    style Pass2 fill:#90EE90
    style Pass3 fill:#90EE90
    style Pass4 fill:#90EE90
    style Pass5 fill:#90EE90
```

| Metric | Value |
|--------|-------|
| **New tests** | 5 added (`mod story_120`), ~26 construction sites modified |
| **Total suite** | 408 tests PASS, 0 failed |
| **Regressions** | 0 |
| **Mutation kill rate** | N/A — evaluated at wave gate |

<details>
<summary><strong>New Tests (mod story_120)</strong></summary>

| Test | AC | Result |
|------|----|--------|
| `test_findings_render_derives_debug_clone_copy_partialeq_eq` | AC-001 | PASS |
| `test_terminal_reporter_struct_has_three_fields` | AC-002 | PASS |
| `test_BC_2_11_019_findings_dispatch_match_exhaustive` | AC-003 | PASS |
| `test_BC_2_11_025_grouped_mode_bypasses_collapse` | AC-004 | PASS |
| `test_BC_2_11_028_flag_wired_to_reporter_field` | AC-005 | PASS |

**All pre-existing tests in reporter_terminal_tests.rs, reporter_tests.rs,
dnp3_f5_remediation_tests.rs, bc_2_09_100_multitag_tests.rs pass unchanged.**

</details>

---

## Demo Evidence

All three `FindingsRender` modes captured against `tests/fixtures/local-samples/modbus-large.pcap`
(85-packet, 5-flow Modbus TCP corpus). All three recordings show correct distinct output;
byte-identical to pre-refactor behavior.

| Recording | Variant | CLI Flag | Key Observable |
|-----------|---------|----------|----------------|
| `AC-003-flat-collapsed.gif` | `FindingsRender::FlatCollapsed` | (none — default) | `(x34)` suffix on write-command group |
| `AC-003-grouped.gif` | `FindingsRender::Grouped` | `--mitre` | Tactic headers + em-dash technique names; no `(xN)` suffix |
| `AC-003-flat-expanded.gif` | `FindingsRender::FlatExpanded` | `--no-collapse` | 34 individual finding headers; distinct TxnID values |

Evidence files at: `.factory/demo-evidence/issue-62-story-120/`

---

## Holdout Evaluation

N/A — evaluated at wave gate (per pipeline convention).

---

## Adversarial Review

| Pass | Lens | Findings | Critical | High | Medium+ | Status |
|------|------|----------|----------|------|---------|--------|
| 1 | behavior-preservation | 0 | 0 | 0 | 0 | CLEAN |
| 2 | construction-site census / scope / semver | 0 | 0 | 0 | 0 | CLEAN |
| 3 | AC-017 doc-sweep / test-quality | 0 | 0 | 0 | 0 | CLEAN |

**Convergence:** All 3 passes CLEAN on frozen corpus (HEAD 864de05). Zero MEDIUM+ findings across all lenses.

---

## Security Review

This PR is a pure internal refactor — it moves data between struct fields and an enum within
a single module (`src/reporter/terminal.rs`). No network I/O, no user input parsing, no
authentication, no cryptography, and no new external dependencies are introduced.

```mermaid
graph LR
    Critical["Critical: 0"]
    High["High: 0"]
    Medium["Medium: 0"]
    Low["Low: 0"]

    style Critical fill:#90EE90
    style High fill:#90EE90
    style Medium fill:#90EE90
    style Low fill:#90EE90
```

<details>
<summary><strong>Security Scan Details</strong></summary>

### Assessment
- No OWASP Top 10 vectors applicable (CLI tool, no web surface)
- No injection risk (enum dispatch replaces if-chain; no string interpolation)
- No auth changes
- No new crate dependencies (`FindingsRender` uses only stdlib)
- `escape_for_terminal` function unchanged; VP-012 proptest suite still covers it
- `cargo audit` not run (no dependency changes; existing baseline clean)

</details>

---

## Semver / Breaking Change Note

Removing `show_mitre_grouping: bool` and `collapse_findings: bool` (public fields) and
adding `render: FindingsRender` constitutes a breaking struct API change under Cargo semver
(RFC 1105). For a `0.y.z` crate, this requires a minor bump: **v0.8.0 → v0.9.0**.

Running `cargo semver-checks` against a v0.8.x baseline fires `struct_field_missing` for
the two removed fields. **This is expected and correct — not a defect.** The v0.9.0 bump
is the deliberate semver boundary for this breaking change. Documented in ADR-0003 Binding
Rule 5.

---

## Risk Assessment & Deployment

### Blast Radius
- **Systems affected:** `src/reporter/terminal.rs` (SS-11), `src/main.rs` (2 construction sites, SS-12 wiring glue)
- **User impact:** Zero — terminal output is byte-identical to pre-refactor. Pure structural change.
- **Data impact:** None
- **Risk Level:** LOW (pure refactor; behavior preserved by exhaustive match + 408-test regression suite)

### Performance Impact
| Metric | Before | After | Delta | Status |
|--------|--------|-------|-------|--------|
| Dispatch overhead | if-chain (3 branches) | match (3 arms) | negligible | OK |
| Memory | 2 bool fields | 1 enum field (1 byte) | -1 byte per reporter instance | OK |

<details>
<summary><strong>Rollback Instructions</strong></summary>

**Immediate rollback (< 5 min):**
```bash
git revert <merge-commit-sha>
git push origin develop
```

**Verification after rollback:**
- `cargo test --all-targets` passes
- `wirerust analyze --modbus ...` produces expected terminal output

</details>

### Feature Flags
N/A — no feature flags. The change is structural; it takes effect on merge.

---

## Traceability

| BC | Story AC | Test | Status |
|----|---------|------|--------|
| BC-2.11.013 | AC-004, AC-012 | `test_BC_2_11_013_grouped_mode_suffix_free` | PASS |
| BC-2.11.014 | AC-003 | `test_BC_2_11_019_findings_dispatch_match_exhaustive` | PASS |
| BC-2.11.015 | AC-003 | (covered by grouped-mode tests) | PASS |
| BC-2.11.016 | AC-003 | (covered by grouped-mode tests) | PASS |
| BC-2.11.017 | AC-014 | `test_BC_2_11_028_no_collapse_flag_one_line_per_finding` | PASS |
| BC-2.11.019 | AC-003, AC-010 | `test_BC_2_11_019_findings_dispatch_match_exhaustive` | PASS |
| BC-2.11.025 | AC-004, AC-013 | `test_BC_2_11_025_grouped_mode_bypasses_collapse` | PASS |
| BC-2.11.026 | AC-013 | `test_BC_2_11_026_*` suite | PASS |
| BC-2.11.027 | AC-013 | `test_BC_2_11_027_*` suite | PASS |
| BC-2.11.028 | AC-005, AC-006, AC-007 | `test_BC_2_11_028_flag_wired_to_reporter_field` | PASS |
| BC-2.11.029 | AC-008 | `test_BC_2_11_029_*` suite | PASS |
| BC-2.11.010 | AC-015 | `test_BC_2_11_010_escape_in_collapse_path` | PASS |

---

## AI Pipeline Metadata

<details>
<summary><strong>Pipeline Details</strong></summary>

```yaml
ai-generated: true
pipeline-mode: feature
factory-version: "1.0.0"
pipeline-stages:
  spec-crystallization: completed (F1/F2)
  story-decomposition: completed (F3)
  tdd-implementation: completed (F4 RED/GREEN)
  holdout-evaluation: N/A — evaluated at wave gate
  adversarial-review: completed (3/3 CLEAN, fresh-context triple)
  formal-verification: skipped (pure refactor, exhaustiveness by Rust compiler)
  convergence: achieved
convergence-metrics:
  adversarial-passes: 3
  adversarial-verdict: CLEAN (zero MEDIUM+ across all lenses)
  test-pass-rate: 408/408
  implementation-ci: green
story: STORY-120
github-issue: 62
models-used:
  builder: claude-sonnet-4-6
  adversary: claude-sonnet-4-6 (fresh-context)
generated-at: "2026-06-18T00:00:00Z"
```

</details>

---

## Pre-Merge Checklist

- [x] All CI status checks passing (`cargo test`, `cargo clippy -D warnings`, `cargo fmt --check`, action-pin-gate)
- [x] 408/408 tests pass, 0 regressions
- [x] No critical/high security findings (pure refactor, no attack surface)
- [x] Semver bump documented (v0.8.0 → v0.9.0, breaking struct fields removed)
- [x] ADR-0003 Binding Rule 5 subsection in docs/adr/0003-reporting-pipeline-layering.md (rides in this PR)
- [x] Demo evidence recorded for all 3 FindingsRender variants (AC-003)
- [x] AC-017 comment sweep completed (both greps yield only EXEMPT allow-list lines)
- [x] Adversarial convergence: 3/3 CLEAN passes
- [x] No feature flag needed (structural change, byte-identical output)
- [ ] PR reviewer approval
- [ ] CI green on PR
