### PR TITLE
docs(reporter): F7 convergence doc fixes -- --mitre help, ADR supersession, README/CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Version numbers follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
-## [0.9.0] - 2026-06-18
+## [0.9.0] - 2026-06-19
 
 ### Changed (BREAKING)
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Options:
 --arp                                  Analyze ARP traffic (spoofing, GARP, storms, malformed, MAC mismatch; default-off; included in --all)
 --arp-spoof-threshold N                MAC-rebind escalation threshold per IP within 60s window (default: 3)
 --arp-storm-rate N                     ARP storm frames/second per source MAC threshold (default: 50)
---no-collapse                          Disable collapsing of repeated findings in both flat and grouped (--mitre) terminal output. By default, collapse is enabled in both modes. Pass --no-collapse to restore one-line-per-finding output in both modes. Has no effect on --output json or --output csv.
+--no-collapse                          Disable collapsing of repeated findings in both flat and grouped (--mitre) terminal output. By default, collapse is enabled in both modes. When --mitre is used, collapse groups identical findings within each MITRE tactic bucket with a (xN) count suffix. Pass --no-collapse to restore one-line-per-finding output in both modes. Has no effect on --output json or --output csv.
 --mitre                                Group findings by MITRE ATT&CK tactic and show technique names; collapses identical findings within each tactic bucket with a (xN) count suffix by default (pass --no-collapse to disable)
 -a, --all                              Run all analyzers
 ```

--- a/docs/adr/0003-reporting-pipeline-layering.md
+++ b/docs/adr/0003-reporting-pipeline-layering.md
@@ -235,7 +235,7 @@ human readability is another display-layer transform that MUST NOT mutate the ca
 
 **Aggregate identical findings at the terminal-display layer only.** The `Finding` stream
 and all machine-readable reporters (JSON, CSV) are unchanged. `TerminalReporter::render`
-applies a private collapse pass before rendering when `collapse_findings` is `true`.
+applies a private collapse pass before rendering when `render.collapse == Collapse::Collapsed`.
 
 ### Aggregation Key
 
@@ -307,6 +307,11 @@ accuracy and is widely criticized (see validation report §3.1 sources [9][16]).
 preserves every raw `Finding`; the collapse is strictly a terminal-display lens.
 
 ### Flat Mode Only for v0.8.0 (STORY-118)
+
+> **NOTE (superseded by v0.9.0):** The following describes pre-v0.9.0 behavior only.
+> STORY-119/B (PR #269) extended collapse to grouped (`--mitre`) mode; all four
+> `Grouping` × `Collapse` combinations are now valid. See the "Grouped-Mode Collapse"
+> subsection below for current behavior.
 
 Collapse applies only when `show_mitre_grouping = false` (the default flat mode).
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -150,7 +150,6 @@ pub enum Commands {
         /// Group findings by MITRE ATT&CK tactic and show technique names;
         /// collapses identical findings within each tactic bucket with a
         /// `(xN)` count suffix by default (pass --no-collapse to disable).
-        /// F-PASS-A-001: doc-comment updated to match shipped collapse behavior.
         #[arg(long)]
         mitre: bool,
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -147,7 +147,10 @@ pub enum Commands {
         #[arg(long)]
         tls: bool,
 
-        /// Group findings by MITRE ATT&CK tactic and show technique names
+        /// Group findings by MITRE ATT&CK tactic and show technique names;
+        /// collapses identical findings within each tactic bucket with a
+        /// `(xN)` count suffix by default (pass --no-collapse to disable).
+        /// F-PASS-A-001: doc-comment updated to match shipped collapse behavior.
         #[arg(long)]
         mitre: bool,
 

--- a/tests/cli_integration_tests.rs
+++ b/tests/cli_integration_tests.rs
@@ -261,6 +261,68 @@ fn mitre_no_collapse_emits_tactic_headers_without_collapse_suffix() {
 // This test pins a NAMED tactic header so that a bug suppressing tactic-name
 // resolution (while still emitting `## Uncategorized`) would be caught.
 
