### PR TITLE
docs(reporter): re-anchor ADR-0003 color-ladder + add v0.9.0 CHANGELOG entry (#62)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ Version numbers follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-06-18
+
+### Changed (BREAKING)
+
+- **`TerminalReporter` findings-render mode: two bools → `FindingsRender` enum (STORY-120, PR #266).**
+  The `show_mitre_grouping: bool` and `collapse_findings: bool` public fields on `TerminalReporter`
+  are removed and replaced by a single `render: FindingsRender` field. `FindingsRender` is an enum
+  with three variants: `Grouped` (formerly `show_mitre_grouping = true`), `FlatCollapsed` (formerly
+  `collapse_findings = true`), and `FlatExpanded` (formerly both bools false). The previously
+  representable invalid state (`show_mitre_grouping = true` and `collapse_findings = true`
+  simultaneously) is now structurally impossible. Terminal output is byte-identical across all
+  three modes; this is an internal refactor only. Per RFC 1105 the removal of public fields is a
+  breaking change, hence the 0.8.x → 0.9.0 minor bump.
+
 ## [0.8.0] - 2026-06-17
 
 ### Added
@@ -381,7 +395,8 @@ Downstream consumers of wirerust JSON or CSV output must update for this release
 - Output sanitization in the terminal reporter guards against C1 control bytes
   in packet-derived strings.
 
-[Unreleased]: https://github.com/Zious11/wirerust/compare/v0.8.0...HEAD
+[Unreleased]: https://github.com/Zious11/wirerust/compare/v0.9.0...HEAD
+[0.9.0]: https://github.com/Zious11/wirerust/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/Zious11/wirerust/compare/v0.7.1...v0.8.0
 [0.7.1]: https://github.com/Zious11/wirerust/compare/v0.7.0...v0.7.1
 [0.7.0]: https://github.com/Zious11/wirerust/compare/v0.6.0...v0.7.0

--- a/docs/adr/0003-reporting-pipeline-layering.md
+++ b/docs/adr/0003-reporting-pipeline-layering.md
@@ -265,7 +265,7 @@ displayed:
 The ` (xN)` suffix is part of the string that is passed to the color function — it is appended
 **before** colorization, not after the ANSI reset. The color ladder applied to the pre-suffix
 string is the same verdict/confidence ladder used by the existing `render_finding_prefix`
-(terminal.rs:209-221): `Likely/High → red().bold()`, `Likely/other → yellow`,
+(terminal.rs:273-285): `Likely/High → red().bold()`, `Likely/other → yellow`,
 `Possible → yellow`, `Inconclusive → cyan`, `Unlikely → dimmed`. See BC-2.11.026 PC-6.
 
 Evidence sampling: a collapsed group retains at most K = 3 evidence lines, taken from the


### PR DESCRIPTION
## Summary

Fixes F5-Pass-3 HIGH finding F-1 (stale anchor): ADR-0003 §Display-Layer Aggregation referenced `terminal.rs:209-221` for the color ladder in `render_finding_prefix`. The STORY-120 `FindingsRender` enum refactor (PR #266) shifted the helper downward; the ladder now lives at `terminal.rs:273-285`. This PR corrects the anchor.

Adds the `[0.9.0]` CHANGELOG entry documenting the breaking `FindingsRender` enum migration (STORY-120, PR #266) which was missing from the changelog.

**Scope:** docs-only (`docs/adr/0003-reporting-pipeline-layering.md`, `CHANGELOG.md`). No source or test code changes.

## Changes

| File | Change |
|------|--------|
| `docs/adr/0003-reporting-pipeline-layering.md` | Line ~268: anchor `terminal.rs:209-221` → `terminal.rs:273-285` |
| `CHANGELOG.md` | New `## [0.9.0] - 2026-06-18` entry + link-ref footer update |

## Traceability

- Closes #62 (F5-Pass-3 stale-anchor remediation)
- ADR-0003 §Display-Layer Aggregation / color ladder prose
- STORY-120 / PR #266 (FindingsRender enum, merged to develop)

## Architecture Changes

No architectural changes. Documentation accuracy fix only.

## Security Review

N/A — docs-only change, no executable code modified.

## Risk Assessment

- **Blast radius:** Documentation only; zero runtime impact.
- **Performance impact:** None.
- **Rollback:** Revert this commit; no migration needed.

## Pre-Merge Checklist

- [x] ADR anchor verified against `src/reporter/terminal.rs` — `render_finding_prefix` at line 267, color ladder at lines 273-285
- [x] CHANGELOG entry is descriptive of actual merged behavior (not aspirational)
- [x] Semantic PR title uses allowed type `docs`
- [x] No source/test code changes (CI test/clippy/fmt trivially pass)
- [x] Action-pin-gate unaffected (no workflow file changes)