### PR TITLE
feat(reporter): grouped-mode finding-collapse — render_findings_grouped_collapsed + --mitre default flip (STORY-119/B)

### DIFF
--- a/docs/adr/0003-reporting-pipeline-layering.md
+++ b/docs/adr/0003-reporting-pipeline-layering.md
@@ -604,9 +604,11 @@ type-system fix is strictly superior.
 
 ## Grouped-Mode Collapse — Issue #259 tail / STORY-119/B (+ STORY-122/A reshape)
 
-**Status of this subsection:** Accepted (F2 spec evolution 2026-06-18; D-120 split: enum→struct
-reshape + migration map = STORY-122/A; grouped-collapse render path + `--mitre` default-collapse
-CLI flip + `--no-collapse` dual-scope = STORY-119/B; F4 implementation pending)
+**Status of this subsection:** Implemented (F2 spec evolution 2026-06-18; D-120 split:
+enum→struct reshape + migration map = STORY-122/A [IMPLEMENTED]; grouped-collapse render path
++ `--mitre` default-collapse CLI flip + `--no-collapse` dual-scope = STORY-119/B [IMPLEMENTED
+2026-06-19: `render_findings_grouped_collapsed` live; `{Grouped, Collapsed}` dispatch arm
+active; `--mitre` default is now per-bucket collapsed output])
 
 *(D-120 split note: the monolithic STORY-119 was split per D-120 into STORY-122 (A — enum→struct
 reshape, 84-site migration, byte-identical, CLI unchanged) and STORY-119 (B — grouped-collapse

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -151,12 +151,13 @@ pub enum Commands {
         #[arg(long)]
         mitre: bool,
 
-        /// Disable terminal finding-collapse (default: collapse ON).
-        /// By default, repeated findings sharing the same (category, verdict,
-        /// confidence, summary) are collapsed into one display group with a
-        /// `(xN)` count suffix. Pass --no-collapse to restore one-line-per-finding
-        /// output identical to pre-v0.8.0 behavior.
-        /// BC-2.11.028 precondition 2; mirrors the --mitre / --dns boolean precedent.
+        /// Disable collapsing of repeated findings in both flat and grouped
+        /// (--mitre) terminal output. By default, collapse is enabled in both
+        /// modes. When --mitre is used, collapse groups identical findings
+        /// within each MITRE tactic bucket with a `(xN)` count suffix.
+        /// Pass --no-collapse to restore one-line-per-finding output in both modes.
+        /// Has no effect on --output json or --output csv.
+        /// BC-2.11.028 precondition 2; dual-scope since STORY-119.
         #[arg(long)]
         no_collapse: bool,
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -375,23 +375,14 @@ fn run_analyze(
                 // `analyze` does not expose a per-host breakdown flag —
                 // that is `summary`-subcommand-only (LESSON-P1.03).
                 show_hosts_breakdown: false,
-                // BC-2.11.028: render mode selection (3-arm if for byte-identical STORY-122/A;
-                // orthogonal 2-if form in STORY-119/B).
-                render: if show_mitre_grouping {
-                    FindingsRender {
-                        grouping: Grouping::Grouped,
-                        collapse: Collapse::Expanded,
-                    }
-                } else if collapse_findings {
-                    FindingsRender {
-                        grouping: Grouping::Flat,
-                        collapse: Collapse::Collapsed,
-                    }
-                } else {
-                    FindingsRender {
-                        grouping: Grouping::Flat,
-                        collapse: Collapse::Expanded,
-                    }
+                // BC-2.11.028 / BC-2.11.030: orthogonal 2-if struct wiring (STORY-119/B CLI flip).
+                // --mitre alone (show_mitre_grouping=true, collapse_findings=true) → {Grouped, Collapsed}.
+                // --mitre --no-collapse (show_mitre_grouping=true, collapse_findings=false) → {Grouped, Expanded}.
+                // default (show_mitre_grouping=false, collapse_findings=true) → {Flat, Collapsed}.
+                // --no-collapse only (show_mitre_grouping=false, collapse_findings=false) → {Flat, Expanded}.
+                render: FindingsRender {
+                    grouping: if show_mitre_grouping { Grouping::Grouped } else { Grouping::Flat },
+                    collapse: if collapse_findings { Collapse::Collapsed } else { Collapse::Expanded },
                 },
             };
             reporter.render(&summary, &all_findings, &analyzer_summaries)

--- a/src/main.rs
+++ b/src/main.rs
@@ -381,8 +381,16 @@ fn run_analyze(
                 // default (show_mitre_grouping=false, collapse_findings=true) → {Flat, Collapsed}.
                 // --no-collapse only (show_mitre_grouping=false, collapse_findings=false) → {Flat, Expanded}.
                 render: FindingsRender {
-                    grouping: if show_mitre_grouping { Grouping::Grouped } else { Grouping::Flat },
-                    collapse: if collapse_findings { Collapse::Collapsed } else { Collapse::Expanded },
+                    grouping: if show_mitre_grouping {
+                        Grouping::Grouped
+                    } else {
+                        Grouping::Flat
+                    },
+                    collapse: if collapse_findings {
+                        Collapse::Collapsed
+                    } else {
+                        Collapse::Expanded
+                    },
                 },
             };
             reporter.render(&summary, &all_findings, &analyzer_summaries)

--- a/src/reporter/terminal.rs
+++ b/src/reporter/terminal.rs
@@ -210,11 +210,7 @@ impl Reporter for TerminalReporter {
                     self.render_findings_grouped(&mut out, findings);
                 }
                 (Grouping::Grouped, Collapse::Collapsed) => {
-                    // TEMPORARY (STORY-122/A): routes to render_findings_grouped until STORY-119/B
-                    // introduces render_findings_grouped_collapsed and repoints this arm.
-                    // {Grouped, Collapsed} is unreachable via CLI in this story (--mitre alone maps
-                    // to {Grouped, Expanded} until STORY-119/B flips the CLI default).
-                    self.render_findings_grouped(&mut out, findings);
+                    self.render_findings_grouped_collapsed(&mut out, findings);
                 }
                 (Grouping::Flat, Collapse::Collapsed) => {
                     self.render_findings_collapsed(&mut out, findings);
@@ -329,23 +325,22 @@ impl TerminalReporter {
         }
     }
 
-    /// Groups findings by `CollapseKey` in first-occurrence order using a
-    /// `Vec<(CollapseKey, Vec<&Finding>)>` accumulator with linear-scan
-    /// `PartialEq` matching (no HashMap / IndexMap — `ThreatCategory`, `Verdict`,
-    /// and `Confidence` do not derive `Hash` in v0.8.0).
+    /// Shared collapse-logic helper: groups a slice of finding references by
+    /// `CollapseKey` in first-occurrence order.
     ///
-    /// Each finding's four-tuple `(category, verdict, confidence, summary)` is
-    /// compared by raw bytes (the summary is not escaped before key construction;
-    /// escape is a render-time operation). Groups appear in first-occurrence order —
-    /// the position of the first member that created the group.
+    /// This is the single source of collapse logic (ADR-0003 "Collapse-API Shape";
+    /// F2 design-note §5.2.1). `collapse_findings_pass` (the flat-mode wrapper)
+    /// delegates to this function. `render_findings_grouped_collapsed` calls this
+    /// directly per bucket.
     ///
-    /// BC-2.11.025 invariant 7 / postcondition 9: Vec accumulator is canonical.
-    fn collapse_findings_pass<'a>(
+    /// BC-2.11.025 invariant 7 / postcondition 9: Vec accumulator is canonical —
+    /// linear-scan `PartialEq`, no `HashMap`, no `IndexMap`.
+    fn collapse_findings_pass_refs<'a>(
         &self,
-        findings: &'a [Finding],
+        refs: &[&'a Finding],
     ) -> Vec<(CollapseKey, Vec<&'a Finding>)> {
         let mut groups: Vec<(CollapseKey, Vec<&'a Finding>)> = Vec::new();
-        for f in findings {
+        for f in refs {
             let key = CollapseKey {
                 category: f.category,
                 verdict: f.verdict,
@@ -360,6 +355,20 @@ impl TerminalReporter {
             }
         }
         groups
+    }
+
+    /// Flat-mode collapse adapter. Collects the `&[Finding]` parameter into
+    /// `Vec<&Finding>` and delegates to `collapse_findings_pass_refs`.
+    ///
+    /// Uses the `findings` PARAMETER — `TerminalReporter` has no `findings` field.
+    ///
+    /// BC-2.11.025 / ADR-0003 "Collapse-API Shape".
+    fn collapse_findings_pass<'a>(
+        &self,
+        findings: &'a [Finding],
+    ) -> Vec<(CollapseKey, Vec<&'a Finding>)> {
+        let refs: Vec<&Finding> = findings.iter().collect();
+        self.collapse_findings_pass_refs(&refs)
     }
 
     /// Renders the FINDINGS section in collapsed flat mode.
@@ -484,6 +493,31 @@ impl TerminalReporter {
                 self.render_finding_grouped(out, f);
             }
         }
+    }
+
+    /// Renders the FINDINGS section grouped by MITRE tactic WITH per-bucket collapse.
+    ///
+    /// Per-tactic-bucket grouping identical to `render_findings_grouped` (BC-2.11.013),
+    /// then per-bucket sort (BC-2.11.033 PC-5 / BC-2.11.014), then per-bucket
+    /// `collapse_findings_pass_refs` (BC-2.11.033 Invariant 3), then collapsed
+    /// group rendering with `(xN)` suffix (BC-2.11.031), K=3 evidence sampling
+    /// (BC-2.11.032), and MITRE em-dash line from `members[0]` (BC-2.11.034).
+    ///
+    /// Singletons (N=1) render via `render_finding_grouped` (byte-identical to
+    /// `{Grouped, Expanded}` for that finding).
+    ///
+    /// STORY-119/B GREEN: implement per-bucket collapse rendering here.
+    fn render_findings_grouped_collapsed(&self, _out: &mut String, _findings: &[Finding]) {
+        // BC-5.38.001: non-trivial body — todo!() until GREEN phase.
+        // "If I include this real implementation, will the test for this function pass
+        // trivially without any implementer work?" Yes — therefore todo!() here.
+        // Self-check per BC-5.38.005 invariant 1.
+        todo!(
+            "STORY-119/B GREEN: render_findings_grouped_collapsed — \
+             per-bucket sort + collapse_findings_pass_refs + (xN) headers + \
+             K=3 evidence sampling + MITRE em-dash from members[0] \
+             (BC-2.11.031/032/033/034)"
+        )
     }
 }
 

--- a/src/reporter/terminal.rs
+++ b/src/reporter/terminal.rs
@@ -65,28 +65,28 @@ fn escape_for_terminal(s: &str) -> String {
     out
 }
 
-/// Escape control bytes for safe terminal display in the grouped-collapse rendering path.
+/// Ascending sort rank for [`Verdict`]: lower value → appears first in a sorted bucket.
 ///
-/// Identical to [`escape_for_terminal`] for C1 (U+0080–U+009F) and backslash,
-/// but uses two-digit hex (`\xNN`) instead of unicode (`\u{N}`) for C0 (U+0000–U+001F)
-/// and DEL (U+007F). This matches BC-2.11.031 Precondition 5 / VP-012 as exercised
-/// by the grouped-collapse acceptance tests (AC-023).
-fn escape_for_terminal_grouped(s: &str) -> String {
-    let mut out = String::with_capacity(s.len());
-    for c in s.chars() {
-        if c.is_ascii_control() {
-            // C0 (0x00–0x1F) and DEL (0x7F): two-digit lowercase hex escape.
-            out.push_str(&format!("\\x{:02x}", c as u32));
-        } else if ('\u{80}'..='\u{9f}').contains(&c) || c == '\\' {
-            // C1 range and backslash: delegate to escape_default (same as flat path).
-            for e in c.escape_default() {
-                out.push(e);
-            }
-        } else {
-            out.push(c);
-        }
+/// BC-2.11.014 / BC-2.11.033 PC-5: both `render_findings_grouped` and
+/// `render_findings_grouped_collapsed` share this single source (BC-014 single-source rule).
+fn verdict_rank(v: Verdict) -> u8 {
+    match v {
+        Verdict::Likely => 0,
+        Verdict::Possible => 1,
+        Verdict::Inconclusive => 2,
+        Verdict::Unlikely => 3,
     }
-    out
+}
+
+/// Ascending sort rank for [`Confidence`]: lower value → appears first in a sorted bucket.
+///
+/// BC-2.11.014 / BC-2.11.033 PC-6: both grouped render functions share this single source.
+fn confidence_rank(c: Confidence) -> u8 {
+    match c {
+        Confidence::High => 0,
+        Confidence::Medium => 1,
+        Confidence::Low => 2,
+    }
 }
 
 /// Maximum number of representative evidence lines rendered per collapsed group.
@@ -481,22 +481,7 @@ impl TerminalReporter {
             buckets.entry(tactic).or_default().push((i, f));
         }
 
-        fn verdict_rank(v: Verdict) -> u8 {
-            match v {
-                Verdict::Likely => 0,
-                Verdict::Possible => 1,
-                Verdict::Inconclusive => 2,
-                Verdict::Unlikely => 3,
-            }
-        }
-        fn confidence_rank(c: Confidence) -> u8 {
-            match c {
-                Confidence::High => 0,
-                Confidence::Medium => 1,
-                Confidence::Low => 2,
-            }
-        }
-
+        // verdict_rank / confidence_rank: module-level single-source (BC-014).
         for (_, items) in buckets.iter_mut() {
             items.sort_by_key(|(idx, f)| {
                 (verdict_rank(f.verdict), confidence_rank(f.confidence), *idx)
@@ -543,24 +528,8 @@ impl TerminalReporter {
             buckets.entry(tactic).or_default().push((i, f));
         }
 
-        // Step 2: sort helper ranks (same as render_findings_grouped).
-        fn verdict_rank(v: Verdict) -> u8 {
-            match v {
-                Verdict::Likely => 0,
-                Verdict::Possible => 1,
-                Verdict::Inconclusive => 2,
-                Verdict::Unlikely => 3,
-            }
-        }
-        fn confidence_rank(c: Confidence) -> u8 {
-            match c {
-                Confidence::High => 0,
-                Confidence::Medium => 1,
-                Confidence::Low => 2,
-            }
-        }
-
         // Sort each bucket ascending by (verdict_rank, confidence_rank, emission-index).
+        // verdict_rank / confidence_rank: module-level single-source (BC-014).
         for (_, items) in buckets.iter_mut() {
             items.sort_by_key(|(idx, f)| {
                 (verdict_rank(f.verdict), confidence_rank(f.confidence), *idx)
@@ -569,23 +538,13 @@ impl TerminalReporter {
 
         // Step 3: render buckets in all_tactics_in_report_order(), Uncategorized last.
         let render_collapsed_bucket = |out: &mut String, items: &[(usize, &Finding)]| {
-            // Build a slice of &Finding refs in sorted order for collapse pass.
-            // Per-bucket collapse: group by summary only (BC-2.11.033 PC-5/6 — the
-            // sort-then-collapse semantics require verdict/confidence to determine the
-            // representative, not group membership; findings with the same summary but
-            // different severities form one group whose representative is the
-            // highest-severity post-sort members[0]).
-            let refs: Vec<&Finding> = items.iter().map(|(_, f)| *f).collect();
-            // Inline summary-keyed collapse (linear-scan, insertion-order preserved).
-            let mut groups: Vec<Vec<&Finding>> = Vec::new();
-            for f in &refs {
-                if let Some(pos) = groups.iter().position(|g| g[0].summary == f.summary) {
-                    groups[pos].push(f);
-                } else {
-                    groups.push(vec![f]);
-                }
-            }
-            for members in &groups {
+            // Build sorted &Finding refs and delegate to the shared collapse helper.
+            // BC-2.11.033 Inv3 / BC-2.11.025 Inv1 / BC-2.11.031 PC-3: use the shared
+            // four-tuple (category, verdict, confidence, summary) collapse key via
+            // collapse_findings_pass_refs — no inline summary-only keying.
+            let bucket_refs: Vec<&Finding> = items.iter().map(|(_, f)| *f).collect();
+            let groups = self.collapse_findings_pass_refs(&bucket_refs);
+            for (_key, members) in &groups {
                 let n = members.len();
                 if n == 1 {
                     // Singleton: byte-identical to {Grouped, Expanded}.
@@ -594,12 +553,13 @@ impl TerminalReporter {
                     // N >= 2: build header with (xN) suffix, colorize the full
                     // string (suffix is inside the ANSI color span — BC-2.11.031 PC-3).
                     let rep = members[0];
-                    let escaped_summary = escape_for_terminal_grouped(&rep.summary);
-                    // Debug format (title-case) for verdict and confidence:
-                    // "Likely" / "High" — consistent with BC-2.11.033 PC-5/6 test
-                    // expectation for grouped-collapse group headers.
+                    // escape_for_terminal (char::escape_default, U+NN format) —
+                    // BC-2.11.031 PC-5 / BC-2.11.032 PC-6 / VP-012 / ADR-0003.
+                    let escaped_summary = escape_for_terminal(&rep.summary);
+                    // Display format (`{}`) for verdict and confidence → UPPERCASE output
+                    // (`LIKELY`, `HIGH`) per BC-2.11.031 PC-1 / canonical vector.
                     let header_text = format!(
-                        "[{}] {:?} ({:?}) - {} (x{})",
+                        "[{}] {} ({}) - {} (x{})",
                         rep.category, rep.verdict, rep.confidence, escaped_summary, n
                     );
                     let colored = if self.use_color {
@@ -619,10 +579,11 @@ impl TerminalReporter {
 
                     // Evidence sampling: first min(N, K) members positionally.
                     // Window does NOT slide past empty-evidence members (BC-2.11.032 Inv2).
+                    // escape_for_terminal (char::escape_default) — BC-2.11.032 PC-6 / VP-012.
                     let window = members.len().min(COLLAPSE_EVIDENCE_SAMPLES);
                     for member in &members[..window] {
                         if let Some(ev) = member.evidence.first() {
-                            let escaped_ev = escape_for_terminal_grouped(ev);
+                            let escaped_ev = escape_for_terminal(ev);
                             out.push_str(&format!("    > {escaped_ev}\n"));
                         }
                     }

--- a/src/reporter/terminal.rs
+++ b/src/reporter/terminal.rs
@@ -65,6 +65,30 @@ fn escape_for_terminal(s: &str) -> String {
     out
 }
 
+/// Escape control bytes for safe terminal display in the grouped-collapse rendering path.
+///
+/// Identical to [`escape_for_terminal`] for C1 (U+0080–U+009F) and backslash,
+/// but uses two-digit hex (`\xNN`) instead of unicode (`\u{N}`) for C0 (U+0000–U+001F)
+/// and DEL (U+007F). This matches BC-2.11.031 Precondition 5 / VP-012 as exercised
+/// by the grouped-collapse acceptance tests (AC-023).
+fn escape_for_terminal_grouped(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        if c.is_ascii_control() {
+            // C0 (0x00–0x1F) and DEL (0x7F): two-digit lowercase hex escape.
+            out.push_str(&format!("\\x{:02x}", c as u32));
+        } else if ('\u{80}'..='\u{9f}').contains(&c) || c == '\\' {
+            // C1 range and backslash: delegate to escape_default (same as flat path).
+            for e in c.escape_default() {
+                out.push(e);
+            }
+        } else {
+            out.push(c);
+        }
+    }
+    out
+}
+
 /// Maximum number of representative evidence lines rendered per collapsed group.
 ///
 /// BC-2.11.027 invariant 1: K = 3 is a hardcoded named constant, not a magic number.
@@ -498,26 +522,139 @@ impl TerminalReporter {
     /// Renders the FINDINGS section grouped by MITRE tactic WITH per-bucket collapse.
     ///
     /// Per-tactic-bucket grouping identical to `render_findings_grouped` (BC-2.11.013),
-    /// then per-bucket sort (BC-2.11.033 PC-5 / BC-2.11.014), then per-bucket
+    /// then per-bucket sort ascending by (verdict_rank, confidence_rank, emission-index)
+    /// (BC-2.11.033 PC-5 / BC-2.11.014), then per-bucket
     /// `collapse_findings_pass_refs` (BC-2.11.033 Invariant 3), then collapsed
     /// group rendering with `(xN)` suffix (BC-2.11.031), K=3 evidence sampling
     /// (BC-2.11.032), and MITRE em-dash line from `members[0]` (BC-2.11.034).
     ///
     /// Singletons (N=1) render via `render_finding_grouped` (byte-identical to
     /// `{Grouped, Expanded}` for that finding).
-    ///
-    /// STORY-119/B GREEN: implement per-bucket collapse rendering here.
-    fn render_findings_grouped_collapsed(&self, _out: &mut String, _findings: &[Finding]) {
-        // BC-5.38.001: non-trivial body — todo!() until GREEN phase.
-        // "If I include this real implementation, will the test for this function pass
-        // trivially without any implementer work?" Yes — therefore todo!() here.
-        // Self-check per BC-5.38.005 invariant 1.
-        todo!(
-            "STORY-119/B GREEN: render_findings_grouped_collapsed — \
-             per-bucket sort + collapse_findings_pass_refs + (xN) headers + \
-             K=3 evidence sampling + MITRE em-dash from members[0] \
-             (BC-2.11.031/032/033/034)"
-        )
+    fn render_findings_grouped_collapsed(&self, out: &mut String, findings: &[Finding]) {
+        // Step 1: bucket by tactic (same as render_findings_grouped, BC-2.11.013).
+        let mut buckets: std::collections::HashMap<Option<MitreTactic>, Vec<(usize, &Finding)>> =
+            std::collections::HashMap::new();
+        for (i, f) in findings.iter().enumerate() {
+            let tactic = f
+                .mitre_techniques
+                .first()
+                .map(|id| id.as_str())
+                .and_then(technique_tactic);
+            buckets.entry(tactic).or_default().push((i, f));
+        }
+
+        // Step 2: sort helper ranks (same as render_findings_grouped).
+        fn verdict_rank(v: Verdict) -> u8 {
+            match v {
+                Verdict::Likely => 0,
+                Verdict::Possible => 1,
+                Verdict::Inconclusive => 2,
+                Verdict::Unlikely => 3,
+            }
+        }
+        fn confidence_rank(c: Confidence) -> u8 {
+            match c {
+                Confidence::High => 0,
+                Confidence::Medium => 1,
+                Confidence::Low => 2,
+            }
+        }
+
+        // Sort each bucket ascending by (verdict_rank, confidence_rank, emission-index).
+        for (_, items) in buckets.iter_mut() {
+            items.sort_by_key(|(idx, f)| {
+                (verdict_rank(f.verdict), confidence_rank(f.confidence), *idx)
+            });
+        }
+
+        // Step 3: render buckets in all_tactics_in_report_order(), Uncategorized last.
+        let render_collapsed_bucket = |out: &mut String, items: &[(usize, &Finding)]| {
+            // Build a slice of &Finding refs in sorted order for collapse pass.
+            // Per-bucket collapse: group by summary only (BC-2.11.033 PC-5/6 — the
+            // sort-then-collapse semantics require verdict/confidence to determine the
+            // representative, not group membership; findings with the same summary but
+            // different severities form one group whose representative is the
+            // highest-severity post-sort members[0]).
+            let refs: Vec<&Finding> = items.iter().map(|(_, f)| *f).collect();
+            // Inline summary-keyed collapse (linear-scan, insertion-order preserved).
+            let mut groups: Vec<Vec<&Finding>> = Vec::new();
+            for f in &refs {
+                if let Some(pos) = groups.iter().position(|g| g[0].summary == f.summary) {
+                    groups[pos].push(f);
+                } else {
+                    groups.push(vec![f]);
+                }
+            }
+            for members in &groups {
+                let n = members.len();
+                if n == 1 {
+                    // Singleton: byte-identical to {Grouped, Expanded}.
+                    self.render_finding_grouped(out, members[0]);
+                } else {
+                    // N >= 2: build header with (xN) suffix, colorize the full
+                    // string (suffix is inside the ANSI color span — BC-2.11.031 PC-3).
+                    let rep = members[0];
+                    let escaped_summary = escape_for_terminal_grouped(&rep.summary);
+                    // Debug format (title-case) for verdict and confidence:
+                    // "Likely" / "High" — consistent with BC-2.11.033 PC-5/6 test
+                    // expectation for grouped-collapse group headers.
+                    let header_text = format!(
+                        "[{}] {:?} ({:?}) - {} (x{})",
+                        rep.category, rep.verdict, rep.confidence, escaped_summary, n
+                    );
+                    let colored = if self.use_color {
+                        match rep.verdict {
+                            Verdict::Likely => match rep.confidence {
+                                Confidence::High => header_text.red().bold().to_string(),
+                                _ => header_text.yellow().to_string(),
+                            },
+                            Verdict::Possible => header_text.yellow().to_string(),
+                            Verdict::Inconclusive => header_text.cyan().to_string(),
+                            Verdict::Unlikely => header_text.dimmed().to_string(),
+                        }
+                    } else {
+                        header_text
+                    };
+                    out.push_str(&format!("  {colored}\n"));
+
+                    // Evidence sampling: first min(N, K) members positionally.
+                    // Window does NOT slide past empty-evidence members (BC-2.11.032 Inv2).
+                    let window = members.len().min(COLLAPSE_EVIDENCE_SAMPLES);
+                    for member in &members[..window] {
+                        if let Some(ev) = member.evidence.first() {
+                            let escaped_ev = escape_for_terminal_grouped(ev);
+                            out.push_str(&format!("    > {escaped_ev}\n"));
+                        }
+                    }
+
+                    // MITRE line from members[0] with em-dash name expansion (BC-2.11.034).
+                    if !rep.mitre_techniques.is_empty() {
+                        let ids = rep.mitre_techniques.join(", ");
+                        match rep
+                            .mitre_techniques
+                            .first()
+                            .and_then(|id| technique_name(id.as_str()))
+                        {
+                            Some(name) => {
+                                out.push_str(&format!("    MITRE: {ids} \u{2014} {name}\n"))
+                            }
+                            None => out.push_str(&format!("    MITRE: {ids} (unknown)\n")),
+                        }
+                    }
+                }
+            }
+        };
+
+        for tactic in all_tactics_in_report_order() {
+            if let Some(items) = buckets.get(&Some(*tactic)) {
+                out.push_str(&format!("  ## {tactic}\n"));
+                render_collapsed_bucket(out, items);
+            }
+        }
+        if let Some(items) = buckets.get(&None) {
+            out.push_str("  ## Uncategorized\n");
+            render_collapsed_bucket(out, items);
+        }
     }
 }
 

--- a/tests/reporter_terminal_tests.rs
+++ b/tests/reporter_terminal_tests.rs
@@ -4569,13 +4569,17 @@ mod story_122 {
         );
     }
 
-    /// AC-002 (BC-2.11.013 Invariant 4):
-    /// The {Grouped, Collapsed} dispatch arm TEMPORARILY routes to render_findings_grouped
-    /// (same as {Grouped, Expanded}) — output is byte-identical; tactic headers appear
-    /// and no (xN) suffix is emitted. This arm is unreachable via the CLI in STORY-122/A;
-    /// STORY-119/B repoints it to render_findings_grouped_collapsed.
+    /// AC-002 (BC-2.11.013 Invariant 4 / STORY-119/B post-implementation):
+    /// The {Grouped, Collapsed} dispatch arm routes to `render_findings_grouped_collapsed`
+    /// (STORY-119/B). For N≥2 identical-key findings in a tactic bucket, the output
+    /// carries a `(xN)` suffix — it is NO longer byte-identical to {Grouped, Expanded}.
+    /// Tactic headers still appear (`## <tactic>`).
+    ///
+    /// Supersedes the TEMPORARY STORY-122/A assertion that {Grouped,Collapsed} was
+    /// byte-identical to {Grouped,Expanded}. That was a scaffolding state; STORY-119/B
+    /// wires the real implementation.
     #[test]
-    fn test_BC_2_11_028_ac002_grouped_collapsed_arm_temporary_routes_to_render_findings_grouped() {
+    fn test_BC_2_11_028_ac002_grouped_collapsed_arm_routes_to_render_findings_grouped_collapsed() {
         let findings: Vec<Finding> = (0..3)
             .map(|_| make_mitre_finding_s122("s122-dispatch-gc"))
             .collect();
@@ -4600,12 +4604,19 @@ mod story_122 {
         }
         .render(&Summary::new(), &findings, &[]);
 
-        // TEMPORARY: {Grouped,Collapsed} routes to the same function as {Grouped,Expanded}.
-        assert_eq!(
-            out_gc, out_ge,
-            "AC-002: {{Grouped,Collapsed}} arm (TEMPORARY in STORY-122/A) must produce \
-             byte-identical output to {{Grouped,Expanded}}; outputs differ"
+        // Post-STORY-119/B: {Grouped,Collapsed} routes to render_findings_grouped_collapsed.
+        // N=3 identical-key findings must produce (x3) suffix — collapsed, not expanded.
+        assert!(
+            out_gc.contains("(x3)"),
+            "AC-002: {{Grouped,Collapsed}} with N=3 identical findings must emit `(x3)` suffix; \
+             got:\n{out_gc}"
         );
+        // {Grouped,Collapsed} output must differ from {Grouped,Expanded} (no longer byte-identical).
+        assert_ne!(
+            out_gc, out_ge,
+            "AC-002: {{Grouped,Collapsed}} must differ from {{Grouped,Expanded}} post-STORY-119/B"
+        );
+        // Tactic headers still appear.
         assert!(
             out_gc.contains("## "),
             "AC-002: {{Grouped,Collapsed}} arm must emit tactic header '## '; got:\n{out_gc}"
@@ -5418,8 +5429,16 @@ mod story_119 {
         // Construct the reporter exactly as run_analyze does when
         // show_mitre_grouping=true, collapse_findings=true.
         let render = FindingsRender {
-            grouping: if true { Grouping::Grouped } else { Grouping::Flat },
-            collapse: if true { Collapse::Collapsed } else { Collapse::Expanded },
+            grouping: if true {
+                Grouping::Grouped
+            } else {
+                Grouping::Flat
+            },
+            collapse: if true {
+                Collapse::Collapsed
+            } else {
+                Collapse::Expanded
+            },
         };
         assert_eq!(
             render,
@@ -5462,8 +5481,16 @@ mod story_119 {
     #[test]
     fn test_BC_2_11_030_mitre_no_collapse_maps_to_grouped_expanded() {
         let render = FindingsRender {
-            grouping: if true { Grouping::Grouped } else { Grouping::Flat },
-            collapse: if false { Collapse::Collapsed } else { Collapse::Expanded },
+            grouping: if true {
+                Grouping::Grouped
+            } else {
+                Grouping::Flat
+            },
+            collapse: if false {
+                Collapse::Collapsed
+            } else {
+                Collapse::Expanded
+            },
         };
         assert_eq!(
             render,
@@ -5516,8 +5543,16 @@ mod story_119 {
     fn test_BC_2_11_030_flat_routing_unchanged() {
         // PC-4: default (no --mitre, no --no-collapse)
         let default_render = FindingsRender {
-            grouping: if false { Grouping::Grouped } else { Grouping::Flat },
-            collapse: if true { Collapse::Collapsed } else { Collapse::Expanded },
+            grouping: if false {
+                Grouping::Grouped
+            } else {
+                Grouping::Flat
+            },
+            collapse: if true {
+                Collapse::Collapsed
+            } else {
+                Collapse::Expanded
+            },
         };
         assert_eq!(
             default_render,
@@ -5530,8 +5565,16 @@ mod story_119 {
 
         // PC-5: --no-collapse without --mitre
         let no_collapse_flat_render = FindingsRender {
-            grouping: if false { Grouping::Grouped } else { Grouping::Flat },
-            collapse: if false { Collapse::Collapsed } else { Collapse::Expanded },
+            grouping: if false {
+                Grouping::Grouped
+            } else {
+                Grouping::Flat
+            },
+            collapse: if false {
+                Collapse::Collapsed
+            } else {
+                Collapse::Expanded
+            },
         };
         assert_eq!(
             no_collapse_flat_render,
@@ -5637,10 +5680,7 @@ mod story_119 {
         // The ANSI reset sequence (\x1b[0m) must NOT appear BEFORE `(x2)` on
         // the same header line. Verify by checking that `(x2)` does not appear
         // after a reset on the header line.
-        let header_line = out
-            .lines()
-            .find(|l| l.contains("(x2)"))
-            .unwrap_or_default();
+        let header_line = out.lines().find(|l| l.contains("(x2)")).unwrap_or_default();
         // Split by reset: if (x2) appears in the LAST segment (after reset),
         // the suffix was appended after the ANSI reset — NON-CONFORMANT.
         let reset = "\x1b[0m";
@@ -6051,10 +6091,7 @@ mod story_119 {
 
         // The header verdict must be "Likely" (the sorted-first representative),
         // not "Inconclusive". Find the header line (contains `(x2)`).
-        let header_line = out
-            .lines()
-            .find(|l| l.contains("(x2)"))
-            .unwrap_or_default();
+        let header_line = out.lines().find(|l| l.contains("(x2)")).unwrap_or_default();
         assert!(
             header_line.contains("Likely"),
             "AC-016: post-sort representative must be Likely (rank=0 sorts first); \
@@ -6199,11 +6236,21 @@ mod story_119 {
     /// divergent `mitre_techniques`, only `members[0]`'s technique appears on
     /// the MITRE line. The other members' techniques are elided from terminal
     /// output (preserved in raw findings for JSON/CSV).
+    ///
+    /// Both findings MUST be in the same tactic bucket for per-bucket collapse
+    /// to merge them (BC-2.11.033 Invariant 3 / EC-003): T1046 and T1083 both
+    /// map to Discovery, so they land in the same bucket and collapse as N=2.
+    /// Using findings from different tactics (e.g. T1046 Discovery + T1071 C&C)
+    /// would produce two independent singletons per BC-2.11.033 EC-003 — the
+    /// correct per-bucket behavior — but the divergent-MITRE elision property
+    /// (BC-2.11.034 PC-3) can only be observed when N≥2 within one bucket.
     #[test]
     fn test_BC_2_11_034_divergent_mitre_representative_sourcing() {
-        // Two findings with same collapse key but different MITRE techniques.
+        // Two findings with same summary but different MITRE techniques,
+        // both in the Discovery tactic bucket (T1046 and T1083).
         // After sort (Likely rank=0 for both, same confidence), the first
         // submitted becomes members[0] (stable emission-index tiebreak).
+        // They collapse into N=2 within the Discovery bucket.
         let findings = vec![
             Finding {
                 category: ThreatCategory::Anomaly,
@@ -6211,7 +6258,7 @@ mod story_119 {
                 confidence: Confidence::High,
                 summary: "s119-ac020-divergent-mitre".to_string(),
                 evidence: vec![],
-                mitre_techniques: vec!["T1046".to_string()], // members[0]
+                mitre_techniques: vec!["T1046".to_string()], // members[0] — Discovery
                 source_ip: None,
                 timestamp: None,
                 direction: None,
@@ -6222,7 +6269,7 @@ mod story_119 {
                 confidence: Confidence::High,
                 summary: "s119-ac020-divergent-mitre".to_string(),
                 evidence: vec![],
-                mitre_techniques: vec!["T1071".to_string()], // members[1] — must be elided
+                mitre_techniques: vec!["T1083".to_string()], // members[1] — Discovery; must be elided
                 source_ip: None,
                 timestamp: None,
                 direction: None,
@@ -6238,9 +6285,14 @@ mod story_119 {
         );
         // members[1]'s technique must NOT appear in terminal output.
         assert!(
-            !out.contains("T1071"),
-            "AC-020: members[1] technique T1071 must be elided from terminal output; \
+            !out.contains("T1083"),
+            "AC-020: members[1] technique T1083 must be elided from terminal output; \
              got:\n{out}"
+        );
+        // Group must be collapsed as N=2 (same bucket, same summary-only key).
+        assert!(
+            out.contains("(x2)"),
+            "AC-020: same-bucket same-summary findings must collapse to N=2; got:\n{out}"
         );
     }
 
@@ -6270,12 +6322,10 @@ mod story_119 {
             &out[..out.len().min(500)]
         );
         // All 100 findings must be rendered (header line count via `[Anomaly]`).
-        let header_count = out
-            .lines()
-            .filter(|l| l.contains("[Anomaly]"))
-            .count();
+        let header_count = out.lines().filter(|l| l.contains("[Anomaly]")).count();
         assert_eq!(
-            header_count, 100,
+            header_count,
+            100,
             "AC-022: {{Grouped,Expanded}} must render all 100 findings; got {header_count} in \
              output (first 500 chars):\n{}",
             &out[..out.len().min(500)]

--- a/tests/reporter_terminal_tests.rs
+++ b/tests/reporter_terminal_tests.rs
@@ -1812,8 +1812,10 @@ mod story_118 {
         }
     }
 
-    /// TerminalReporter with MITRE grouping and collapse both enabled (for AC-005).
-    fn mitre_collapse_reporter() -> TerminalReporter {
+    /// TerminalReporter with MITRE grouping ENABLED and collapse DISABLED
+    /// ({Grouped, Expanded}); used to prove grouped mode is structurally
+    /// suffix-free (no `(xN)` suffix regardless of collapse_findings setting).
+    fn mitre_expanded_reporter() -> TerminalReporter {
         TerminalReporter {
             use_color: false,
             show_hosts_breakdown: false,
@@ -2100,7 +2102,7 @@ mod story_118 {
             })
             .collect();
 
-        let out = mitre_collapse_reporter().render(&Summary::new(), &findings, &[]);
+        let out = mitre_expanded_reporter().render(&Summary::new(), &findings, &[]);
 
         // No (xN) suffix of any kind must appear.
         assert!(
@@ -3693,7 +3695,7 @@ mod story_118 {
             })
             .collect();
 
-        let out = mitre_collapse_reporter().render(&Summary::new(), &findings, &[]);
+        let out = mitre_expanded_reporter().render(&Summary::new(), &findings, &[]);
 
         // No (xN) suffix of any kind must appear anywhere in the output.
         assert!(
@@ -6189,6 +6191,15 @@ mod story_119 {
             out.contains("INCONCLUSIVE"),
             "BC-2.11.025 EC-007: Inconclusive group header must appear; got:\n{out}"
         );
+        // Both findings must render as separate group headers — neither merged nor
+        // dropped. Count `[Anomaly]` occurrences (one per header line in no-color
+        // output) to catch a drop-vs-merge bug that the (x2) check alone would miss.
+        assert_eq!(
+            out.matches("[Anomaly]").count(),
+            2,
+            "BC-2.11.025 EC-007: both findings must render as separate group headers \
+             (one `[Anomaly]` prefix each), not merged or dropped; got:\n{out}"
+        );
     }
 
     // -----------------------------------------------------------------------
@@ -6376,10 +6387,12 @@ mod story_119 {
             "AC-020: members[1] technique T1083 must be elided from terminal output; \
              got:\n{out}"
         );
-        // Group must be collapsed as N=2 (same bucket, same summary-only key).
+        // Group must be collapsed as N=2 (same bucket, same shared four-tuple
+        // collapse key: category=Anomaly, verdict=Likely, confidence=High,
+        // summary="s119-ac020-divergent-mitre").
         assert!(
             out.contains("(x2)"),
-            "AC-020: same-bucket same-summary findings must collapse to N=2; got:\n{out}"
+            "AC-020: same-bucket same-four-tuple-key findings must collapse to N=2; got:\n{out}"
         );
     }
 

--- a/tests/reporter_terminal_tests.rs
+++ b/tests/reporter_terminal_tests.rs
@@ -5277,3 +5277,1260 @@ mod story_122 {
         );
     }
 }
+
+// ============================================================================
+// mod story_119 — STORY-119/B: Grouped-Collapse Behavioral Delta
+// ============================================================================
+//
+// Tests for render_findings_grouped_collapsed (BC-2.11.031/032/033/034),
+// CLI mapping to {Grouped,Collapsed} (BC-2.11.030), and the per-bucket
+// collapse-not-global invariant (BC-2.11.025 Invariant 5).
+//
+// Namespace wrapper per DF-TEST-NAMESPACE-001: all test functions live inside
+// `mod story_119` so that identically-named siblings in sibling mods (e.g.
+// `test_BC_2_11_025_grouped_mode_bypasses_flat_collapse` vs the pre-existing
+// siblings in the outer scope) resolve without collision.
+//
+// Red Gate (BC-5.38.001): every test in this module exercises
+// `render_findings_grouped_collapsed`, which is a `todo!()` stub until the
+// GREEN phase. All tests panic at runtime — that is the expected RED signal.
+// ============================================================================
+mod story_119 {
+    use wirerust::findings::{Confidence, Finding, ThreatCategory, Verdict};
+    use wirerust::reporter::Reporter;
+    use wirerust::reporter::terminal::{Collapse, FindingsRender, Grouping, TerminalReporter};
+    use wirerust::summary::Summary;
+
+    // -----------------------------------------------------------------------
+    // Module-level helpers
+    // -----------------------------------------------------------------------
+
+    /// Returns a `TerminalReporter` wired to `{Grouped, Collapsed}` with
+    /// color and hosts-breakdown disabled. This is the canonical reporter for
+    /// all STORY-119/B grouped-collapse behavioral tests.
+    ///
+    /// Fields used: `use_color`, `show_hosts_breakdown`, `render` —
+    /// `TerminalReporter` has no `findings` field (STORY-119/B Previous Story
+    /// Intelligence lesson 3).
+    fn grouped_collapse_reporter() -> TerminalReporter {
+        TerminalReporter {
+            use_color: false,
+            show_hosts_breakdown: false,
+            render: FindingsRender {
+                grouping: Grouping::Grouped,
+                collapse: Collapse::Collapsed,
+            },
+        }
+    }
+
+    /// Returns a `TerminalReporter` wired to `{Grouped, Collapsed}` WITH
+    /// color enabled. Used by the color-ladder test (AC-008 / BC-2.11.031 PC-3).
+    fn grouped_collapse_reporter_color() -> TerminalReporter {
+        TerminalReporter {
+            use_color: true,
+            show_hosts_breakdown: false,
+            render: FindingsRender {
+                grouping: Grouping::Grouped,
+                collapse: Collapse::Collapsed,
+            },
+        }
+    }
+
+    /// Returns a `TerminalReporter` wired to `{Grouped, Expanded}` (the
+    /// `--mitre --no-collapse` path). Used to verify suffix-free behaviour and
+    /// byte-identical singleton output.
+    fn grouped_expanded_reporter() -> TerminalReporter {
+        TerminalReporter {
+            use_color: false,
+            show_hosts_breakdown: false,
+            render: FindingsRender {
+                grouping: Grouping::Grouped,
+                collapse: Collapse::Expanded,
+            },
+        }
+    }
+
+    /// Builds a minimal `Finding` with the given `summary`, no evidence, no
+    /// MITRE techniques, `Verdict::Likely`, `Confidence::High`.
+    fn make_finding_s119(summary: impl Into<String>) -> Finding {
+        Finding {
+            category: ThreatCategory::Anomaly,
+            verdict: Verdict::Likely,
+            confidence: Confidence::High,
+            summary: summary.into(),
+            evidence: vec![],
+            mitre_techniques: vec![],
+            source_ip: None,
+            timestamp: None,
+            direction: None,
+        }
+    }
+
+    /// Builds a `Finding` with a known MITRE technique T1046 (Discovery tactic).
+    /// T1046 → "Network Service Discovery" per `technique_info`.
+    fn make_discovery_finding_s119(summary: impl Into<String>) -> Finding {
+        Finding {
+            category: ThreatCategory::Anomaly,
+            verdict: Verdict::Likely,
+            confidence: Confidence::High,
+            summary: summary.into(),
+            evidence: vec![],
+            mitre_techniques: vec!["T1046".to_string()],
+            source_ip: None,
+            timestamp: None,
+            direction: None,
+        }
+    }
+
+    /// Builds a `Finding` with a known MITRE technique T1071 (Command and
+    /// Control tactic). T1071 → "Application Layer Protocol".
+    fn make_c2_finding_s119(summary: impl Into<String>) -> Finding {
+        Finding {
+            category: ThreatCategory::Anomaly,
+            verdict: Verdict::Likely,
+            confidence: Confidence::High,
+            summary: summary.into(),
+            evidence: vec![],
+            mitre_techniques: vec!["T1071".to_string()],
+            source_ip: None,
+            timestamp: None,
+            direction: None,
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // AC-001 — `--mitre` alone routes to {Grouped, Collapsed}
+    // (traces to BC-2.11.030 PC-2)
+    // -----------------------------------------------------------------------
+
+    /// AC-001 (BC-2.11.030 Postcondition 2):
+    /// REGRESSION GUARD: The `run_analyze` construction site produces
+    /// `FindingsRender { grouping: Grouping::Grouped, collapse: Collapse::Collapsed }`
+    /// when `show_mitre_grouping == true` and `collapse_findings == true`
+    /// (`--mitre` alone, default collapse enabled).
+    ///
+    /// Verified via the observable dispatch: a reporter constructed with
+    /// `{Grouped, Collapsed}` exercises `render_findings_grouped_collapsed`.
+    /// A FINDINGS section with grouped-collapse output appears in the rendered
+    /// string (tactic headers and `(xN)` suffix for N≥2 groups).
+    #[test]
+    fn test_BC_2_11_030_mitre_alone_maps_to_grouped_collapsed() {
+        // Construct the reporter exactly as run_analyze does when
+        // show_mitre_grouping=true, collapse_findings=true.
+        let render = FindingsRender {
+            grouping: if true { Grouping::Grouped } else { Grouping::Flat },
+            collapse: if true { Collapse::Collapsed } else { Collapse::Expanded },
+        };
+        assert_eq!(
+            render,
+            FindingsRender {
+                grouping: Grouping::Grouped,
+                collapse: Collapse::Collapsed,
+            },
+            "AC-001: --mitre alone (show_mitre_grouping=true, collapse_findings=true) \
+             must produce {{Grouped, Collapsed}}"
+        );
+
+        // Observable render: N=3 identical-key findings in one tactic bucket
+        // must produce a header with `(x3)` suffix — the grouped-collapse path.
+        let findings: Vec<Finding> = (0..3)
+            .map(|_| make_discovery_finding_s119("s119-ac001-mitre-collapse"))
+            .collect();
+        let out = TerminalReporter {
+            use_color: false,
+            show_hosts_breakdown: false,
+            render,
+        }
+        .render(&Summary::new(), &findings, &[]);
+        assert!(
+            out.contains("(x3)"),
+            "AC-001: {{Grouped,Collapsed}} with N=3 identical findings must emit \
+             `(x3)` suffix; got:\n{out}"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // AC-002 — `--mitre --no-collapse` routes to {Grouped, Expanded}
+    // (traces to BC-2.11.030 PC-3)
+    // -----------------------------------------------------------------------
+
+    /// AC-002 (BC-2.11.030 Postcondition 3):
+    /// REGRESSION GUARD: The `run_analyze` construction site produces
+    /// `FindingsRender { grouping: Grouping::Grouped, collapse: Collapse::Expanded }`
+    /// when `show_mitre_grouping == true` and `collapse_findings == false`
+    /// (`--mitre` with `--no-collapse`).
+    #[test]
+    fn test_BC_2_11_030_mitre_no_collapse_maps_to_grouped_expanded() {
+        let render = FindingsRender {
+            grouping: if true { Grouping::Grouped } else { Grouping::Flat },
+            collapse: if false { Collapse::Collapsed } else { Collapse::Expanded },
+        };
+        assert_eq!(
+            render,
+            FindingsRender {
+                grouping: Grouping::Grouped,
+                collapse: Collapse::Expanded,
+            },
+            "AC-002: --mitre --no-collapse (show_mitre_grouping=true, collapse_findings=false) \
+             must produce {{Grouped, Expanded}}"
+        );
+
+        // Observable render: {Grouped, Expanded} must not emit any `(xN)` suffix.
+        let findings: Vec<Finding> = (0..3)
+            .map(|_| make_discovery_finding_s119("s119-ac002-mitre-expanded"))
+            .collect();
+        let out = TerminalReporter {
+            use_color: false,
+            show_hosts_breakdown: false,
+            render,
+        }
+        .render(&Summary::new(), &findings, &[]);
+        assert!(
+            !out.contains("(x"),
+            "AC-002: {{Grouped,Expanded}} must not emit any `(xN)` suffix; got:\n{out}"
+        );
+        assert!(
+            out.contains("## "),
+            "AC-002: {{Grouped,Expanded}} must emit tactic headers; got:\n{out}"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // AC-003 — flat-mode routing unchanged at construction site
+    // (traces to BC-2.11.030 PC-4 and PC-5)
+    // -----------------------------------------------------------------------
+
+    /// AC-003 (BC-2.11.030 Postconditions 4 and 5):
+    /// REGRESSION GUARD: Flat-mode `FindingsRender` wiring at the `run_analyze`
+    /// construction site is unchanged.
+    ///
+    /// BC-2.11.030 PC-4: "When neither `--mitre` nor `--no-collapse` is present
+    /// (the default terminal output): `render == FindingsRender { grouping:
+    /// Grouping::Flat, collapse: Collapse::Collapsed }`. Unchanged from
+    /// pre-STORY-119 behavior."
+    ///
+    /// BC-2.11.030 PC-5: "When `--no-collapse` is present but `--mitre` is
+    /// absent: `render == FindingsRender { grouping: Grouping::Flat, collapse:
+    /// Collapse::Expanded }`. Unchanged from pre-STORY-119 behavior."
+    #[test]
+    fn test_BC_2_11_030_flat_routing_unchanged() {
+        // PC-4: default (no --mitre, no --no-collapse)
+        let default_render = FindingsRender {
+            grouping: if false { Grouping::Grouped } else { Grouping::Flat },
+            collapse: if true { Collapse::Collapsed } else { Collapse::Expanded },
+        };
+        assert_eq!(
+            default_render,
+            FindingsRender {
+                grouping: Grouping::Flat,
+                collapse: Collapse::Collapsed,
+            },
+            "AC-003 PC-4: default routing must produce {{Flat, Collapsed}}"
+        );
+
+        // PC-5: --no-collapse without --mitre
+        let no_collapse_flat_render = FindingsRender {
+            grouping: if false { Grouping::Grouped } else { Grouping::Flat },
+            collapse: if false { Collapse::Collapsed } else { Collapse::Expanded },
+        };
+        assert_eq!(
+            no_collapse_flat_render,
+            FindingsRender {
+                grouping: Grouping::Flat,
+                collapse: Collapse::Expanded,
+            },
+            "AC-003 PC-5: --no-collapse without --mitre must produce {{Flat, Expanded}}"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // AC-006 — per-bucket collapse: N≥2 group renders header with `(xN)` suffix
+    // (traces to BC-2.11.031 PC-1)
+    // -----------------------------------------------------------------------
+
+    /// AC-006 (BC-2.11.031 Postcondition 1):
+    /// REGRESSION GUARD: For a group of N=3 findings sharing the same collapse
+    /// key within a MITRE tactic bucket under `{Grouped, Collapsed}`, the header
+    /// line contains ` (x3)` — a space before the opening parenthesis, exact
+    /// decimal N, no leading zeros.
+    #[test]
+    fn test_BC_2_11_031_grouped_collapse_suffix_format() {
+        let findings: Vec<Finding> = (0..3)
+            .map(|_| make_discovery_finding_s119("s119-ac006-suffix"))
+            .collect();
+        let out = grouped_collapse_reporter().render(&Summary::new(), &findings, &[]);
+
+        // BC-2.11.031 PC-1: header line contains ` (x3)` suffix.
+        assert!(
+            out.contains("(x3)"),
+            "AC-006: N=3 group in bucket must emit `(x3)` suffix; got:\n{out}"
+        );
+        // Tactic header for Discovery must be present.
+        assert!(
+            out.contains("## Discovery"),
+            "AC-006: Discovery bucket header must appear; got:\n{out}"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // AC-007 — singleton (N=1) renders via render_finding_grouped, no suffix
+    // (traces to BC-2.11.031 PC-2)
+    // -----------------------------------------------------------------------
+
+    /// AC-007 (BC-2.11.031 Postcondition 2):
+    /// REGRESSION GUARD: A singleton finding (N=1 within a bucket) under
+    /// `{Grouped, Collapsed}` renders via `render_finding_grouped` with no
+    /// `(xN)` suffix — byte-identical to `{Grouped, Expanded}` for that finding.
+    #[test]
+    fn test_BC_2_11_031_singleton_no_suffix_in_bucket() {
+        let findings = vec![make_discovery_finding_s119("s119-ac007-singleton")];
+
+        let out_collapsed = grouped_collapse_reporter().render(&Summary::new(), &findings, &[]);
+        let out_expanded = grouped_expanded_reporter().render(&Summary::new(), &findings, &[]);
+
+        // BC-2.11.031 PC-2: singleton output is byte-identical to {Grouped, Expanded}.
+        assert_eq!(
+            out_collapsed, out_expanded,
+            "AC-007: singleton under {{Grouped,Collapsed}} must be byte-identical to \
+             {{Grouped,Expanded}}; outputs differ"
+        );
+        // No (xN) suffix anywhere in output.
+        assert!(
+            !out_collapsed.contains("(x"),
+            "AC-007: singleton must not emit any `(xN)` suffix; got:\n{out_collapsed}"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // AC-008 — color-ladder: `(xN)` suffix is part of the pre-colorization string
+    // (traces to BC-2.11.031 PC-3)
+    // -----------------------------------------------------------------------
+
+    /// AC-008 (BC-2.11.031 Postcondition 3):
+    /// REGRESSION GUARD: For a `Likely + High` group of N=2 under
+    /// `{Grouped, Collapsed}` with `use_color: true`, the ` (x2)` suffix
+    /// is inside the ANSI color span (i.e., it appears before the ANSI reset
+    /// sequence, not after it). Verified by asserting the suffix is NOT
+    /// preceded by an ANSI reset `\x1b[0m` in the output.
+    #[test]
+    fn test_BC_2_11_031_grouped_collapse_color_ladder() {
+        let findings: Vec<Finding> = (0..2)
+            .map(|_| Finding {
+                category: ThreatCategory::Anomaly,
+                verdict: Verdict::Likely,
+                confidence: Confidence::High,
+                summary: "s119-ac008-color".to_string(),
+                evidence: vec![],
+                mitre_techniques: vec!["T1046".to_string()],
+                source_ip: None,
+                timestamp: None,
+                direction: None,
+            })
+            .collect();
+        let out = grouped_collapse_reporter_color().render(&Summary::new(), &findings, &[]);
+
+        // BC-2.11.031 PC-3: the suffix must appear in the output.
+        assert!(
+            out.contains("(x2)"),
+            "AC-008: N=2 group with color must still emit `(x2)` suffix; got:\n{out}"
+        );
+        // The ANSI reset sequence (\x1b[0m) must NOT appear BEFORE `(x2)` on
+        // the same header line. Verify by checking that `(x2)` does not appear
+        // after a reset on the header line.
+        let header_line = out
+            .lines()
+            .find(|l| l.contains("(x2)"))
+            .unwrap_or_default();
+        // Split by reset: if (x2) appears in the LAST segment (after reset),
+        // the suffix was appended after the ANSI reset — NON-CONFORMANT.
+        let reset = "\x1b[0m";
+        let after_reset = header_line
+            .rfind(reset)
+            .map(|pos| &header_line[pos + reset.len()..])
+            .unwrap_or("");
+        assert!(
+            !after_reset.contains("(x2)"),
+            "AC-008: `(x2)` must be inside the ANSI color span (before reset), \
+             not after the reset sequence. Header line: {header_line:?}"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // AC-009 — `(xN)` suffix NOT on MITRE line, evidence lines, or bucket headers
+    // (traces to BC-2.11.031 PC-4)
+    // -----------------------------------------------------------------------
+
+    /// AC-009 (BC-2.11.031 Postcondition 4):
+    /// REGRESSION GUARD: The ` (xN)` suffix appears ONLY on the finding-group
+    /// header line. It must not appear on the MITRE line (`    MITRE: ...`),
+    /// evidence lines (`    > ...`), or the tactic bucket header (`  ## ...`).
+    #[test]
+    fn test_BC_2_11_031_suffix_only_on_header_not_mitre_or_evidence() {
+        let findings: Vec<Finding> = (0..3)
+            .map(|_| Finding {
+                category: ThreatCategory::Anomaly,
+                verdict: Verdict::Likely,
+                confidence: Confidence::High,
+                summary: "s119-ac009-no-suffix-leak".to_string(),
+                evidence: vec!["evidence-line".to_string()],
+                mitre_techniques: vec!["T1046".to_string()],
+                source_ip: None,
+                timestamp: None,
+                direction: None,
+            })
+            .collect();
+        let out = grouped_collapse_reporter().render(&Summary::new(), &findings, &[]);
+
+        // `(x3)` must appear somewhere in output.
+        assert!(
+            out.contains("(x3)"),
+            "AC-009: N=3 group must emit `(x3)` suffix; got:\n{out}"
+        );
+
+        // `(xN)` must NOT appear on any MITRE line, evidence line, or bucket header.
+        for line in out.lines() {
+            let trimmed = line.trim_start();
+            if trimmed.starts_with("MITRE:") {
+                assert!(
+                    !line.contains("(x"),
+                    "AC-009: `(xN)` must not appear on MITRE line: {line:?}"
+                );
+            }
+            if trimmed.starts_with("> ") {
+                assert!(
+                    !line.contains("(x"),
+                    "AC-009: `(xN)` must not appear on evidence line: {line:?}"
+                );
+            }
+            if trimmed.starts_with("## ") {
+                assert!(
+                    !line.contains("(x"),
+                    "AC-009: `(xN)` must not appear on tactic bucket header: {line:?}"
+                );
+            }
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // AC-010 — cross-bucket suffix independence
+    // (traces to BC-2.11.031 PC-6)
+    // -----------------------------------------------------------------------
+
+    /// AC-010 (BC-2.11.031 Postcondition 6):
+    /// REGRESSION GUARD: Two groups with the same collapse key but in different
+    /// MITRE tactic buckets produce independent `(xN)` suffixes. A group of 3
+    /// in the Discovery bucket (T1046) and a group of 2 in the Command and
+    /// Control bucket (T1071) produce `(x3)` and `(x2)` respectively — never
+    /// merged to `(x5)`.
+    #[test]
+    fn test_BC_2_11_031_cross_bucket_suffix_independence() {
+        // 3 findings with same summary → Discovery bucket (T1046).
+        let mut findings: Vec<Finding> = (0..3)
+            .map(|_| Finding {
+                category: ThreatCategory::Anomaly,
+                verdict: Verdict::Likely,
+                confidence: Confidence::High,
+                summary: "s119-ac010-shared-key".to_string(),
+                evidence: vec![],
+                mitre_techniques: vec!["T1046".to_string()],
+                source_ip: None,
+                timestamp: None,
+                direction: None,
+            })
+            .collect();
+        // 2 findings with same summary → Command and Control bucket (T1071).
+        findings.extend((0..2).map(|_| Finding {
+            category: ThreatCategory::Anomaly,
+            verdict: Verdict::Likely,
+            confidence: Confidence::High,
+            summary: "s119-ac010-shared-key".to_string(),
+            evidence: vec![],
+            mitre_techniques: vec!["T1071".to_string()],
+            source_ip: None,
+            timestamp: None,
+            direction: None,
+        }));
+
+        let out = grouped_collapse_reporter().render(&Summary::new(), &findings, &[]);
+
+        // Each bucket must produce its own independent suffix.
+        assert!(
+            out.contains("(x3)"),
+            "AC-010: Discovery bucket (3 findings) must emit `(x3)`; got:\n{out}"
+        );
+        assert!(
+            out.contains("(x2)"),
+            "AC-010: C&C bucket (2 findings) must emit `(x2)`; got:\n{out}"
+        );
+        // No cross-bucket merge to (x5).
+        assert!(
+            !out.contains("(x5)"),
+            "AC-010: cross-bucket merge must not occur — `(x5)` must not appear; got:\n{out}"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // AC-011 — per-bucket evidence sampling: at most K=3 lines per N≥2 group
+    // (traces to BC-2.11.032 PC-1)
+    // -----------------------------------------------------------------------
+
+    /// AC-011 (BC-2.11.032 Postconditions 1–2):
+    /// REGRESSION GUARD: For a collapsed group of N=5 in a tactic bucket, each
+    /// member with one evidence line, the terminal output contains at most K=3
+    /// evidence lines (`    > ` prefix).
+    #[test]
+    fn test_BC_2_11_032_evidence_sampling_k3_in_bucket() {
+        let findings: Vec<Finding> = (0..5)
+            .map(|i| Finding {
+                category: ThreatCategory::Anomaly,
+                verdict: Verdict::Likely,
+                confidence: Confidence::High,
+                summary: "s119-ac011-k3-evidence".to_string(),
+                evidence: vec![format!("ev-{i}")],
+                mitre_techniques: vec!["T1046".to_string()],
+                source_ip: None,
+                timestamp: None,
+                direction: None,
+            })
+            .collect();
+
+        let out = grouped_collapse_reporter().render(&Summary::new(), &findings, &[]);
+
+        let evidence_count = out
+            .lines()
+            .filter(|l| l.trim_start().starts_with("> "))
+            .count();
+        assert!(
+            evidence_count <= 3,
+            "AC-011: K=3 evidence cap — at most 3 evidence lines; got {evidence_count} in:\n{out}"
+        );
+        assert!(
+            evidence_count >= 1,
+            "AC-011: at least 1 evidence line expected from evidence-bearing group; \
+             got {evidence_count} in:\n{out}"
+        );
+        // `(x5)` suffix must be present (group of 5).
+        assert!(
+            out.contains("(x5)"),
+            "AC-011: N=5 group must emit `(x5)` suffix; got:\n{out}"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // AC-011 edge — no sliding window: empty-evidence member blocks window
+    // (traces to BC-2.11.032 Invariant 2)
+    // -----------------------------------------------------------------------
+
+    /// AC-011 edge (BC-2.11.032 Invariant 2):
+    /// REGRESSION GUARD: For a group of N=5, `members[0].evidence = []` (empty),
+    /// `members[1..4]` each have one evidence line. The positional window
+    /// inspects members[0], [1], [2] — member[0] contributes 0 lines (no
+    /// sliding), members[1] and [2] each contribute 1 line. Total = 2 evidence
+    /// lines; NOT 3.
+    #[test]
+    fn test_BC_2_11_032_evidence_positional_no_slide() {
+        // members[0]: no evidence.
+        let mut findings = vec![Finding {
+            category: ThreatCategory::Anomaly,
+            verdict: Verdict::Likely,
+            confidence: Confidence::High,
+            summary: "s119-ac011b-no-slide".to_string(),
+            evidence: vec![],
+            mitre_techniques: vec!["T1046".to_string()],
+            source_ip: None,
+            timestamp: None,
+            direction: None,
+        }];
+        // members[1..4]: each with one evidence line.
+        findings.extend((1..5).map(|i| Finding {
+            category: ThreatCategory::Anomaly,
+            verdict: Verdict::Likely,
+            confidence: Confidence::High,
+            summary: "s119-ac011b-no-slide".to_string(),
+            evidence: vec![format!("ev-{i}")],
+            mitre_techniques: vec!["T1046".to_string()],
+            source_ip: None,
+            timestamp: None,
+            direction: None,
+        }));
+
+        let out = grouped_collapse_reporter().render(&Summary::new(), &findings, &[]);
+
+        // Window inspects members[0..min(5,3)=3]. members[0]: 0 lines; [1] and [2]: 1 each.
+        let evidence_count = out
+            .lines()
+            .filter(|l| l.trim_start().starts_with("> "))
+            .count();
+        assert_eq!(
+            evidence_count, 2,
+            "AC-011 edge: positional no-slide — members[0] empty, window=[0,1,2], \
+             expected 2 evidence lines; got {evidence_count} in:\n{out}"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // AC-013 — tactic-bucket ordering invariant under {Grouped, Collapsed}
+    // (traces to BC-2.11.033 PC-1 / VP-016)
+    // -----------------------------------------------------------------------
+
+    /// AC-013 (BC-2.11.033 Postconditions 1–2 / VP-016):
+    /// REGRESSION GUARD: Tactic bucket headers appear in the order returned by
+    /// `all_tactics_in_report_order()` under `{Grouped, Collapsed}`. Discovery
+    /// (index 8) appears before Command and Control (index 11) in the output.
+    #[test]
+    fn test_BC_2_11_033_grouped_collapsed_preserves_bucket_order() {
+        // Findings in two tactics in reverse order to confirm sorted output.
+        let mut findings: Vec<Finding> = (0..2)
+            .map(|_| make_c2_finding_s119("s119-ac013-c2")) // C&C = later bucket
+            .collect();
+        findings.extend((0..2).map(|_| make_discovery_finding_s119("s119-ac013-disc"))); // Discovery = earlier
+
+        let out = grouped_collapse_reporter().render(&Summary::new(), &findings, &[]);
+
+        let disc_pos = out.find("## Discovery");
+        let c2_pos = out.find("## Command and Control");
+
+        assert!(
+            disc_pos.is_some(),
+            "AC-013: Discovery bucket header must appear; got:\n{out}"
+        );
+        assert!(
+            c2_pos.is_some(),
+            "AC-013: Command and Control bucket header must appear; got:\n{out}"
+        );
+        assert!(
+            disc_pos.unwrap() < c2_pos.unwrap(),
+            "AC-013: Discovery (index 8) must appear before Command and Control (index 11) \
+             per all_tactics_in_report_order(); got:\n{out}"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // AC-014 — `Uncategorized` emitted last under {Grouped, Collapsed}
+    // (traces to BC-2.11.033 PC-3)
+    // -----------------------------------------------------------------------
+
+    /// AC-014 (BC-2.11.033 Postcondition 3):
+    /// REGRESSION GUARD: The `Uncategorized` bucket header appears last among
+    /// emitted buckets under `{Grouped, Collapsed}`.
+    #[test]
+    fn test_BC_2_11_033_uncategorized_last_under_grouped_collapse() {
+        // One finding in Discovery, two uncategorized (no mitre_techniques).
+        let mut findings = vec![make_discovery_finding_s119("s119-ac014-disc")];
+        findings.extend((0..2).map(|_| make_finding_s119("s119-ac014-uncategorized")));
+
+        let out = grouped_collapse_reporter().render(&Summary::new(), &findings, &[]);
+
+        let disc_pos = out.find("## Discovery");
+        let uncat_pos = out.find("## Uncategorized");
+
+        assert!(
+            disc_pos.is_some(),
+            "AC-014: Discovery bucket header must appear; got:\n{out}"
+        );
+        assert!(
+            uncat_pos.is_some(),
+            "AC-014: Uncategorized bucket header must appear; got:\n{out}"
+        );
+        assert!(
+            disc_pos.unwrap() < uncat_pos.unwrap(),
+            "AC-014: Uncategorized must appear after Discovery — Uncategorized is last; \
+             got:\n{out}"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // AC-015 — bucket membership unchanged by collapse
+    // (traces to BC-2.11.033 PC-4)
+    // -----------------------------------------------------------------------
+
+    /// AC-015 (BC-2.11.033 Postcondition 4):
+    /// REGRESSION GUARD: A finding assigned to the Discovery bucket under
+    /// `{Grouped, Expanded}` is assigned to the same bucket under `{Grouped,
+    /// Collapsed}`. The collapse key is orthogonal to bucket assignment.
+    #[test]
+    fn test_BC_2_11_033_different_buckets_not_cross_collapsed() {
+        // Two findings with the same summary but different MITRE techniques
+        // (different buckets). They must NOT be cross-collapsed.
+        let findings = vec![
+            Finding {
+                category: ThreatCategory::Anomaly,
+                verdict: Verdict::Likely,
+                confidence: Confidence::High,
+                summary: "s119-ac015-same-key".to_string(),
+                evidence: vec![],
+                mitre_techniques: vec!["T1046".to_string()], // Discovery
+                source_ip: None,
+                timestamp: None,
+                direction: None,
+            },
+            Finding {
+                category: ThreatCategory::Anomaly,
+                verdict: Verdict::Likely,
+                confidence: Confidence::High,
+                summary: "s119-ac015-same-key".to_string(),
+                evidence: vec![],
+                mitre_techniques: vec!["T1071".to_string()], // C&C
+                source_ip: None,
+                timestamp: None,
+                direction: None,
+            },
+        ];
+
+        let out = grouped_collapse_reporter().render(&Summary::new(), &findings, &[]);
+
+        // Both bucket headers must appear (two separate buckets, not merged).
+        assert!(
+            out.contains("## Discovery"),
+            "AC-015: Discovery bucket header must appear (same key, different tactic); \
+             got:\n{out}"
+        );
+        assert!(
+            out.contains("## Command and Control"),
+            "AC-015: C&C bucket header must appear (same key, different tactic); got:\n{out}"
+        );
+        // No cross-bucket merge: `(x2)` must NOT appear (each bucket has only 1).
+        assert!(
+            !out.contains("(x2)"),
+            "AC-015: cross-bucket collapse must not occur — `(x2)` must not appear; \
+             got:\n{out}"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // AC-016 / AC-017 — sort-then-collapse: post-sort order determines representative
+    // (traces to BC-2.11.033 PC-5/6)
+    // -----------------------------------------------------------------------
+
+    /// AC-016/AC-017 (BC-2.11.033 Postconditions 5 and 6):
+    /// REGRESSION GUARD: Within a bucket, findings are sorted by verdict-rank
+    /// ascending (Likely=0, Possible=1, Inconclusive=2, Unlikely=3) BEFORE the
+    /// collapse pass. The lower-rank (higher-severity) finding becomes
+    /// `members[0]` (the group representative).
+    ///
+    /// Test: two findings with the same collapse key in one bucket —
+    /// one `Likely` (rank=0) and one `Inconclusive` (rank=2). The `Likely`
+    /// finding sorts first → becomes `members[0]` → its fields appear in the
+    /// header. The header verdict must be "Likely", not "Inconclusive".
+    #[test]
+    fn test_BC_2_11_033_first_occurrence_in_sorted_bucket_order() {
+        let findings = vec![
+            // Submitted second but sorts first by verdict-rank.
+            Finding {
+                category: ThreatCategory::Anomaly,
+                verdict: Verdict::Inconclusive, // rank=2
+                confidence: Confidence::Low,
+                summary: "s119-ac016-sort-key".to_string(),
+                evidence: vec![],
+                mitre_techniques: vec!["T1046".to_string()],
+                source_ip: None,
+                timestamp: None,
+                direction: None,
+            },
+            // Submitted first but sorts second.
+            Finding {
+                category: ThreatCategory::Anomaly,
+                verdict: Verdict::Likely, // rank=0 — sorts first
+                confidence: Confidence::High,
+                summary: "s119-ac016-sort-key".to_string(),
+                evidence: vec![],
+                mitre_techniques: vec!["T1046".to_string()],
+                source_ip: None,
+                timestamp: None,
+                direction: None,
+            },
+        ];
+
+        let out = grouped_collapse_reporter().render(&Summary::new(), &findings, &[]);
+
+        // `(x2)` suffix must appear (N=2 group).
+        assert!(
+            out.contains("(x2)"),
+            "AC-016: N=2 group in bucket must emit `(x2)` suffix; got:\n{out}"
+        );
+
+        // The header verdict must be "Likely" (the sorted-first representative),
+        // not "Inconclusive". Find the header line (contains `(x2)`).
+        let header_line = out
+            .lines()
+            .find(|l| l.contains("(x2)"))
+            .unwrap_or_default();
+        assert!(
+            header_line.contains("Likely"),
+            "AC-016: post-sort representative must be Likely (rank=0 sorts first); \
+             header line: {header_line:?}\nfull output:\n{out}"
+        );
+        assert!(
+            !header_line.contains("Inconclusive"),
+            "AC-016: Inconclusive (rank=2) must NOT be the representative; \
+             header line: {header_line:?}\nfull output:\n{out}"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // AC-018 / AC-021 — MITRE line from members[0] with em-dash format
+    // (traces to BC-2.11.034 PC-1 and PC-5)
+    // -----------------------------------------------------------------------
+
+    /// AC-018 / AC-021 (BC-2.11.034 Postconditions 1 and 5):
+    /// REGRESSION GUARD: For a collapsed N≥2 group, the MITRE line is rendered
+    /// from `group_members[0].mitre_techniques` using em-dash expansion
+    /// (U+2014, not ASCII `--`). The observable line format is:
+    /// `    MITRE: T1046 — Network Service Discovery`.
+    ///
+    /// Output block order: (1) header with `(xN)`, (2) evidence lines,
+    /// (3) MITRE line. The `(xN)` suffix appears ONLY in item (1).
+    #[test]
+    fn test_BC_2_11_034_grouped_collapse_mitre_line_em_dash_format() {
+        let findings: Vec<Finding> = (0..2)
+            .map(|_| Finding {
+                category: ThreatCategory::Anomaly,
+                verdict: Verdict::Likely,
+                confidence: Confidence::High,
+                summary: "s119-ac018-mitre-em-dash".to_string(),
+                evidence: vec![],
+                mitre_techniques: vec!["T1046".to_string()],
+                source_ip: None,
+                timestamp: None,
+                direction: None,
+            })
+            .collect();
+
+        let out = grouped_collapse_reporter().render(&Summary::new(), &findings, &[]);
+
+        // BC-2.11.034 PC-1: em-dash (U+2014) + name on MITRE line.
+        assert!(
+            out.contains("T1046 \u{2014} Network Service Discovery"),
+            "AC-018: MITRE line must use em-dash (U+2014) + name from members[0]; got:\n{out}"
+        );
+        // `(x2)` suffix on header.
+        assert!(
+            out.contains("(x2)"),
+            "AC-018: header must carry `(x2)` suffix; got:\n{out}"
+        );
+        // Block order: header (with `(x2)`) must appear before MITRE line.
+        let header_pos = out.find("(x2)").unwrap_or(usize::MAX);
+        let mitre_pos = out.find("MITRE: T1046").unwrap_or(usize::MAX);
+        assert!(
+            header_pos < mitre_pos,
+            "AC-021: header (with `(x2)`) must appear before MITRE line; got:\n{out}"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // AC-018 edge — unknown technique in collapsed group
+    // (traces to BC-2.11.034 PC-1 unknown-ID branch)
+    // -----------------------------------------------------------------------
+
+    /// AC-018 edge (BC-2.11.034 Postcondition 1 — unknown ID):
+    /// REGRESSION GUARD: For a collapsed N≥2 group where `members[0]` has an
+    /// unknown technique ID, the MITRE line format is
+    /// `    MITRE: <ids_joined> (unknown)` — not an em-dash expansion.
+    #[test]
+    fn test_BC_2_11_034_unknown_technique_in_grouped_collapse() {
+        let findings: Vec<Finding> = (0..2)
+            .map(|_| Finding {
+                category: ThreatCategory::Anomaly,
+                verdict: Verdict::Likely,
+                confidence: Confidence::High,
+                summary: "s119-ac018b-unknown-tech".to_string(),
+                evidence: vec![],
+                mitre_techniques: vec!["T9999".to_string()], // unknown ID
+                source_ip: None,
+                timestamp: None,
+                direction: None,
+            })
+            .collect();
+
+        let out = grouped_collapse_reporter().render(&Summary::new(), &findings, &[]);
+
+        assert!(
+            out.contains("(x2)"),
+            "AC-018 edge: N=2 group with unknown technique must emit `(x2)` suffix; \
+             got:\n{out}"
+        );
+        assert!(
+            out.contains("T9999 (unknown)"),
+            "AC-018 edge: unknown technique ID must produce `(unknown)` format on MITRE line; \
+             got:\n{out}"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // AC-019 — `(xN)` suffix NOT on MITRE line for N≥2 groups
+    // (traces to BC-2.11.034 PC-2)
+    // -----------------------------------------------------------------------
+
+    /// AC-019 (BC-2.11.034 Postcondition 2):
+    /// REGRESSION GUARD: The `(xN)` count suffix does not appear on the MITRE
+    /// line for N≥2 collapsed groups. The suffix is scoped to the header line
+    /// only (verified together with AC-009).
+    #[test]
+    fn test_BC_2_11_034_suffix_not_on_mitre_line() {
+        let findings: Vec<Finding> = (0..3)
+            .map(|_| make_discovery_finding_s119("s119-ac019-no-suffix-mitre"))
+            .collect();
+
+        let out = grouped_collapse_reporter().render(&Summary::new(), &findings, &[]);
+
+        // `(x3)` must appear (on header).
+        assert!(
+            out.contains("(x3)"),
+            "AC-019: `(x3)` must appear in output; got:\n{out}"
+        );
+        // The MITRE line must not contain any `(xN)`.
+        for line in out.lines() {
+            if line.trim_start().starts_with("MITRE:") {
+                assert!(
+                    !line.contains("(x"),
+                    "AC-019: `(xN)` must not appear on MITRE line: {line:?}"
+                );
+            }
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // AC-020 — divergent MITRE: only members[0] appears in terminal output
+    // (traces to BC-2.11.034 PC-3)
+    // -----------------------------------------------------------------------
+
+    /// AC-020 (BC-2.11.034 Postcondition 3):
+    /// REGRESSION GUARD: For a collapsed group of N≥2 where members have
+    /// divergent `mitre_techniques`, only `members[0]`'s technique appears on
+    /// the MITRE line. The other members' techniques are elided from terminal
+    /// output (preserved in raw findings for JSON/CSV).
+    #[test]
+    fn test_BC_2_11_034_divergent_mitre_representative_sourcing() {
+        // Two findings with same collapse key but different MITRE techniques.
+        // After sort (Likely rank=0 for both, same confidence), the first
+        // submitted becomes members[0] (stable emission-index tiebreak).
+        let findings = vec![
+            Finding {
+                category: ThreatCategory::Anomaly,
+                verdict: Verdict::Likely,
+                confidence: Confidence::High,
+                summary: "s119-ac020-divergent-mitre".to_string(),
+                evidence: vec![],
+                mitre_techniques: vec!["T1046".to_string()], // members[0]
+                source_ip: None,
+                timestamp: None,
+                direction: None,
+            },
+            Finding {
+                category: ThreatCategory::Anomaly,
+                verdict: Verdict::Likely,
+                confidence: Confidence::High,
+                summary: "s119-ac020-divergent-mitre".to_string(),
+                evidence: vec![],
+                mitre_techniques: vec!["T1071".to_string()], // members[1] — must be elided
+                source_ip: None,
+                timestamp: None,
+                direction: None,
+            },
+        ];
+
+        let out = grouped_collapse_reporter().render(&Summary::new(), &findings, &[]);
+
+        // members[0]'s technique must appear on the MITRE line.
+        assert!(
+            out.contains("T1046"),
+            "AC-020: members[0] technique T1046 must appear in terminal output; got:\n{out}"
+        );
+        // members[1]'s technique must NOT appear in terminal output.
+        assert!(
+            !out.contains("T1071"),
+            "AC-020: members[1] technique T1071 must be elided from terminal output; \
+             got:\n{out}"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // AC-022 — {Grouped, Expanded} suffix-free guarantee unchanged
+    // (traces to BC-2.11.013 Invariant 4)
+    // -----------------------------------------------------------------------
+
+    /// AC-022 (BC-2.11.013 Invariant 4):
+    /// REGRESSION GUARD: Under `render = {Grouped, Expanded}`, N=100 identical-
+    /// key findings in a tactic bucket produce 100 individual finding lines with
+    /// no ` (xN)` suffix on any line. The `{Grouped, Expanded}` suffix-free
+    /// guarantee (pre-STORY-119 `--mitre` behavior) is unchanged.
+    #[test]
+    fn test_BC_2_11_028_no_collapse_with_mitre_produces_grouped_expanded() {
+        let findings: Vec<Finding> = (0..100)
+            .map(|_| make_discovery_finding_s119("s119-ac022-no-collapse-100"))
+            .collect();
+
+        let out = grouped_expanded_reporter().render(&Summary::new(), &findings, &[]);
+
+        // No `(xN)` suffix anywhere.
+        assert!(
+            !out.contains("(x"),
+            "AC-022: {{Grouped,Expanded}} with N=100 identical findings must emit zero \
+             `(xN)` suffixes; got excerpt:\n{}",
+            &out[..out.len().min(500)]
+        );
+        // All 100 findings must be rendered (header line count via `[Anomaly]`).
+        let header_count = out
+            .lines()
+            .filter(|l| l.contains("[Anomaly]"))
+            .count();
+        assert_eq!(
+            header_count, 100,
+            "AC-022: {{Grouped,Expanded}} must render all 100 findings; got {header_count} in \
+             output (first 500 chars):\n{}",
+            &out[..out.len().min(500)]
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // AC-023 — escape_for_terminal applied in grouped-collapse path
+    // (traces to BC-2.11.031 Precondition 5 / VP-012)
+    // -----------------------------------------------------------------------
+
+    /// AC-023 (BC-2.11.031 Precondition 5 / VP-012):
+    /// REGRESSION GUARD: `escape_for_terminal` is applied to all `summary` and
+    /// `evidence` strings in `render_findings_grouped_collapsed`. A summary
+    /// containing a C0 control character (U+0001) must not appear raw in the
+    /// output — it must be escaped to `\x01`.
+    #[test]
+    fn test_BC_2_11_031_escape_for_terminal_in_grouped_collapse_path() {
+        let findings: Vec<Finding> = (0..2)
+            .map(|_| Finding {
+                category: ThreatCategory::Anomaly,
+                verdict: Verdict::Likely,
+                confidence: Confidence::High,
+                // C0 control character in summary — must be escaped.
+                summary: "s119-ac023-\u{0001}escape".to_string(),
+                evidence: vec!["ev-\u{0001}escape".to_string()],
+                mitre_techniques: vec!["T1046".to_string()],
+                source_ip: None,
+                timestamp: None,
+                direction: None,
+            })
+            .collect();
+
+        let out = grouped_collapse_reporter().render(&Summary::new(), &findings, &[]);
+
+        // Raw U+0001 must NOT appear in the output.
+        assert!(
+            !out.contains('\u{0001}'),
+            "AC-023: raw C0 control char U+0001 must not appear in output — \
+             escape_for_terminal must be applied; got:\n{out:?}"
+        );
+        // The escaped form `\\x01` must appear in output (escaped).
+        assert!(
+            out.contains("\\x01"),
+            "AC-023: C0 char must be escaped to `\\x01` in output; got:\n{out:?}"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // AC-024 — collapse_findings_pass_refs called per bucket, not globally
+    // (traces to BC-2.11.033 Invariant 3 / BC-2.11.025 Invariant 5)
+    // -----------------------------------------------------------------------
+
+    /// AC-024 / test_BC_2_11_025_grouped_mode_bypasses_flat_collapse
+    /// (BC-2.11.025 Invariant 5 — updated; BC-2.11.033 Invariant 3):
+    /// REGRESSION GUARD: `render.grouping == Grouping::Grouped` with
+    /// `Collapse::Collapsed` uses per-bucket `collapse_findings_pass_refs`,
+    /// never the global flat `collapse_findings_pass` adapter. Observable
+    /// consequence: two findings with the same summary but in different tactic
+    /// buckets produce two separate group headers (one per bucket), not one
+    /// merged group of N=2.
+    ///
+    /// Note: this test is DISTINCT from the pre-existing siblings
+    /// `test_BC_2_11_025_grouped_mode_bypasses_collapse` (line ~2072) and
+    /// `test_BC_2_11_025_grouped_mode_bypasses_collapse_structurally` (line
+    /// ~4140) which verify the `{Grouped, Expanded}` path. This test verifies
+    /// the `{Grouped, Collapsed}` per-bucket invariant (BC-2.11.025 Inv5).
+    #[test]
+    fn test_BC_2_11_025_grouped_mode_bypasses_flat_collapse() {
+        // Same collapse key, different MITRE tactic → different buckets.
+        // A global flat collapse pass would merge them into one N=2 group.
+        // Per-bucket collapse must produce two separate singleton groups (N=1
+        // each) — neither emits `(x2)` and neither emits a cross-bucket header.
+        let findings = vec![
+            Finding {
+                category: ThreatCategory::Anomaly,
+                verdict: Verdict::Likely,
+                confidence: Confidence::High,
+                summary: "s119-ac024-per-bucket".to_string(),
+                evidence: vec![],
+                mitre_techniques: vec!["T1046".to_string()], // Discovery
+                source_ip: None,
+                timestamp: None,
+                direction: None,
+            },
+            Finding {
+                category: ThreatCategory::Anomaly,
+                verdict: Verdict::Likely,
+                confidence: Confidence::High,
+                summary: "s119-ac024-per-bucket".to_string(),
+                evidence: vec![],
+                mitre_techniques: vec!["T1071".to_string()], // C&C
+                source_ip: None,
+                timestamp: None,
+                direction: None,
+            },
+        ];
+
+        let out = grouped_collapse_reporter().render(&Summary::new(), &findings, &[]);
+
+        // Per-bucket pass: each bucket has N=1 → no `(x2)` suffix.
+        assert!(
+            !out.contains("(x2)"),
+            "AC-024: per-bucket collapse must not cross-collapse findings from different \
+             buckets — `(x2)` must not appear; got:\n{out}"
+        );
+        // Both bucket headers must appear (each bucket independently emitted).
+        assert!(
+            out.contains("## Discovery"),
+            "AC-024: Discovery bucket header must appear; got:\n{out}"
+        );
+        assert!(
+            out.contains("## Command and Control"),
+            "AC-024: C&C bucket header must appear; got:\n{out}"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // AC-025 — flat paths byte-identical
+    // (traces to BC-2.11.025 Invariant 5)
+    // -----------------------------------------------------------------------
+
+    /// AC-025 (BC-2.11.025 Invariant 5):
+    /// REGRESSION GUARD: The `{Flat, Collapsed}` arm calls `render_findings_collapsed`
+    /// and the `{Flat, Expanded}` arm calls the `render_finding_flat` loop —
+    /// both byte-identical to v0.9.0 behavior. Flat-mode tests are unaffected
+    /// by STORY-119/B. Verified here as a smoke check.
+    #[test]
+    fn test_BC_2_11_025_flat_paths_unchanged_by_story_119() {
+        let findings: Vec<Finding> = (0..3)
+            .map(|_| make_finding_s119("s119-ac025-flat-unchanged"))
+            .collect();
+
+        // {Flat, Collapsed} must emit at most 1 `(x3)` suffix (flat collapse).
+        let out_fc = TerminalReporter {
+            use_color: false,
+            show_hosts_breakdown: false,
+            render: FindingsRender {
+                grouping: Grouping::Flat,
+                collapse: Collapse::Collapsed,
+            },
+        }
+        .render(&Summary::new(), &findings, &[]);
+        assert!(
+            out_fc.contains("(x3)"),
+            "AC-025: {{Flat,Collapsed}} with N=3 identical findings must emit `(x3)`; \
+             got:\n{out_fc}"
+        );
+
+        // {Flat, Expanded} must emit zero `(xN)` suffixes.
+        let out_fe = TerminalReporter {
+            use_color: false,
+            show_hosts_breakdown: false,
+            render: FindingsRender {
+                grouping: Grouping::Flat,
+                collapse: Collapse::Expanded,
+            },
+        }
+        .render(&Summary::new(), &findings, &[]);
+        assert!(
+            !out_fe.contains("(x"),
+            "AC-025: {{Flat,Expanded}} must not emit any `(xN)` suffix; got:\n{out_fe}"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // AC-004 — run_summary construction site produces {Flat, Collapsed}
+    // (traces to BC-2.11.030 PC-6)
+    // -----------------------------------------------------------------------
+
+    /// AC-004 (BC-2.11.030 Postcondition 6):
+    /// REGRESSION GUARD: The `run_summary` construction site always produces
+    /// `FindingsRender { grouping: Grouping::Flat, collapse: Collapse::Collapsed }`.
+    /// Inert value semantics — `run_summary` renders no FINDINGS section; the
+    /// field is structurally present but irrelevant.
+    #[test]
+    fn test_BC_2_11_030_run_summary_produces_flat_collapsed() {
+        // Verify the literal struct value that run_summary uses.
+        let run_summary_render = FindingsRender {
+            grouping: Grouping::Flat,
+            collapse: Collapse::Collapsed,
+        };
+        assert_eq!(
+            run_summary_render,
+            FindingsRender {
+                grouping: Grouping::Flat,
+                collapse: Collapse::Collapsed,
+            },
+            "AC-004: run_summary render field must be {{Flat, Collapsed}}"
+        );
+        // This is a structural/value test — no dispatch exercised.
+    }
+
+    // -----------------------------------------------------------------------
+    // AC-005 — render_findings_grouped_collapsed function exists and dispatches
+    // (traces to BC-2.11.031 Architecture Anchors)
+    // -----------------------------------------------------------------------
+
+    /// AC-005 (BC-2.11.031 Architecture Anchors):
+    /// REGRESSION GUARD: `render_findings_grouped_collapsed` is dispatched for
+    /// the `(Grouping::Grouped, Collapse::Collapsed)` arm. Observable: a
+    /// `{Grouped, Collapsed}` reporter with N=1 finding renders the FINDINGS
+    /// section (non-empty FINDINGS block present) without panicking.
+    #[test]
+    fn test_BC_2_11_031_grouped_collapsed_arm_dispatches_to_new_function() {
+        let findings = vec![make_discovery_finding_s119("s119-ac005-dispatch")];
+        let out = grouped_collapse_reporter().render(&Summary::new(), &findings, &[]);
+
+        assert!(
+            out.contains("FINDINGS"),
+            "AC-005: {{Grouped,Collapsed}} must emit a FINDINGS section; got:\n{out}"
+        );
+        assert!(
+            out.contains("## Discovery"),
+            "AC-005: {{Grouped,Collapsed}} must bucket into Discovery tactic; got:\n{out}"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // EC-006 edge — members[0].mitre_techniques empty → no MITRE line
+    // (traces to AC-018 / BC-2.11.034 PC-1)
+    // -----------------------------------------------------------------------
+
+    /// EC-006 / AC-018 edge (BC-2.11.034 Postcondition 1):
+    /// REGRESSION GUARD: For a collapsed N≥2 group where `members[0].mitre_techniques`
+    /// is empty, no MITRE line is rendered — header + evidence only.
+    #[test]
+    fn test_BC_2_11_034_empty_mitre_techniques_no_mitre_line() {
+        // N=2 identical-key findings, no mitre_techniques → Uncategorized bucket.
+        let findings: Vec<Finding> = (0..2)
+            .map(|_| Finding {
+                category: ThreatCategory::Anomaly,
+                verdict: Verdict::Likely,
+                confidence: Confidence::High,
+                summary: "s119-ec006-empty-mitre".to_string(),
+                evidence: vec!["ev-ec006".to_string()],
+                mitre_techniques: vec![],
+                source_ip: None,
+                timestamp: None,
+                direction: None,
+            })
+            .collect();
+
+        let out = grouped_collapse_reporter().render(&Summary::new(), &findings, &[]);
+
+        // Header with `(x2)` must appear.
+        assert!(
+            out.contains("(x2)"),
+            "EC-006: N=2 group must emit `(x2)` suffix; got:\n{out}"
+        );
+        // No MITRE line must be present (empty mitre_techniques on members[0]).
+        assert!(
+            !out.contains("MITRE:"),
+            "EC-006: no MITRE line must appear when members[0].mitre_techniques is empty; \
+             got:\n{out}"
+        );
+    }
+}

--- a/tests/reporter_terminal_tests.rs
+++ b/tests/reporter_terminal_tests.rs
@@ -4685,10 +4685,14 @@ mod story_122 {
     // -----------------------------------------------------------------------
 
     /// AC-004 (BC-2.11.028 Invariant 1, EC-001):
-    /// --mitre alone (show_mitre_grouping=true) → run_analyze produces
-    /// FindingsRender { grouping: Grouping::Grouped, collapse: Collapse::Expanded }.
-    /// Routes to render_findings_grouped; tactic headers emitted; no (xN) suffix.
-    /// {Grouped, Collapsed} is NOT produced by run_analyze in STORY-122/A.
+    /// HISTORICAL REGRESSION GUARD (STORY-122/A era): in STORY-122/A, `--mitre` alone
+    /// produced `{Grouped, Expanded}`. This test asserts the struct value that
+    /// STORY-122/A's construction site emitted — preserved as a regression guard for
+    /// the STORY-122/A struct value only.
+    /// NOTE: Post-STORY-119/B, `--mitre` alone produces `{Grouped, Collapsed}` (the
+    /// CLI default was flipped by STORY-119/B Task 4). This test does NOT assert the
+    /// run_analyze CLI behavior after STORY-119/B — it asserts only the struct value
+    /// equality and that `{Grouped,Expanded}` ≠ `{Grouped,Collapsed}`.
     #[test]
     fn test_BC_2_11_028_ac004_mitre_alone_yields_grouped_expanded() {
         let findings: Vec<Finding> = (0..2)
@@ -4717,7 +4721,8 @@ mod story_122 {
             "AC-004: --mitre alone → {{Grouped,Expanded}} must not emit (xN) suffix; got:\n{out}"
         );
 
-        // {Grouped, Collapsed} is NOT what --mitre alone produces in STORY-122/A.
+        // {Grouped, Collapsed} is NOT what --mitre alone produced in STORY-122/A
+        // (post-STORY-119/B this IS the CLI default, but this test only asserts the struct values).
         let render_grouped_collapsed = FindingsRender {
             grouping: Grouping::Grouped,
             collapse: Collapse::Collapsed,
@@ -5302,9 +5307,9 @@ mod story_122 {
 // `test_BC_2_11_025_grouped_mode_bypasses_flat_collapse` vs the pre-existing
 // siblings in the outer scope) resolve without collision.
 //
-// Red Gate (BC-5.38.001): every test in this module exercises
-// `render_findings_grouped_collapsed`, which is a `todo!()` stub until the
-// GREEN phase. All tests panic at runtime — that is the expected RED signal.
+// Regression guard: every test in this module verifies BC-canonical behavior
+// of `render_findings_grouped_collapsed` and related helpers. A failing
+// assertion is the RED signal for the implementer to fix.
 // ============================================================================
 mod story_119 {
     use wirerust::findings::{Confidence, Finding, ThreatCategory, Verdict};
@@ -6045,35 +6050,53 @@ mod story_119 {
     /// AC-016/AC-017 (BC-2.11.033 Postconditions 5 and 6):
     /// REGRESSION GUARD: Within a bucket, findings are sorted by verdict-rank
     /// ascending (Likely=0, Possible=1, Inconclusive=2, Unlikely=3) BEFORE the
-    /// collapse pass. The lower-rank (higher-severity) finding becomes
-    /// `members[0]` (the group representative).
+    /// collapse pass. The lower-rank (higher-severity) finding becomes the group
+    /// representative.
     ///
-    /// Test: two findings with the same collapse key in one bucket —
-    /// one `Likely` (rank=0) and one `Inconclusive` (rank=2). The `Likely`
-    /// finding sorts first → becomes `members[0]` → its fields appear in the
-    /// header. The header verdict must be "Likely", not "Inconclusive".
+    /// Setup: three findings in the T1046 (Discovery) bucket.
+    ///   - Two share key (Anomaly, Likely, High, "s119-ac016-likely-finding"):
+    ///     they collapse to a N=2 group. The group representative is Likely.
+    ///   - One has key (Anomaly, Inconclusive, Low, "s119-ac016-inconclusive"):
+    ///     a singleton group. Sorts after the Likely group.
+    ///
+    /// Observable consequences:
+    ///   1. The N=2 group header shows `(x2)` suffix.
+    ///   2. The N=2 group header uses UPPERCASE verdict `LIKELY` (not title-case).
+    ///   3. The Likely group header appears before the Inconclusive singleton in output.
     #[test]
     fn test_BC_2_11_033_first_occurrence_in_sorted_bucket_order() {
         let findings = vec![
-            // Submitted second but sorts first by verdict-rank.
+            // Emitted first — Inconclusive/Low singleton.
             Finding {
                 category: ThreatCategory::Anomaly,
-                verdict: Verdict::Inconclusive, // rank=2
+                verdict: Verdict::Inconclusive, // rank=2 — sorts after Likely
                 confidence: Confidence::Low,
-                summary: "s119-ac016-sort-key".to_string(),
+                summary: "s119-ac016-inconclusive".to_string(),
                 evidence: vec![],
                 mitre_techniques: vec!["T1046".to_string()],
                 source_ip: None,
                 timestamp: None,
                 direction: None,
             },
-            // Submitted first but sorts second.
+            // Emitted second — first member of the Likely/High N=2 group.
             Finding {
                 category: ThreatCategory::Anomaly,
                 verdict: Verdict::Likely, // rank=0 — sorts first
                 confidence: Confidence::High,
-                summary: "s119-ac016-sort-key".to_string(),
-                evidence: vec![],
+                summary: "s119-ac016-likely-finding".to_string(),
+                evidence: vec!["ev-ac016-a".to_string()],
+                mitre_techniques: vec!["T1046".to_string()],
+                source_ip: None,
+                timestamp: None,
+                direction: None,
+            },
+            // Emitted third — second member of the Likely/High N=2 group (same key).
+            Finding {
+                category: ThreatCategory::Anomaly,
+                verdict: Verdict::Likely, // rank=0 — same key as above
+                confidence: Confidence::High,
+                summary: "s119-ac016-likely-finding".to_string(),
+                evidence: vec!["ev-ac016-b".to_string()],
                 mitre_techniques: vec!["T1046".to_string()],
                 source_ip: None,
                 timestamp: None,
@@ -6083,24 +6106,88 @@ mod story_119 {
 
         let out = grouped_collapse_reporter().render(&Summary::new(), &findings, &[]);
 
-        // `(x2)` suffix must appear (N=2 group).
+        // The Likely/High pair collapses to a N=2 group.
         assert!(
             out.contains("(x2)"),
             "AC-016: N=2 group in bucket must emit `(x2)` suffix; got:\n{out}"
         );
 
-        // The header verdict must be "Likely" (the sorted-first representative),
-        // not "Inconclusive". Find the header line (contains `(x2)`).
+        // The header verdict must use UPPERCASE Display format: `LIKELY`, not title-case.
         let header_line = out.lines().find(|l| l.contains("(x2)")).unwrap_or_default();
         assert!(
-            header_line.contains("Likely"),
-            "AC-016: post-sort representative must be Likely (rank=0 sorts first); \
+            header_line.contains("LIKELY"),
+            "AC-016: N=2 group header must use uppercase Display format `LIKELY`; \
              header line: {header_line:?}\nfull output:\n{out}"
         );
         assert!(
-            !header_line.contains("Inconclusive"),
-            "AC-016: Inconclusive (rank=2) must NOT be the representative; \
+            !header_line.contains("Likely"),
+            "AC-016: header must not contain title-case `Likely` — Display format is `LIKELY`; \
              header line: {header_line:?}\nfull output:\n{out}"
+        );
+
+        // Sort order: Likely group (rank=0) appears before Inconclusive singleton (rank=2).
+        let likely_pos = out.find("(x2)").unwrap_or(usize::MAX);
+        let inconclusive_pos = out.find("INCONCLUSIVE").unwrap_or(usize::MAX);
+        assert!(
+            likely_pos < inconclusive_pos,
+            "AC-017: Likely group (lower rank) must appear before Inconclusive singleton \
+             in sorted bucket order; got:\n{out}"
+        );
+    }
+
+    /// BC-2.11.025 EC-007/EC-008 grouped analogue:
+    /// REGRESSION GUARD: Two findings in the SAME tactic bucket with the SAME
+    /// summary but DIFFERENT verdict (or confidence, or category) must NOT be
+    /// merged — they have distinct four-tuple collapse keys and must render as
+    /// two separate group headers with NO `(xN)` suffix on either.
+    ///
+    /// This catches a summary-only (three-field) collapse key bug: if the
+    /// implementation keyed on summary alone, these two findings would be
+    /// incorrectly merged into one N=2 group.
+    #[test]
+    fn test_BC_2_11_025_distinct_verdict_same_summary_no_merge_in_bucket() {
+        // Same bucket (T1046 / Discovery), same summary, DIFFERENT verdict.
+        let findings = vec![
+            Finding {
+                category: ThreatCategory::Anomaly,
+                verdict: Verdict::Likely,
+                confidence: Confidence::High,
+                summary: "s119-ec007-same-summary".to_string(),
+                evidence: vec!["ev-likely".to_string()],
+                mitre_techniques: vec!["T1046".to_string()],
+                source_ip: None,
+                timestamp: None,
+                direction: None,
+            },
+            Finding {
+                category: ThreatCategory::Anomaly,
+                verdict: Verdict::Inconclusive,
+                confidence: Confidence::High,
+                summary: "s119-ec007-same-summary".to_string(), // identical summary
+                evidence: vec!["ev-inconclusive".to_string()],
+                mitre_techniques: vec!["T1046".to_string()],
+                source_ip: None,
+                timestamp: None,
+                direction: None,
+            },
+        ];
+
+        let out = grouped_collapse_reporter().render(&Summary::new(), &findings, &[]);
+
+        // Different verdict → different four-tuple keys → two distinct groups, no merge.
+        assert!(
+            !out.contains("(x2)"),
+            "BC-2.11.025 EC-007: same summary but different verdict must produce TWO distinct \
+             groups, not one N=2 merged group — `(x2)` must not appear; got:\n{out}"
+        );
+        // Both headers must appear independently.
+        assert!(
+            out.contains("LIKELY"),
+            "BC-2.11.025 EC-007: Likely group header must appear; got:\n{out}"
+        );
+        assert!(
+            out.contains("INCONCLUSIVE"),
+            "BC-2.11.025 EC-007: Inconclusive group header must appear; got:\n{out}"
         );
     }
 
@@ -6341,7 +6428,7 @@ mod story_119 {
     /// REGRESSION GUARD: `escape_for_terminal` is applied to all `summary` and
     /// `evidence` strings in `render_findings_grouped_collapsed`. A summary
     /// containing a C0 control character (U+0001) must not appear raw in the
-    /// output — it must be escaped to `\x01`.
+    /// output — it must be escaped via `char::escape_default` to `\u{1}`.
     #[test]
     fn test_BC_2_11_031_escape_for_terminal_in_grouped_collapse_path() {
         let findings: Vec<Finding> = (0..2)
@@ -6367,10 +6454,52 @@ mod story_119 {
             "AC-023: raw C0 control char U+0001 must not appear in output — \
              escape_for_terminal must be applied; got:\n{out:?}"
         );
-        // The escaped form `\\x01` must appear in output (escaped).
+        // The escaped form `\u{1}` must appear in output (char::escape_default output).
         assert!(
-            out.contains("\\x01"),
-            "AC-023: C0 char must be escaped to `\\x01` in output; got:\n{out:?}"
+            out.contains("\\u{1}"),
+            "AC-023: C0 char U+0001 must be escaped to `\\u{{1}}` via char::escape_default; \
+             got:\n{out:?}"
+        );
+    }
+
+    /// BC-2.11.032 EC-007 / VP canonical vector:
+    /// REGRESSION GUARD: Evidence strings in grouped-collapse bucket groups pass
+    /// through `escape_for_terminal`. A raw ESC byte (U+001B = 0x1B) in evidence
+    /// must be escaped via `char::escape_default` to `\u{1b}` in the output.
+    ///
+    /// Canonical test vector (BC-2.11.032 EC-007):
+    ///   evidence `"\x1b[31m"` → rendered as `> \u{1b}[31m` in the terminal.
+    #[test]
+    fn test_BC_2_11_032_escape_preserved_in_bucket_evidence() {
+        // N=2 group so both findings collapse; K=3 evidence cap not reached.
+        let findings: Vec<Finding> = (0..2)
+            .map(|i| Finding {
+                category: ThreatCategory::Anomaly,
+                verdict: Verdict::Likely,
+                confidence: Confidence::High,
+                summary: "s119-ec007-esc-evidence".to_string(),
+                // Raw ESC byte in ANSI sequence — must be escaped in output.
+                evidence: vec![format!("\x1b[31m-item-{i}")],
+                mitre_techniques: vec!["T1046".to_string()],
+                source_ip: None,
+                timestamp: None,
+                direction: None,
+            })
+            .collect();
+
+        let out = grouped_collapse_reporter().render(&Summary::new(), &findings, &[]);
+
+        // Raw ESC byte must NOT appear in the output.
+        assert!(
+            !out.contains('\x1b'),
+            "BC-2.11.032 EC-007: raw ESC byte must not appear in grouped-collapse evidence output; \
+             got:\n{out:?}"
+        );
+        // The ESC must be escaped via char::escape_default to `\u{1b}`.
+        assert!(
+            out.contains("\\u{1b}"),
+            "BC-2.11.032 EC-007: ESC byte in evidence must render as `\\u{{1b}}` \
+             (char::escape_default); got:\n{out:?}"
         );
     }
 


### PR DESCRIPTION
# [STORY-119] Terminal Finding-Collapse — Grouped Mode / `--mitre` (render path + CLI flip)

**Epic:** E-18 — Finding Collapse (issue #259 / issue #62 tail)
**Mode:** feature
**Convergence:** CONVERGED after 3 adversarial passes (F4 per-story gate 3/3 SATISFIED)

![Tests](https://img.shields.io/badge/tests-122%2F122-brightgreen)
![Story](https://img.shields.io/badge/story-STORY--119%2FB-blue)
![BCs](https://img.shields.io/badge/BCs-12%2F12-brightgreen)
![Demo](https://img.shields.io/badge/demo-3%20recordings-green)

Implements `render_findings_grouped_collapsed` — the grouped-mode counterpart of the flat-mode
collapse added in STORY-118. Builds on STORY-122/A's `FindingsRender` struct-of-enums reshape
(merged PR #268). Key changes: (1) new `collapse_findings_pass_refs` shared helper extracted
from `collapse_findings_pass`; (2) `render_findings_grouped_collapsed` with per-tactic-bucket
deduplication, `(xN)` count suffix, K=3 evidence sampling, and em-dash MITRE name expansion
sourced from `group_members[0]`; (3) the `{Grouped, Collapsed}` dispatch arm repointed from the
STORY-122/A TEMPORARY target to the new function; (4) the `--mitre` CLI default flipped to
`{Grouped, Collapsed}` via the orthogonal 2-if construction in `run_analyze`; (5) `--no-collapse`
doc-comment updated for dual-scope (flat + grouped). The `{Grouped, Expanded}` path
(`--mitre --no-collapse`) is byte-identical to v0.8.0 `--mitre` behavior.

Closes #259. Resolves issue #62 tail (grouped-collapse segment).

---

## Architecture Changes

```mermaid
graph TD
    Main["src/main.rs\nrun_analyze()"]
    CLI["src/cli.rs\n--no-collapse doc"]
    Dispatch["TerminalReporter::render()\n4-arm match dispatch"]
    GC["render_findings_grouped_collapsed()\nNEW"]
    GE["render_findings_grouped()\nunchanged"]
    FC["render_findings_collapsed()\nunchanged"]
    CFR["collapse_findings_pass_refs()\nNEW shared helper"]
    CFP["collapse_findings_pass()\nthin adapter"]
    RFG["render_finding_grouped()\nunchanged"]

    Main -->|"orthogonal 2-if (STORY-119/B flip)"| Dispatch
    CLI -.->|"dual-scope doc update"| Main
    Dispatch -->|"{Grouped, Collapsed}"| GC
    Dispatch -->|"{Grouped, Expanded}"| GE
    Dispatch -->|"{Flat, Collapsed}"| FC
    GC -->|"per-bucket"| CFR
    GC -->|"N=1 singleton"| RFG
    CFP -->|"delegates to"| CFR

    style GC fill:#90EE90
    style CFR fill:#90EE90
```

<details>
<summary><strong>Architecture Decision Record</strong></summary>

### ADR: Collapse-API Shape (ADR-0003 "Collapse-API Shape" subsection)

**Context:** Flat-mode collapse (`render_findings_collapsed`) uses `collapse_findings_pass(&[Finding])`.
Grouped-mode collapse applies collapse independently per tactic bucket, requiring a refs-based variant
that can operate on a `Vec<&Finding>` slice without copying owned data.

**Decision:** Introduce `collapse_findings_pass_refs<'a>(&self, refs: &[&'a Finding]) -> Vec<(CollapseKey, Vec<&'a Finding>)>`
as the shared collapse-logic body. Make `collapse_findings_pass` a thin adapter that collects
`findings.iter().collect()` and delegates. Grouped callers invoke `collapse_findings_pass_refs`
directly, once per bucket slice.

**Rationale:** Avoids duplicating the linear-scan `Vec<(CollapseKey, Vec<&Finding>)>` accumulator
logic. Preserves the flat-mode API surface unchanged. Per-bucket isolation means no cross-bucket
collapse is possible — the grouped caller cannot pass the full global slice by construction.

**Alternatives Considered:**
1. Duplicate the collapse body inline in `render_findings_grouped_collapsed` — rejected because
   it creates drift between flat and grouped collapse semantics.
2. Pass `&[Finding]` by taking ownership / cloning — rejected because it introduces unnecessary
   allocation for a display-layer pure function.

**Consequences:**
- Shared collapse logic tested once at the refs level; both flat and grouped paths exercise it.
- `collapse_findings_pass` adapter body is trivially verifiable by inspection.

</details>

---

## Story Dependencies

```mermaid
graph LR
    S120["STORY-120\n✅ merged PR #266"]
    S122["STORY-122/A\n✅ merged PR #268"]
    S119["STORY-119/B\n🔶 this PR"]

    S120 --> S122
    S122 --> S119

    style S119 fill:#FFD700
    style S120 fill:#90EE90
    style S122 fill:#90EE90
```

All upstream dependencies are merged:
- STORY-120 (FindingsRender enum migration) — merged PR #266
- STORY-122/A (struct-of-enums reshape + 84-site migration) — merged PR #268
- STORY-119/B blocks nothing downstream (`blocks: []`)

---

## Spec Traceability

```mermaid
flowchart LR
    BC025["BC-2.11.025\nCollapse key + accumulator"]
    BC028["BC-2.11.028\n--no-collapse dual-scope"]
    BC030["BC-2.11.030\nCLI→render mapping"]
    BC031["BC-2.11.031\nPer-bucket (xN) suffix"]
    BC032["BC-2.11.032\nK=3 evidence sampling"]
    BC033["BC-2.11.033\nBucket order invariant"]
    BC034["BC-2.11.034\nMITRE line format"]

    AC001["AC-001\n--mitre → Grouped,Collapsed"]
    AC005["AC-005..007\nrender fn + dispatch"]
    AC006["AC-006\n(xN) suffix N≥2"]
    AC011["AC-011\nK=3 evidence cap"]
    AC013["AC-013..017\nBucket order + sort"]
    AC018["AC-018..021\nMITRE line format"]

    T030["test_BC_2_11_030_*\n3 tests"]
    T031["test_BC_2_11_031_*\n5 tests"]
    T032["test_BC_2_11_032_*\n2 tests"]
    T033["test_BC_2_11_033_*\n4 tests"]
    T034["test_BC_2_11_034_*\n4 tests"]

    SRC["src/reporter/terminal.rs\nsrc/main.rs\nsrc/cli.rs"]

    BC030 --> AC001 --> T030 --> SRC
    BC031 --> AC006 --> T031 --> SRC
    BC032 --> AC011 --> T032 --> SRC
    BC033 --> AC013 --> T033 --> SRC
    BC034 --> AC018 --> T034 --> SRC
    BC025 --> AC001
    BC028 --> AC001
```

**BC coverage:** 12/12 BCs covered (BC-2.11.013, 014, 016, 025, 026, 027, 028, 030, 031, 032, 033, 034)

| BC | Version | AC(s) | Test(s) |
|----|---------|-------|---------|
| BC-2.11.013 | v1.15 | AC-013, AC-014 | `test_BC_2_11_033_grouped_collapsed_preserves_bucket_order` |
| BC-2.11.014 | v2.1 | AC-016, AC-017 | `test_BC_2_11_033_first_occurrence_in_sorted_bucket_order` |
| BC-2.11.016 | v1.10 | AC-007, AC-018 | `test_BC_2_11_034_grouped_collapse_mitre_line_em_dash_format` |
| BC-2.11.025 | v1.14 | AC-024, AC-025 | `test_BC_2_11_025_grouped_mode_bypasses_flat_collapse` |
| BC-2.11.026 | v1.14 | AC-008 | `test_BC_2_11_031_grouped_collapse_color_ladder` |
| BC-2.11.027 | v1.8 | AC-011 | `test_BC_2_11_032_evidence_sampling_k3_in_bucket` |
| BC-2.11.028 | v1.10 | AC-002, AC-026 | `test_BC_2_11_028_no_collapse_with_mitre_produces_grouped_expanded` |
| BC-2.11.030 | v1.5 | AC-001..004 | `test_BC_2_11_030_*` (3 tests) |
| BC-2.11.031 | v1.4 | AC-006..010 | `test_BC_2_11_031_*` (5 tests) |
| BC-2.11.032 | v1.5 | AC-011, AC-012 | `test_BC_2_11_032_*` (2 tests) |
| BC-2.11.033 | v1.4 | AC-013..017 | `test_BC_2_11_033_*` (4 tests) |
| BC-2.11.034 | v1.4 | AC-018..021 | `test_BC_2_11_034_*` (4 tests) |

---

## Test Evidence

### Coverage Summary

| Metric | Value | Threshold | Status |
|--------|-------|-----------|--------|
| Total tests | 122/122 pass | 100% | PASS |
| New tests (mod story_119) | 24 new tests | all ACs covered | PASS |
| Regressions | 0 | 0 | PASS |
| Holdout | N/A — evaluated at wave gate | >0.85 | N/A |

### Test Flow

```mermaid
graph LR
    Unit["122 Unit Tests\n(reporter_terminal_tests.rs)"]
    Integration["Integration tests\n(cargo test --all-targets)"]
    Demo["3 Demo recordings\n(per-AC VHS captures)"]

    Unit -->|"0 failures"| Pass1["PASS"]
    Integration -->|"0 failures"| Pass2["PASS"]
    Demo -->|"AC-001/002/003"| Pass3["PASS"]

    style Pass1 fill:#90EE90
    style Pass2 fill:#90EE90
    style Pass3 fill:#90EE90
```

| Metric | Value |
|--------|-------|
| **New tests** | 24 added in `mod story_119` |
| **Total suite** | 122 tests PASS |
| **Regressions** | 0 — all pre-existing test modules pass unchanged |
| **Mutation kill rate** | N/A — not run in F4 per-story cycle |

<details>
<summary><strong>New Tests Added (mod story_119)</strong></summary>

| Test | BC | What it verifies |
|------|----|-----------------|
| `test_BC_2_11_030_mitre_alone_maps_to_grouped_collapsed` | BC-2.11.030 PC-2 | `--mitre` alone → `{Grouped, Collapsed}` |
| `test_BC_2_11_030_mitre_no_collapse_maps_to_grouped_expanded` | BC-2.11.030 PC-3 | `--mitre --no-collapse` → `{Grouped, Expanded}` |
| `test_BC_2_11_030_flat_routing_unchanged` | BC-2.11.030 PC-4,5 | flat routing unchanged |
| `test_BC_2_11_031_grouped_collapse_suffix_format` | BC-2.11.031 PC-1 | N=3 → `(x3)` suffix |
| `test_BC_2_11_031_singleton_no_suffix_in_bucket` | BC-2.11.031 PC-2 | N=1 singleton → no suffix |
| `test_BC_2_11_031_grouped_collapse_color_ladder` | BC-2.11.031 PC-3 | Likely+High → red().bold() |
| `test_BC_2_11_031_suffix_only_on_header_not_mitre_or_evidence` | BC-2.11.031 PC-4 | suffix not on MITRE/evidence lines |
| `test_BC_2_11_031_cross_bucket_suffix_independence` | BC-2.11.031 PC-6 | independent per-bucket counts |
| `test_BC_2_11_032_evidence_sampling_k3_in_bucket` | BC-2.11.032 PC-1 | N=5 → 3 evidence lines |
| `test_BC_2_11_032_evidence_positional_no_slide` | BC-2.11.032 Inv-2 | empty member[0] → no window slide |
| `test_BC_2_11_033_grouped_collapsed_preserves_bucket_order` | BC-2.11.033 PC-1 | bucket order unchanged |
| `test_BC_2_11_033_uncategorized_last_under_grouped_collapse` | BC-2.11.033 PC-3 | Uncategorized last |
| `test_BC_2_11_033_different_buckets_not_cross_collapsed` | BC-2.11.033 Inv-3 | no cross-bucket collapse |
| `test_BC_2_11_033_first_occurrence_in_sorted_bucket_order` | BC-2.11.033 PC-5,6 | sort-then-collapse order |
| `test_BC_2_11_025_distinct_verdict_same_summary_no_merge_in_bucket` | BC-2.11.025 | distinct verdict = no merge |
| `test_BC_2_11_034_grouped_collapse_mitre_line_em_dash_format` | BC-2.11.034 PC-1 | em-dash + name from members[0] |
| `test_BC_2_11_034_unknown_technique_in_grouped_collapse` | BC-2.11.034 PC-1 | unknown ID → `(unknown)` |
| `test_BC_2_11_034_suffix_not_on_mitre_line` | BC-2.11.034 PC-2 | no suffix on MITRE line |
| `test_BC_2_11_034_divergent_mitre_representative_sourcing` | BC-2.11.034 PC-3 | only members[0] MITRE in output |
| `test_BC_2_11_028_no_collapse_with_mitre_produces_grouped_expanded` | BC-2.11.028 PC-4 | N=100 → zero `(xN)` suffixes |
| `test_BC_2_11_031_escape_for_terminal_in_grouped_collapse_path` | VP-012 | escape_for_terminal in grouped-collapse |
| `test_BC_2_11_032_escape_preserved_in_bucket_evidence` | VP-012 | escape in evidence lines |
| `test_BC_2_11_025_grouped_mode_bypasses_flat_collapse` | BC-2.11.025 Inv-5 | per-bucket not global collapse |
| `test_BC_2_11_025_flat_paths_unchanged_by_story_119` | BC-2.11.025 Inv-5 | flat paths byte-identical |

</details>

---

## Demo Evidence

Evidence captured at `.factory/demo-evidence/issue-62-story-119/` on HEAD `6a28bbe`.

| Recording | ACs Covered | Observable |
|-----------|-------------|-----------|
| `AC-001-mitre-grouped-collapsed.{gif,webm}` | AC-001, AC-006, AC-011, AC-018 | `--mitre` alone → grouped + COLLAPSED with `(x2)` suffix, 2 evidence lines, em-dash MITRE line |
| `AC-002-mitre-no-collapse-expanded.{gif,webm}` | AC-002 | `--mitre --no-collapse` → two separate lines, no suffix, dual-scope confirmed |
| `AC-003-flat-collapsed-vs-expanded.{gif,webm}` | contrast | flat collapsed vs flat expanded — unchanged behavior |

**Key observable in AC-001 recording:**
```
  ## Discovery
  [Anomaly] INCONCLUSIVE (MEDIUM) - Modbus recon: Report Server ID (FC 0x11) from unit 1 (x2)
    > FC=0x11 TxnID=0x0001 UnitID=1
    > FC=0x11 TxnID=0x0001 UnitID=1
    MITRE: T0888 — Remote System Information Discovery
```

**Key observable in AC-002 recording (`--mitre --no-collapse`):**
```
  ## Discovery
  [Anomaly] INCONCLUSIVE (MEDIUM) - Modbus recon: Report Server ID (FC 0x11) from unit 1
    MITRE: T0888 — Remote System Information Discovery
  [Anomaly] INCONCLUSIVE (MEDIUM) - Modbus recon: Report Server ID (FC 0x11) from unit 1
    MITRE: T0888 — Remote System Information Discovery
```

---

## Holdout Evaluation

N/A — evaluated at wave gate (wave 50). Per-story adversarial gate satisfied 3/3 passes.

---

## Adversarial Review

| Pass | Status | Findings | Critical | High |
|------|--------|----------|----------|------|
| 1 | SATISFIED | 3 CRITICAL spec violations (suffix-after-color, inverted BC assertions, misleading helper name) | 3 | 0 |
| 2 | SATISFIED | round-2 hygiene (rename misleading helper, harden guard, fix comment) | 0 | 0 |
| 3 | SATISFIED | No new findings — gate 3/3 SATISFIED | 0 | 0 |

**Convergence:** Per-story adversarial gate achieved at pass 3.

<details>
<summary><strong>High-Severity Findings & Resolutions</strong></summary>

### Finding 1: Suffix appended AFTER color reset (CRITICAL — AC-008 spec violation)
- **Location:** `src/reporter/terminal.rs` — grouped-collapse header render path
- **Category:** spec-fidelity
- **Problem:** Initial implementation appended ` (xN)` after the ANSI color-reset sequence, violating BC-2.11.031 PC-3 ("appending the suffix after the ANSI reset is NON-CONFORMANT")
- **Resolution:** Suffix appended to pre-color string before colorization — commit `a55b06c`
- **Test added:** `test_BC_2_11_031_grouped_collapse_color_ladder`

### Finding 2: Inverted BC assertions in test suite (CRITICAL — test quality)
- **Location:** `tests/reporter_terminal_tests.rs` — `mod story_119` block
- **Category:** test-quality
- **Problem:** Several tests asserted the negation of the BC-specified behavior (e.g., asserting `!output.contains("(x2)")` instead of `assert!(output.contains("(x2)"))`)
- **Resolution:** All inverted assertions rewritten to assert BC-canonical behavior — commit `8c9b487`

### Finding 3: Misleading helper name `unique_findings_in_bucket` (CRITICAL — naming)
- **Location:** `src/reporter/terminal.rs` — helper function
- **Category:** code-quality
- **Problem:** Helper name implied uniqueness check but actually performed evidence-line rendering; misleading for future readers
- **Resolution:** Renamed to accurately reflect role — commit `6a28bbe`

</details>

---

## Security Review

Pending — to be completed by security-reviewer sub-agent during this PR lifecycle step.

```mermaid
graph LR
    Critical["Critical: pending"]
    High["High: pending"]
    Medium["Medium: pending"]
    Low["Low: pending"]
```

---

## Risk Assessment & Deployment

### Blast Radius
- **Systems affected:** Terminal reporter output only (`src/reporter/terminal.rs`). JSON and CSV reporters are unaffected — they receive the complete, unmodified `&[Finding]` slice per ADR-0003 Binding Rule 4.
- **User impact:** `--mitre` alone now collapses repeated findings by default. Pre-collapse behavior preserved exactly via `--mitre --no-collapse`.
- **Data impact:** None — collapse is a display-layer transform only; no finding data is modified or lost.
- **Risk Level:** LOW — display-only change; no parsing, no network, no persistence.

### Performance Impact
| Metric | Impact |
|--------|--------|
| CPU | Negligible — per-bucket linear scan identical to flat-mode collapse already shipped in STORY-118 |
| Memory | Negligible — refs-based accumulator; no additional `Finding` copies |
| Throughput | No change — purely synchronous display path |

<details>
<summary><strong>Rollback Instructions</strong></summary>

**Immediate rollback:**
```bash
git revert 6a28bbe a55b06c 8c9b487 f32befa 29d1430 72d9d31
git push origin develop
```

**Verification after rollback:**
- `--mitre` output should NOT contain `(xN)` suffixes
- `cargo test --all-targets` should pass with pre-STORY-119 test count

</details>

### Feature Flags
No feature flags — CLI flags `--mitre` and `--no-collapse` govern the behavior.

---

## Traceability

| BC | AC | Test | Status |
|----|-----|------|--------|
| BC-2.11.030 | AC-001 | `test_BC_2_11_030_mitre_alone_maps_to_grouped_collapsed` | PASS |
| BC-2.11.030 | AC-002 | `test_BC_2_11_030_mitre_no_collapse_maps_to_grouped_expanded` | PASS |
| BC-2.11.030 | AC-003 | `test_BC_2_11_030_flat_routing_unchanged` | PASS |
| BC-2.11.030 | AC-004 | `test_BC_2_11_030_flat_routing_unchanged` | PASS |
| BC-2.11.031 | AC-005 | `test_BC_2_11_031_grouped_collapse_suffix_format` | PASS |
| BC-2.11.031 | AC-006 | `test_BC_2_11_031_grouped_collapse_suffix_format` | PASS |
| BC-2.11.031 | AC-007 | `test_BC_2_11_031_singleton_no_suffix_in_bucket` | PASS |
| BC-2.11.031 | AC-008 | `test_BC_2_11_031_grouped_collapse_color_ladder` | PASS |
| BC-2.11.031 | AC-009 | `test_BC_2_11_031_suffix_only_on_header_not_mitre_or_evidence` | PASS |
| BC-2.11.031 | AC-010 | `test_BC_2_11_031_cross_bucket_suffix_independence` | PASS |
| BC-2.11.032 | AC-011 | `test_BC_2_11_032_evidence_sampling_k3_in_bucket` | PASS |
| BC-2.11.032 | AC-012 | `test_BC_2_11_032_evidence_sampling_k3_in_bucket` | PASS |
| BC-2.11.033 | AC-013 | `test_BC_2_11_033_grouped_collapsed_preserves_bucket_order` | PASS |
| BC-2.11.033 | AC-014 | `test_BC_2_11_033_uncategorized_last_under_grouped_collapse` | PASS |
| BC-2.11.033 | AC-015 | `test_BC_2_11_033_different_buckets_not_cross_collapsed` | PASS |
| BC-2.11.033 | AC-016 | `test_BC_2_11_033_first_occurrence_in_sorted_bucket_order` | PASS |
| BC-2.11.033 | AC-017 | `test_BC_2_11_033_first_occurrence_in_sorted_bucket_order` | PASS |
| BC-2.11.034 | AC-018 | `test_BC_2_11_034_grouped_collapse_mitre_line_em_dash_format` | PASS |
| BC-2.11.034 | AC-019 | `test_BC_2_11_034_suffix_not_on_mitre_line` | PASS |
| BC-2.11.034 | AC-020 | `test_BC_2_11_034_divergent_mitre_representative_sourcing` | PASS |
| BC-2.11.034 | AC-021 | `test_BC_2_11_034_grouped_collapse_mitre_line_em_dash_format` | PASS |
| BC-2.11.013 | AC-022 | `test_BC_2_11_028_no_collapse_with_mitre_produces_grouped_expanded` | PASS |
| VP-012 | AC-023 | `test_BC_2_11_031_escape_for_terminal_in_grouped_collapse_path` | PASS |
| BC-2.11.025 | AC-024 | `test_BC_2_11_025_grouped_mode_bypasses_flat_collapse` | PASS |
| BC-2.11.025 | AC-025 | `test_BC_2_11_025_flat_paths_unchanged_by_story_119` | PASS |
| BC-2.11.028 | AC-026 | `test_BC_2_11_028_no_collapse_with_mitre_produces_grouped_expanded` | PASS |
| All BCs | AC-027 | `cargo test --all-targets` — 122/122 | PASS |

<details>
<summary><strong>Full VSDD Contract Chain</strong></summary>

```
BC-2.11.030 -> AC-001 -> test_BC_2_11_030_mitre_alone_maps_to_grouped_collapsed -> src/main.rs run_analyze orthogonal-2-if -> F4 CONVERGED
BC-2.11.031 -> AC-006 -> test_BC_2_11_031_grouped_collapse_suffix_format -> src/reporter/terminal.rs:render_findings_grouped_collapsed -> ADV-PASS-1-FIXED (suffix-before-color)
BC-2.11.032 -> AC-011 -> test_BC_2_11_032_evidence_sampling_k3_in_bucket -> src/reporter/terminal.rs:render_findings_grouped_collapsed K=3 loop
BC-2.11.033 -> AC-013 -> test_BC_2_11_033_grouped_collapsed_preserves_bucket_order -> src/reporter/terminal.rs:render_findings_grouped_collapsed outer loop
BC-2.11.034 -> AC-018 -> test_BC_2_11_034_grouped_collapse_mitre_line_em_dash_format -> src/reporter/terminal.rs:render_findings_grouped_collapsed MITRE inline
```

</details>

---

## AI Pipeline Metadata

<details>
<summary><strong>Pipeline Details</strong></summary>

```yaml
ai-generated: true
pipeline-mode: feature
factory-version: "1.0.0-rc.21"
pipeline-stages:
  f1-delta-analysis: completed
  f2-spec-evolution: completed (12 BCs, F2-frozen)
  f3-incremental-stories: completed (STORY-119 v2.4)
  f4-delta-implementation: completed (6 commits, F4 GREEN)
  f5-scoped-adversarial: completed (3 passes, gate 3/3 SATISFIED)
  f6-targeted-hardening: N/A (per-story)
  f7-delta-convergence: N/A (per-story)
convergence-metrics:
  adversarial-passes: 3
  per-story-gate: "3/3 SATISFIED"
  implementation-ci: pending-PR-check
story-id: STORY-119
epic: E-18
wave: 50
points: 5
generated-at: "2026-06-19T00:00:00Z"
models-used:
  builder: claude-sonnet-4-6
  adversary: claude-sonnet-4-6 (F5 per-story gate)
```

</details>

---

## Pre-Merge Checklist

- [ ] All CI status checks passing (test, clippy -D warnings, fmt --check, semantic-PR-title gate)
- [x] 122/122 unit tests passing locally (pre-push)
- [x] 3 demo recordings present covering AC-001, AC-002, AC-003
- [x] 12/12 BCs traced to ACs and tests
- [x] All 3 adversarial-pass CRITICAL findings resolved
- [x] Dependency PRs #266 (STORY-120) and #268 (STORY-122) merged
- [ ] Security review completed (pending)
- [ ] PR reviewer approval (pending)
- [ ] Human gate authorization before merge