+// ---- F-PASS-A-001: --mitre help-text collapse regression guard ----
+//
+// The --mitre clap doc-comment must mention collapse behavior so that
+// `wirerust analyze --help` agrees with README and --no-collapse docs.
+// This test pins those keywords so a revert to the terse pre-STORY-119
+// one-liner is caught immediately.
+
+/// F-PASS-A-001 regression guard:
+/// `wirerust analyze --help` must document that `--mitre` collapses
+/// identical findings within each tactic bucket with a `(xN)` count suffix
+/// by default, and that `--no-collapse` disables it.
+///
+/// The test scopes to only the `--mitre` entry text (between `--mitre` and the
+/// next `--no-collapse` flag entry) so that keywords found in the `--no-collapse`
+/// description do not produce a false pass when `--mitre` reverts to the stale
+/// terse one-liner.
+///
+/// Mutation-fail verification (performed during F-PASS-A-001 fix):
+///   Reverted `--mitre` doc-comment to "Group findings by MITRE ATT&CK tactic
+///   and show technique names" (single terse line, no "collapse" / "(x").
+///   Confirmed the binary renders the terse text under `--mitre` with no
+///   "collapse" or "(x" in the scoped slice up to `--no-collapse`.
+///   Test failed with: assertion `--mitre` help text must mention 'collapse'.
+///   Restored new doc-comment: test passes.
+#[test]
+fn mitre_help_text_mentions_collapse_behavior() {
+    let output = Command::cargo_bin("wirerust")
+        .expect("binary built")
+        .args(["analyze", "--help"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let help = String::from_utf8(output).expect("utf-8 stdout");
+
+    // Locate the --mitre entry and extract only the text up to the sibling
+    // --no-collapse entry.  This scoping prevents the richer --no-collapse
+    // description from satisfying the assertions when --mitre reverts to the
+    // stale one-liner (the bug F-PASS-A-001 guards against).
+    let mitre_pos = help
+        .find("--mitre\n")
+        .expect("F-PASS-A-001: `--mitre` flag must appear in `analyze --help` output");
+    let after_mitre = &help[mitre_pos..];
+    // Clap renders the next flag with leading spaces + "--no-collapse"; slice before it.
+    let no_collapse_pos = after_mitre
+        .find("--no-collapse")
+        .expect("F-PASS-A-001: `--no-collapse` must appear after `--mitre` in help output");
+    let mitre_entry = &after_mitre[..no_collapse_pos];
+
+    assert!(
+        mitre_entry.contains("collapse"),
+        "F-PASS-A-001: `--mitre` help text (before --no-collapse entry) must mention \
+         'collapse'; got mitre entry:\n{mitre_entry}"
+    );
+    assert!(
+        mitre_entry.contains("(x"),
+        "F-PASS-A-001: `--mitre` help text (before --no-collapse entry) must mention \
+         '(x' count suffix; got mitre entry:\n{mitre_entry}"
+    );
+}
+
 /// O-1 (BC-2.11.030 PC-2 / BC-2.11.033 PC-3):
 /// REGRESSION GUARD: `analyze modbus-write.pcap --all --mitre` must emit a
 /// NAMED MITRE tactic header `## Discovery` (produced by T1046 findings in the


### PR DESCRIPTION
## Fix: F7 Convergence Documentation Fixes

**Branch:** `docs/f7-convergence-doc-fixes`
**Closes:** #62, #259
**Severity:** MED/MINOR/LOW (documentation only)
**Behavior change:** None — doc/help-text corrections only, one new regression test

---

### What Changed

This PR resolves 5 F7 holistic/consistency review findings. All changes are documentation, help text, and ADR corrections. No runtime behavior is altered.

| Finding | Severity | Change |
|---------|----------|--------|
| F-PASS-A-001 | MED | `src/cli.rs` `--mitre` doc-comment now mentions collapse-by-default + `--no-collapse` opt-out; adds regression test `mitre_help_text_mentions_collapse_behavior` |
| F-03 | MED | `docs/adr/0003` "Flat Mode Only for v0.8.0" section got supersession notice — 3 now-false collapse assertions marked pre-v0.9.0 with forward-ref to Grouped-Mode Collapse |
| F-04 | MINOR | `docs/adr/0003:238` bool vocabulary → struct vocabulary (`render.collapse == Collapse::Collapsed`) |
| F-05 | MINOR | `README.md` `--no-collapse` entry gained the `(xN)` suffix sentence to match cli.rs |
| F-PASSC-002 | LOW | `CHANGELOG.md` `[0.9.0]` date corrected: 2026-06-18 → 2026-06-19 |

### Files Changed

- `src/cli.rs` — `--mitre` and `--no-collapse` doc-comment updates
- `tests/cli_integration_tests.rs` — new `mitre_help_text_mentions_collapse_behavior` test
- `docs/adr/0003-reporting-pipeline-layering.md` — supersession notice + struct vocabulary fix
- `README.md` — `--no-collapse` description alignment
- `CHANGELOG.md` — release date correction

### Why

The F7 holistic review (issue #259, tracked from issue #62) identified these 5 documentation gaps introduced when v0.9.0 shipped the `FindingsRender` struct refactor. The headline behavior — collapse-by-default in both flat and `--mitre` modes — was present in code but absent from `--help` and docs, creating a UX discoverability gap.

### Testing

- All existing tests pass (`cargo test --all-targets`): 0 failures
- New test `mitre_help_text_mentions_collapse_behavior` added and mutation-fail verified (test fails when the collapse description is removed from help text)
- `cargo clippy --all-targets -- -D warnings`: clean
- `cargo fmt --check`: clean
- Demo recording: not required — no behavior change

### Verification: No Internal Finding-ID Leakage

A first draft of F-PASS-A-001 accidentally embedded the internal finding-ID `F-PASS-A-001` in the `--mitre` help text. This was caught and removed in commit `b34b3ab`. The `src/` directory has been verified to contain no internal finding-IDs (F-PASS-A-001, F-03, F-04, F-05, F-PASSC-002) in user-facing content.

### Pre-Merge Checklist

- [x] Branch uses semantic naming (`docs/f7-convergence-doc-fixes`)
- [x] PR title uses allowed semantic type (`docs`)
- [x] No internal finding-IDs in user-facing `--help` / doc-comments
- [x] All tests pass locally
- [x] clippy -D warnings clean
- [x] fmt clean
- [x] No behavior change (doc/help-text only)
- [x] New test for F-PASS-A-001 regression
- [ ] CI checks pass (pending)
- [ ] PR reviewer approved (pending)
- [ ] Security reviewer cleared (pending)
