### PR TITLE
chore: release v0.9.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,9 +212,8 @@ jobs:
   # Background: clap derives --help output exclusively from `///` (doc-comment) lines
   # on Parser/Args/Subcommand/ValueEnum structs and their fields. Plain `//` comments
   # are never rendered to users and are not scanned here. Internal identifiers of the
-  # form BC-NNN, STORY-NNN, and LESSON-* must not appear in `///` doc-comments in
-  # clap-hosting files — they are implementation bookkeeping and have no meaning to
-  # end users.
+  # factory convention must not appear in `///` doc-comments in clap-hosting files —
+  # they are implementation bookkeeping and have no meaning to end users.
   #
   # Scope: src/cli.rs only. All clap derive macros (#[derive(Parser)], #[arg(...)],
   # #[command(...)]) currently live in src/cli.rs. Other src/ files use `///` for
@@ -224,9 +223,24 @@ jobs:
   # target in the step below.
   #
   # Pattern rationale:
-  #   BC-[0-9]    — behavioral contract refs (e.g. BC-2.11.028, BC-2.14.023)
-  #   STORY-[0-9] — factory story refs  (e.g. STORY-114, STORY-119)
-  #   LESSON-     — factory lesson refs (e.g. LESSON-P1.03, LESSON-P2.05)
+  #   \b[A-Z]{2,}-[0-9A-Z]  — matches any factory internal-ID convention:
+  #     two-or-more uppercase letters, a literal hyphen, then a digit or uppercase
+  #     letter. This covers the full known set of factory prefixes:
+  #       BC-       behavioral contract refs    (e.g. BC-2.11.028, BC-2.14.023)
+  #       STORY-    story refs                  (e.g. STORY-114, STORY-119)
+  #       LESSON-   lesson refs                 (e.g. LESSON-P1.03, LESSON-P2.05)
+  #       VP-       variant-proposal refs       (e.g. VP-016)
+  #       ADR-      architecture decision refs  (e.g. ADR-0003)
+  #       EC-       evaluation criterion refs   (e.g. EC-006)
+  #       AC-       acceptance criterion refs   (e.g. AC-007)
+  #       TD-       tech-debt refs              (e.g. TD-012)
+  #       PG-       policy-gate refs            (e.g. PG-001)
+  #   and any future two-plus-letter prefix that follows the same convention.
+  #   False-positive safety: ordinary hyphenated English prose uses lowercase
+  #   (e.g. "non-zero", "opt-in") and will never match [A-Z]{2,}. Legitimate
+  #   uppercase terms in help text that do not precede a hyphen (e.g. "MITRE",
+  #   "JSON", "TCP", "ARP") are equally safe — the hyphen-then-[0-9A-Z] suffix
+  #   anchors the match to ID-structured tokens only.
   # Only `///` lines (doc-comments) are matched; `//` comment lines are excluded by
   # the leading `^\s*///` anchor.
   help-provenance-gate:
@@ -237,21 +251,25 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Verify no internal factory IDs in clap /// doc-comments
         # Scans src/cli.rs (the sole clap-derive module) for `///` lines containing
-        # internal ID patterns (BC-NNN, STORY-NNN, LESSON-*). These patterns appear
-        # verbatim in clap --help output and must not be visible to end users.
-        # Plain // comment lines are not matched and are never rendered by clap.
-        # If a new clap-derive module is added, append its path to the grep target.
+        # factory internal-ID patterns. The pattern \b[A-Z]{2,}-[0-9A-Z] catches any
+        # UPPERCASE-prefix factory ID (BC-, STORY-, LESSON-, VP-, ADR-, EC-, AC-,
+        # TD-, PG-, and future additions) while excluding lowercase hyphenated prose
+        # and standalone uppercase acronyms that are not followed by -[digit/UPPER].
+        # These patterns appear verbatim in clap --help output and must not be visible
+        # to end users. Plain // comment lines are not matched and are never rendered
+        # by clap. If a new clap-derive module is added, append its path to the grep target.
         shell: bash
         run: |
           set -euo pipefail
-          VIOLATIONS=$(grep -n -E '^\s*///.*(BC-[0-9]|STORY-[0-9]|LESSON-)' src/cli.rs) || true
+          VIOLATIONS=$(grep -n -E '^\s*///.*\b[A-Z]{2,}-[0-9A-Z]' src/cli.rs) || true
           if [ -n "${VIOLATIONS}" ]; then
             echo "FAIL: Internal factory IDs found in /// doc-comments in src/cli.rs:"
             echo "${VIOLATIONS}"
             echo ""
             echo "/// doc-comments in clap-derive files are rendered verbatim into"
             echo "--help output and must not contain internal IDs (BC-NNN, STORY-NNN,"
-            echo "LESSON-*). Move internal references to plain // comments, which are"
+            echo "LESSON-*, VP-NNN, ADR-NNN, EC-NNN, AC-NNN, TD-NNN, etc.)."
+            echo "Move internal references to plain // comments, which are"
             echo "never rendered by clap and are invisible to end users."
             exit 1
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,11 +212,16 @@ jobs:
   # Background: clap derives --help output exclusively from `///` (doc-comment) lines
   # on Parser/Args/Subcommand/ValueEnum structs and their fields. Plain `//` comments
   # are never rendered to users and are not scanned here. Internal identifiers of the
-  # form BC-NNN, STORY-NNN, and LESSON-* must not appear in `///` doc-comments on any
-  # source file — they are implementation bookkeeping and have no meaning to end users.
+  # form BC-NNN, STORY-NNN, and LESSON-* must not appear in `///` doc-comments in
+  # clap-hosting files — they are implementation bookkeeping and have no meaning to
+  # end users.
   #
-  # Scope: all *.rs files under src/ (covers current and future clap-hosting files).
-  # A future clap struct added to any src/ file is automatically guarded.
+  # Scope: src/cli.rs only. All clap derive macros (#[derive(Parser)], #[arg(...)],
+  # #[command(...)]) currently live in src/cli.rs. Other src/ files use `///` for
+  # rustdoc on internal/library types (findings.rs, decoder.rs, etc.) where internal
+  # ID traceability is legitimate developer documentation and must not be stripped.
+  # If a new clap-derive module is added to src/, append its path to the grep
+  # target in the step below.
   #
   # Pattern rationale:
   #   BC-[0-9]    — behavioral contract refs (e.g. BC-2.11.028, BC-2.14.023)
@@ -225,31 +230,32 @@ jobs:
   # Only `///` lines (doc-comments) are matched; `//` comment lines are excluded by
   # the leading `^\s*///` anchor.
   help-provenance-gate:
-    name: Help-provenance gate (no internal IDs in /// doc-comments)
+    name: Help-provenance gate (no internal IDs in clap /// doc-comments)
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      - name: Verify no internal factory IDs in /// doc-comments
-        # Scans all Rust source files under src/ for `///` lines that contain
-        # internal ID patterns (BC-NNN, STORY-NNN, LESSON-*). These patterns
-        # appear in clap --help output and must not be visible to end users.
+      - name: Verify no internal factory IDs in clap /// doc-comments
+        # Scans src/cli.rs (the sole clap-derive module) for `///` lines containing
+        # internal ID patterns (BC-NNN, STORY-NNN, LESSON-*). These patterns appear
+        # verbatim in clap --help output and must not be visible to end users.
         # Plain // comment lines are not matched and are never rendered by clap.
+        # If a new clap-derive module is added, append its path to the grep target.
         shell: bash
         run: |
           set -euo pipefail
-          VIOLATIONS=$(grep -rn --include='*.rs' -E '^\s*///.*(BC-[0-9]|STORY-[0-9]|LESSON-)' src/) || true
+          VIOLATIONS=$(grep -n -E '^\s*///.*(BC-[0-9]|STORY-[0-9]|LESSON-)' src/cli.rs) || true
           if [ -n "${VIOLATIONS}" ]; then
-            echo "FAIL: Internal factory IDs found in /// doc-comments under src/:"
+            echo "FAIL: Internal factory IDs found in /// doc-comments in src/cli.rs:"
             echo "${VIOLATIONS}"
             echo ""
-            echo "/// doc-comments are rendered verbatim into clap --help output and"
-            echo "must not contain internal IDs (BC-NNN, STORY-NNN, LESSON-*)."
-            echo "Move internal references to plain // comments, which are never"
-            echo "rendered by clap and are invisible to end users."
+            echo "/// doc-comments in clap-derive files are rendered verbatim into"
+            echo "--help output and must not contain internal IDs (BC-NNN, STORY-NNN,"
+            echo "LESSON-*). Move internal references to plain // comments, which are"
+            echo "never rendered by clap and are invisible to end users."
             exit 1
           fi
-          echo "PASS: No internal factory IDs found in /// doc-comments under src/"
+          echo "PASS: No internal factory IDs found in /// doc-comments in src/cli.rs"
 
   # Supply-chain hardening: enforce that every remote GitHub Action `uses:` reference
   # is pinned to a 40-character commit SHA rather than a mutable tag or branch.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -241,6 +241,21 @@ jobs:
   #   uppercase terms in help text that do not precede a hyphen (e.g. "MITRE",
   #   "JSON", "TCP", "ARP") are equally safe — the hyphen-then-[0-9A-Z] suffix
   #   anchors the match to ID-structured tokens only.
+  #
+  # Standards-body exclusion (SEC-002 / CWE-697):
+  #   The broad regex also matches standards-body identifiers (RFC-9293, ISO-27001,
+  #   CVE-2024-1234, IEC-62443, ANSI-X9, NIST-800, IEEE-802) which are legitimate
+  #   and useful in help text. A second-pass filter strips these known prefixes so
+  #   that legitimate standards references never false-positive the gate.
+  #   Factory IDs use short, project-specific prefixes (BC, STORY, LESSON, VP, ADR,
+  #   EC, AC, TD, PG) that do not appear in the exclusion list.
+  #
+  # File-not-found guard (SEC-001 / CWE-390):
+  #   If src/cli.rs is renamed or deleted, `grep … || true` would silently return
+  #   an empty VIOLATIONS string and falsely PASS. An explicit existence check
+  #   before grep ensures such structural changes fail loudly so the gate scope
+  #   can be updated to match the new clap-derive module location.
+  #
   # Only `///` lines (doc-comments) are matched; `//` comment lines are excluded by
   # the leading `^\s*///` anchor.
   help-provenance-gate:
@@ -258,10 +273,39 @@ jobs:
         # These patterns appear verbatim in clap --help output and must not be visible
         # to end users. Plain // comment lines are not matched and are never rendered
         # by clap. If a new clap-derive module is added, append its path to the grep target.
+        #
+        # SEC-001 (CWE-390): explicit existence check before grep prevents a renamed or
+        # deleted src/cli.rs from silently returning an empty match and false-passing.
+        # SEC-002 (CWE-697): standards-body IDs (RFC, ISO, CVE, IEC, ANSI, NIST, IEEE)
+        # are excluded via a second-pass filter so legitimate references in help text
+        # never false-positive. Factory prefixes (BC, STORY, VP, ADR, etc.) are disjoint
+        # from this exclusion list and continue to be caught correctly.
         shell: bash
         run: |
           set -euo pipefail
-          VIOLATIONS=$(grep -n -E '^\s*///.*\b[A-Z]{2,}-[0-9A-Z]' src/cli.rs) || true
+
+          # SEC-001: fail loudly if the scan target has been renamed or removed.
+          # Without this check, `grep … || true` would silently PASS on a missing file
+          # (grep exits 2 for file-not-found, which `|| true` swallows). Updating the
+          # gate scope to match a new clap-derive module location is a deliberate step.
+          if ! test -f src/cli.rs; then
+            echo "FAIL: help-provenance-gate: src/cli.rs not found — clap surface moved?"
+            echo "Update the gate target in .github/workflows/ci.yml to match the new"
+            echo "clap-derive module location before merging."
+            exit 1
+          fi
+
+          # SEC-002: strip known standards-body IDs from grep hits before deciding
+          # pass/fail. RFC-NNNN, ISO-NNNNN, CVE-YYYY-NNNN, IEC-NNNNN, ANSI-XXX,
+          # NIST-NNN, IEEE-NNN are legitimate references in public help text and must
+          # not trigger the gate. Factory IDs (BC-, STORY-, LESSON-, VP-, ADR-, EC-,
+          # AC-, TD-, PG-) are not in this exclusion list and continue to be caught.
+          VIOLATIONS=$(
+            grep -n -E '^\s*///.*\b[A-Z]{2,}-[0-9A-Z]' src/cli.rs \
+              | grep -vE '\b(RFC|ISO|CVE|IEC|ANSI|NIST|IEEE)-' \
+            || true
+          )
+
           if [ -n "${VIOLATIONS}" ]; then
             echo "FAIL: Internal factory IDs found in /// doc-comments in src/cli.rs:"
             echo "${VIOLATIONS}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,6 +206,51 @@ jobs:
           fi
           echo "PASS: No production callers of _for_testing functions found in src/"
 
+  # Help-provenance gate: prevent internal factory IDs from leaking into user-facing
+  # --help text rendered by clap from `///` doc-comments.
+  #
+  # Background: clap derives --help output exclusively from `///` (doc-comment) lines
+  # on Parser/Args/Subcommand/ValueEnum structs and their fields. Plain `//` comments
+  # are never rendered to users and are not scanned here. Internal identifiers of the
+  # form BC-NNN, STORY-NNN, and LESSON-* must not appear in `///` doc-comments on any
+  # source file — they are implementation bookkeeping and have no meaning to end users.
+  #
+  # Scope: all *.rs files under src/ (covers current and future clap-hosting files).
+  # A future clap struct added to any src/ file is automatically guarded.
+  #
+  # Pattern rationale:
+  #   BC-[0-9]    — behavioral contract refs (e.g. BC-2.11.028, BC-2.14.023)
+  #   STORY-[0-9] — factory story refs  (e.g. STORY-114, STORY-119)
+  #   LESSON-     — factory lesson refs (e.g. LESSON-P1.03, LESSON-P2.05)
+  # Only `///` lines (doc-comments) are matched; `//` comment lines are excluded by
+  # the leading `^\s*///` anchor.
+  help-provenance-gate:
+    name: Help-provenance gate (no internal IDs in /// doc-comments)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: Verify no internal factory IDs in /// doc-comments
+        # Scans all Rust source files under src/ for `///` lines that contain
+        # internal ID patterns (BC-NNN, STORY-NNN, LESSON-*). These patterns
+        # appear in clap --help output and must not be visible to end users.
+        # Plain // comment lines are not matched and are never rendered by clap.
+        shell: bash
+        run: |
+          set -euo pipefail
+          VIOLATIONS=$(grep -rn --include='*.rs' -E '^\s*///.*(BC-[0-9]|STORY-[0-9]|LESSON-)' src/) || true
+          if [ -n "${VIOLATIONS}" ]; then
+            echo "FAIL: Internal factory IDs found in /// doc-comments under src/:"
+            echo "${VIOLATIONS}"
+            echo ""
+            echo "/// doc-comments are rendered verbatim into clap --help output and"
+            echo "must not contain internal IDs (BC-NNN, STORY-NNN, LESSON-*)."
+            echo "Move internal references to plain // comments, which are never"
+            echo "rendered by clap and are invisible to end users."
+            exit 1
+          fi
+          echo "PASS: No internal factory IDs found in /// doc-comments under src/"
+
   # Supply-chain hardening: enforce that every remote GitHub Action `uses:` reference
   # is pinned to a 40-character commit SHA rather than a mutable tag or branch.
   # Mutable refs (e.g. @v6, @v2.9.1, @stable) can be silently moved by the upstream

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,15 +11,37 @@ Version numbers follow [Semantic Versioning](https://semver.org/).
 
 ### Changed (BREAKING)
 
-- **`TerminalReporter` findings-render mode: two bools → `FindingsRender` enum (STORY-120, PR #266).**
-  The `show_mitre_grouping: bool` and `collapse_findings: bool` public fields on `TerminalReporter`
-  are removed and replaced by a single `render: FindingsRender` field. `FindingsRender` is an enum
-  with three variants: `Grouped` (formerly `show_mitre_grouping = true`), `FlatCollapsed` (formerly
-  `collapse_findings = true`), and `FlatExpanded` (formerly both bools false). The previously
-  representable invalid state (`show_mitre_grouping = true` and `collapse_findings = true`
-  simultaneously) is now structurally impossible. Terminal output is byte-identical across all
-  three modes; this is an internal refactor only. Per RFC 1105 the removal of public fields is a
-  breaking change, hence the 0.8.x → 0.9.0 minor bump.
+- **`TerminalReporter` findings-render mode: two bools → `FindingsRender` enum → `FindingsRender`
+  struct of two orthogonal enums (STORY-120 PR #266, STORY-122/A PR #268).**
+  This entry supersedes the three-variant enum description that shipped in an earlier 0.9.0
+  pre-release entry.
+
+  *Phase 1 (STORY-120, PR #266):* The `show_mitre_grouping: bool` and `collapse_findings: bool`
+  public fields on `TerminalReporter` were removed and replaced by a single `render: FindingsRender`
+  field typed as a three-variant enum (`Grouped`, `FlatCollapsed`, `FlatExpanded`).
+
+  *Phase 2 (STORY-122/A, PR #268):* `FindingsRender` was reshaped from a three-variant enum into
+  a **struct of two orthogonal enums**: `{ grouping: Grouping, collapse: Collapse }`. The
+  `Grouping` enum has variants `Grouped` and `Flat`; the `Collapse` enum has variants `Collapsed`
+  and `Expanded`. All four combinations are valid. The three named enum variants (`Grouped`,
+  `FlatCollapsed`, `FlatExpanded`) no longer exist. Per RFC 1105 this is an additional breaking
+  change: any code that matched or constructed the three-variant enum must migrate to the
+  two-field struct. The 0.8.x → 0.9.0 minor bump covers both phases.
+
+### Changed
+
+- **`--mitre` now collapses identical findings within each MITRE tactic bucket by default
+  (STORY-119/B, PR #269).** When `--mitre` is passed, `wirerust analyze` routes output through
+  the new `render_findings_grouped_collapsed` path, which groups identical findings (same category,
+  verdict, confidence, summary) within each tactic bucket into a single line with a `(xN)` count
+  suffix and up to K=3 representative evidence samples. Singletons render without a count suffix.
+  Terminal output for `--mitre` is **no longer byte-identical** to the pre-0.9.0 grouped output.
+  JSON and CSV output are unaffected.
+
+- **`--no-collapse` is now dual-scope (STORY-119/B, PR #269).** Previously `--no-collapse`
+  suppressed collapse only in flat (non-`--mitre`) mode. It now suppresses collapse in both flat
+  and grouped (`--mitre`) modes. Passing `--no-collapse` restores one-line-per-finding output
+  regardless of whether `--mitre` is also passed.
 
 ## [0.8.0] - 2026-06-17
 
@@ -34,8 +56,8 @@ Version numbers follow [Semantic Versioning](https://semver.org/).
   the same (category, verdict, confidence, summary) are collapsed into a single line with a
   `(xN)` count suffix and up to 3 representative evidence samples (K=3). This is a
   **display-layer-only behavioral change**: JSON and CSV output are unaffected, and
-  `--mitre`-grouped mode is also unchanged (grouped-mode collapse is deferred to a future
-  release). Pass `--no-collapse` to disable. Governed by ADR-0003 Display-Layer Aggregation.
+  `--mitre`-grouped mode was unchanged in 0.8.0; grouped-mode collapse shipped in 0.9.0.
+  Pass `--no-collapse` to disable. Governed by ADR-0003 Display-Layer Aggregation.
 
 ## [0.7.1] - 2026-06-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Version numbers follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
-## [0.9.0] - 2026-06-18
+## [0.9.0] - 2026-06-19
 
 ### Changed (BREAKING)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,14 @@ Version numbers follow [Semantic Versioning](https://semver.org/).
   change: any code that matched or constructed the three-variant enum must migrate to the
   two-field struct. The 0.8.x → 0.9.0 minor bump covers both phases.
 
+  *Forward-compatibility (F7-R2):* `Grouping`, `Collapse`, and `FindingsRender` (in
+  `wirerust::reporter::terminal`) are now marked `#[non_exhaustive]`, allowing future
+  variants or fields to be added without a semver-breaking change. Because `FindingsRender`
+  is `#[non_exhaustive]`, external crates must construct it via the new
+  `FindingsRender::new(grouping, collapse)` constructor rather than a struct literal
+  (struct-literal construction of a `#[non_exhaustive]` struct is rejected by the compiler
+  outside the defining crate).
+
 ### Changed
 
 - **`--mitre` now collapses identical findings within each MITRE tactic bucket by default

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ Version numbers follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-06-18
+
+### Changed (BREAKING)
+
+- **`TerminalReporter` findings-render mode: two bools → `FindingsRender` enum (STORY-120, PR #266).**
+  The `show_mitre_grouping: bool` and `collapse_findings: bool` public fields on `TerminalReporter`
+  are removed and replaced by a single `render: FindingsRender` field. `FindingsRender` is an enum
+  with three variants: `Grouped` (formerly `show_mitre_grouping = true`), `FlatCollapsed` (formerly
+  `collapse_findings = true`), and `FlatExpanded` (formerly both bools false). The previously
+  representable invalid state (`show_mitre_grouping = true` and `collapse_findings = true`
+  simultaneously) is now structurally impossible. Terminal output is byte-identical across all
+  three modes; this is an internal refactor only. Per RFC 1105 the removal of public fields is a
+  breaking change, hence the 0.8.x → 0.9.0 minor bump.
+
 ## [0.8.0] - 2026-06-17
 
 ### Added
@@ -381,7 +395,8 @@ Downstream consumers of wirerust JSON or CSV output must update for this release
 - Output sanitization in the terminal reporter guards against C1 control bytes
   in packet-derived strings.
 
-[Unreleased]: https://github.com/Zious11/wirerust/compare/v0.8.0...HEAD
+[Unreleased]: https://github.com/Zious11/wirerust/compare/v0.9.0...HEAD
+[0.9.0]: https://github.com/Zious11/wirerust/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/Zious11/wirerust/compare/v0.7.1...v0.8.0
 [0.7.1]: https://github.com/Zious11/wirerust/compare/v0.7.0...v0.7.1
 [0.7.0]: https://github.com/Zious11/wirerust/compare/v0.6.0...v0.7.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1637,7 +1637,7 @@ dependencies = [
 
 [[package]]
 name = "wirerust"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wirerust"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2024"
 rust-version = "1.91"
 description = "Fast PCAP forensics and network triage CLI tool"

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Options:
 --arp                                  Analyze ARP traffic (spoofing, GARP, storms, malformed, MAC mismatch; default-off; included in --all)
 --arp-spoof-threshold N                MAC-rebind escalation threshold per IP within 60s window (default: 3)
 --arp-storm-rate N                     ARP storm frames/second per source MAC threshold (default: 50)
---no-collapse                          Disable collapsing of repeated findings in both flat and grouped (--mitre) terminal output. By default, collapse is enabled in both modes. Pass --no-collapse to restore one-line-per-finding output in both modes. Has no effect on --output json or --output csv.
+--no-collapse                          Disable collapsing of repeated findings in both flat and grouped (--mitre) terminal output. By default, collapse is enabled in both modes. When --mitre is used, collapse groups identical findings within each MITRE tactic bucket with a (xN) count suffix. Pass --no-collapse to restore one-line-per-finding output in both modes. Has no effect on --output json or --output csv.
 --mitre                                Group findings by MITRE ATT&CK tactic and show technique names; collapses identical findings within each tactic bucket with a (xN) count suffix by default (pass --no-collapse to disable)
 -a, --all                              Run all analyzers
 ```

--- a/README.md
+++ b/README.md
@@ -107,8 +107,8 @@ Options:
 --arp                                  Analyze ARP traffic (spoofing, GARP, storms, malformed, MAC mismatch; default-off; included in --all)
 --arp-spoof-threshold N                MAC-rebind escalation threshold per IP within 60s window (default: 3)
 --arp-storm-rate N                     ARP storm frames/second per source MAC threshold (default: 50)
---no-collapse                          Disable terminal finding-collapse (default ON); restore one-line-per-finding output (pre-v0.8.0)
---mitre                                Group findings by MITRE ATT&CK tactic with technique names
+--no-collapse                          Disable collapsing of repeated findings in both flat and grouped (--mitre) terminal output. By default, collapse is enabled in both modes. Pass --no-collapse to restore one-line-per-finding output in both modes. Has no effect on --output json or --output csv.
+--mitre                                Group findings by MITRE ATT&CK tactic and show technique names; collapses identical findings within each tactic bucket with a (xN) count suffix by default (pass --no-collapse to disable)
 -a, --all                              Run all analyzers
 ```
 

--- a/docs/adr/0003-reporting-pipeline-layering.md
+++ b/docs/adr/0003-reporting-pipeline-layering.md
@@ -265,7 +265,7 @@ displayed:
 The ` (xN)` suffix is part of the string that is passed to the color function — it is appended
 **before** colorization, not after the ANSI reset. The color ladder applied to the pre-suffix
 string is the same verdict/confidence ladder used by the existing `render_finding_prefix`
-(terminal.rs:209-221): `Likely/High → red().bold()`, `Likely/other → yellow`,
+(terminal.rs:273-285): `Likely/High → red().bold()`, `Likely/other → yellow`,
 `Possible → yellow`, `Inconclusive → cyan`, `Unlikely → dimmed`. See BC-2.11.026 PC-6.
 
 Evidence sampling: a collapsed group retains at most K = 3 evidence lines, taken from the

--- a/docs/adr/0003-reporting-pipeline-layering.md
+++ b/docs/adr/0003-reporting-pipeline-layering.md
@@ -700,7 +700,7 @@ The three existing functions (`render_findings_grouped`, `render_findings_collap
 ### CLI → Render Mode Wiring (two-phase: STORY-122/A then STORY-119/B)
 
 `src/main.rs` `run_analyze` TerminalReporter construction site
-(the 3-arm-if at `src/main.rs:380-395`; `run_summary` inert site at `src/main.rs:456-459`).
+(orthogonal 2-if struct construction at `src/main.rs:383-390`; `run_summary` inert site at `src/main.rs:451-454`).
 
 `show_mitre_grouping` ← `*mitre` (CLI `--mitre` flag).
 `collapse_findings` ← `collapse_findings_from_flag(*no_collapse)` (unchanged: `!no_collapse`).

--- a/docs/adr/0003-reporting-pipeline-layering.md
+++ b/docs/adr/0003-reporting-pipeline-layering.md
@@ -318,8 +318,9 @@ individually as today, regardless of the `collapse_findings` flag.
 
 This is a deliberate scope boundary, not a design principle. When both
 `show_mitre_grouping = true` and `collapse_findings = true`, collapse silently does not
-apply to grouped output. Grouped-mode collapse is deferred to STORY-119 in a follow-on
-cycle.
+apply to grouped output. Grouped-mode collapse is deferred to STORY-119/B in a follow-on
+cycle (D-120 split: STORY-119 was subsequently split into STORY-122/A + STORY-119/B; the
+grouped-collapse render path is STORY-119/B scope).
 
 ### Binding Rule
 
@@ -344,8 +345,8 @@ The F1 gate locked always-collapse (no threshold).
 
 **Collapse within each MITRE tactic bucket (`--mitre` + collapse):** Feasible but
 non-trivial — requires a collapse pass after bucketing and sorting but before rendering
-each bucket. Deferred to STORY-119 per F1 gate OQ-3 resolution (flat mode only for
-v0.8.0).
+each bucket. Deferred to STORY-119/B per F1 gate OQ-3 resolution (flat mode only for
+v0.8.0; original deferral was to STORY-119, subsequently scoped to STORY-119/B per D-120).
 
 ### Precedents
 
@@ -362,7 +363,7 @@ Wireshark model and avoids the syslog anti-pattern.
 
 ## Render-Mode Enum (Issue #62 — v0.9.0)
 
-**Status of this subsection:** Accepted (F2 spec evolution 2026-06-17; F3 scope correction 2026-06-18)
+**Status of this subsection:** Accepted (F2 spec evolution 2026-06-17; F3 scope correction 2026-06-18; reshaped to struct by STORY-122/A (D-120 split) — see "Grouped-Mode Collapse" subsection below)
 
 ### Context
 
@@ -549,20 +550,45 @@ variant after the fact.
 
 ### Binding Rule
 
-> **Rule 5 (render-mode type):** `TerminalReporter`'s findings rendering mode MUST be
-> expressed as `FindingsRender`. Adding a new rendering mode requires adding a new variant
-> to `FindingsRender` and updating all exhaustive `match` arms. A bool field on
-> `TerminalReporter` that encodes a mutually-exclusive rendering mode is prohibited; such a
-> field MUST be folded into `FindingsRender` or a successor enum. Orthogonal toggles
-> (properties that do not create illegal states when combined with existing fields) MAY
-> remain as bool fields.
+> **Rule 5 (render-mode type — reshaped by STORY-122/A, D-120 split):** `TerminalReporter`'s
+> findings rendering mode MUST be expressed as `FindingsRender`. As of STORY-122/A,
+> `FindingsRender` is a **struct of two orthogonal enums** (`Grouping` × `Collapse`) rather
+> than a single sum type. The enum→struct reshape, the 84-site construction-site migration,
+> and the four-arm dispatch establishment are STORY-122/A deliverables (D-120 split of the
+> original monolithic STORY-119; byte-identical; CLI behavior unchanged in A). Adding a new
+> rendering axis requires adding a new named enum field to `FindingsRender` and updating all
+> exhaustive `match (grouping, collapse)` dispatch arms. A bool field on `TerminalReporter`
+> that encodes a rendering-mode axis is prohibited; such a field MUST be expressed as a named
+> enum in `FindingsRender`. Orthogonal toggles that do not constitute a rendering-mode axis
+> (e.g., `use_color`, `show_hosts_breakdown`) MAY remain as bool fields.
+>
+> **Orthogonality realization (STORY-122/A → STORY-119/B):** The type reshape establishing
+> the struct-of-enums is STORY-122/A. The orthogonality is made real by STORY-119/B, which
+> adds grouped-mode collapse, making all four combinations valid. The v0.9.0 three-variant sum
+> type was correct when `{Grouped, Collapsed}` was an illegal state; STORY-122/A replaced it
+> with a struct-of-enums (still byte-identical — `{Grouped, Collapsed}` dispatch arm exists
+> but is unreachable via CLI until STORY-119/B flips the default). STORY-119/B completes the
+> realization by implementing `render_findings_grouped_collapsed` and flipping the `--mitre`
+> default. Research basis: `.factory/research/story-119-render-mode-typedesign.md`.
+>
+> *(D-120 split note: the monolithic STORY-119 was split into STORY-122 (A — reshape + 84-site
+> migration, byte-identical) + STORY-119 (B — grouped-collapse render path + `--mitre`
+> default-collapse CLI flip + `--no-collapse` dual-scope) per D-120.)*
 
 ### Alternatives Considered
 
-**Pre-split for STORY-119 (grouped-mode collapse):** Add `GroupedCollapsed` and
+**Pre-split for STORY-119 (grouped-mode collapse, pre-D-120):** Add `GroupedCollapsed` and
 `GroupedExpanded` variants now, anticipating a future feature. Rejected as YAGNI — the
-STORY-119 cycle will have its own F1/F2 and can amend the enum at that time. The current
-three-variant enum exactly models the current three modes with no phantom states.
+STORY-119 cycle (pre-split; now realized as STORY-119/B per D-120) will have its own F1/F2
+and can amend the enum at that time. The current three-variant enum exactly models the
+current three modes with no phantom states.
+*(Note: this alternative was revisited during F2 spec evolution. The flat 4-variant enum was
+evaluated against the struct-of-enums; the struct was chosen because the axes are genuinely
+orthogonal (all four combinations valid). The reshape itself was delivered by STORY-122/A
+(D-120 split), byte-identical. Note: `FindingsRender` IS public library API (via
+`wirerust::reporter::terminal`), so reshaping it is a breaking change — but it is contained
+by the unreleased v0.8.x→v0.9.0 bump (D-110), so there are no already-released downstream
+consumers to break.)*
 
 **Builder / typestate pattern:** A `TerminalReporterBuilder` with typestate enforcement.
 Warranted for multi-step construction with cross-field invariants. Rejected: `TerminalReporter`
@@ -573,6 +599,311 @@ correct, minimal tool.
 documented in comments and BCs. Rejected: the illegal state is still constructible; the
 compiler provides no enforcement; new contributors can silently violate the invariant. The
 type-system fix is strictly superior.
+
+---
+
+## Grouped-Mode Collapse — Issue #259 tail / STORY-119/B (+ STORY-122/A reshape)
+
+**Status of this subsection:** Accepted (F2 spec evolution 2026-06-18; D-120 split: enum→struct
+reshape + migration map = STORY-122/A; grouped-collapse render path + `--mitre` default-collapse
+CLI flip + `--no-collapse` dual-scope = STORY-119/B; F4 implementation pending)
+
+*(D-120 split note: the monolithic STORY-119 was split per D-120 into STORY-122 (A — enum→struct
+reshape, 84-site migration, byte-identical, CLI unchanged) and STORY-119 (B — grouped-collapse
+render path, `--mitre` default-collapse flip, `--no-collapse` dual-scope). The struct definition,
+the 2×2 orthogonal-axes design, and the Migration Map below are STORY-122/A deliverables.)*
+
+### Context
+
+STORY-118 (v0.8.0) introduced finding collapse for flat mode only, explicitly deferring
+grouped-mode collapse as a scope boundary. STORY-119/B closes that deferral: collapse within
+each MITRE tactic bucket is now supported, making the two rendering axes **fully orthogonal**.
+
+This orthogonality realization requires revising the v0.9.0 `FindingsRender` three-variant
+sum type. The constraint that justified the sum type — "`{Grouped, Collapsed}` is an illegal
+state" — no longer holds. A product type is now the faithful encoding of the domain. The
+type itself is reshaped to the struct-of-enums by STORY-122/A (byte-identical); STORY-119/B
+completes the realization by implementing the grouped-collapse render path and flipping
+`--mitre` to default-collapsed.
+
+### Decision
+
+**Replace the three-variant `FindingsRender` enum with a struct of two orthogonal enums.**
+*(Struct definition, `Grouping`/`Collapse` enum types, and 84-site migration = STORY-122/A.
+Grouped-collapse render path + `--mitre` default-collapse + `--no-collapse` dual-scope = STORY-119/B.)*
+
+```rust
+/// Grouping axis: whether to group findings by MITRE tactic.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Grouping {
+    /// Group by MITRE ATT&CK tactic (`--mitre`). Renders tactic-bucket headers.
+    Grouped,
+    /// Render in emission order with no tactic headers (default).
+    Flat,
+}
+
+/// Collapse axis: whether to collapse repeated findings.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Collapse {
+    /// Collapse groups sharing `(category, verdict, confidence, summary)` into
+    /// counted summaries with ` (xN)` suffix (N ≥ 2) and K=3 evidence sampling.
+    /// Default for terminal output.
+    Collapsed,
+    /// One display line per raw finding. Restored by `--no-collapse`.
+    Expanded,
+}
+
+/// Rendering mode for the FINDINGS section — product of the two orthogonal axes.
+///
+/// All four combinations are valid: struct reshaped by STORY-122/A (D-120 split, byte-identical);
+/// grouped-mode collapse implemented by STORY-119/B (D-120 split, `--mitre` default-collapse flip).
+/// No `Default` derived — deliberate omission, consistent with STORY-120.
+/// ADR-0003 Binding Rule 5 (reshaped by STORY-122/A; behavior completed by STORY-119/B).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FindingsRender {
+    pub grouping: Grouping,
+    pub collapse: Collapse,
+}
+```
+
+### Migration Map from v0.9.0 Three-Variant Enum (STORY-122/A deliverable)
+
+This migration map is a STORY-122/A (D-120 split) deliverable. STORY-122/A performs the
+enum→struct reshape across 84 construction sites; under A the resulting struct is byte-identical
+to the prior three-variant enum at every existing call site. The fourth combination
+`{Grouped, Collapsed}` dispatch arm is added by STORY-122/A but is unreachable via CLI until
+STORY-119/B flips the `--mitre` default.
+
+| v0.9.0 `FindingsRender` variant | STORY-122/A `FindingsRender` struct |
+|---------------------------------|-------------------------------------|
+| `FindingsRender::Grouped` | `{ grouping: Grouping::Grouped, collapse: Collapse::Expanded }` |
+| `FindingsRender::FlatCollapsed` | `{ grouping: Grouping::Flat, collapse: Collapse::Collapsed }` |
+| `FindingsRender::FlatExpanded` | `{ grouping: Grouping::Flat, collapse: Collapse::Expanded }` |
+| *(new dispatch arm, unreachable via CLI until STORY-119/B)* | `{ grouping: Grouping::Grouped, collapse: Collapse::Collapsed }` |
+
+### 2×2 Dispatch Matrix
+
+`TerminalReporter::render()` replaces the 3-arm `match self.render` with a 4-arm match on
+the tuple `(self.render.grouping, self.render.collapse)`:
+
+| `Grouping` \ `Collapse` | `Collapsed` | `Expanded` |
+|-------------------------|-------------|------------|
+| **`Grouped`** | **NEW** — `render_findings_grouped_collapsed`: per-bucket collapse, `(xN)` suffix, K=3 evidence sampling, name-expanded MITRE line from group representative | EXISTING — `render_findings_grouped`: suffix-free, name-expanded MITRE lines (BC-2.11.013) |
+| **`Flat`** | EXISTING — `render_findings_collapsed`: flat collapse, `(xN)` suffix, K=3 evidence sampling (BC-2.11.025/026/027) | EXISTING — `render_finding_flat` loop: one line per finding |
+
+The three existing functions (`render_findings_grouped`, `render_findings_collapsed`,
+`render_finding_flat`, `render_finding_grouped`) are structurally unchanged. Only
+`render_findings_grouped_collapsed` is new.
+
+### CLI → Render Mode Wiring (two-phase: STORY-122/A then STORY-119/B)
+
+`src/main.rs` `run_analyze` TerminalReporter construction site
+(`src/reporter/terminal.rs` at the struct initialization, ~line 373 in f851995 era).
+The construction expression is identical in both phases — only the reachability of the
+`{Grouped, Collapsed}` arm changes between them:
+
+```rust
+render: FindingsRender {
+    grouping: if show_mitre_grouping { Grouping::Grouped } else { Grouping::Flat },
+    collapse: if collapse_findings { Collapse::Collapsed } else { Collapse::Expanded },
+},
+```
+
+`show_mitre_grouping` ← `*mitre` (CLI `--mitre` flag).
+`collapse_findings` ← `collapse_findings_from_flag(*no_collapse)` (unchanged: `!no_collapse`).
+
+**Phase A — STORY-122/A (byte-identical; `--mitre` behavior unchanged):**
+
+Under STORY-122/A the construction expression above is in place, but the `collapse_findings`
+value when `--mitre` is passed is still `true` (default-on from v0.8.0 `--no-collapse`
+semantics). The `{Grouped, Collapsed}` dispatch arm exists in `render()` but routes to
+`render_findings_grouped` (the existing grouped-expanded function) as a temporary placeholder
+— `render_findings_grouped_collapsed` does not exist yet. Observable CLI behavior is
+byte-identical to v0.9.0: `--mitre` still produces suffix-free grouped output.
+
+| CLI flags (Phase A) | Resulting struct | Behavior |
+|--------------------|-----------------|----------|
+| *(default)* | `{Flat, Collapsed}` | Flat collapse — unchanged. |
+| `--no-collapse` | `{Flat, Expanded}` | Flat expanded — unchanged. |
+| `--mitre` | `{Grouped, Expanded}` | Routes to `render_findings_grouped` (placeholder) — byte-identical to prior `FindingsRender::Grouped`. (`{Grouped, Collapsed}` struct value is constructed but unreachable via CLI in Phase A; the dispatch arm exists but delegates to the expanded renderer.) |
+| `--mitre --no-collapse` | `{Grouped, Expanded}` | Suffix-free grouped — unchanged. |
+
+**Phase B — STORY-119/B (behavior flip; `--mitre` default changes):**
+
+STORY-119/B introduces `render_findings_grouped_collapsed` and repoints the
+`{Grouped, Collapsed}` dispatch arm from the placeholder to the new function. No change to
+the construction expression. `--no-collapse` becomes dual-scope (suppresses collapse in both
+flat and grouped modes).
+
+| CLI flags (Phase B) | Resulting struct | Behavior |
+|--------------------|-----------------|----------|
+| *(default)* | `{Flat, Collapsed}` | Flat collapse — unchanged default. |
+| `--no-collapse` | `{Flat, Expanded}` | Flat expanded — unchanged opt-out. |
+| `--mitre` | `{Grouped, Collapsed}` | **New behavior** — per-bucket collapse, `(xN)` suffix, K=3 evidence sampling. |
+| `--mitre --no-collapse` | `{Grouped, Expanded}` | Old `--mitre` behavior — suffix-free. |
+
+**Approved behavior change (STORY-119/B):** `--mitre` alone now produces `{Grouped, Collapsed}`
+with per-bucket collapse. In v0.9.0 and Phase A, `--mitre` produced suffix-free grouped output.
+`--no-collapse` is now dual-scope: it suppresses collapse in both flat and grouped modes.
+
+`run_summary` site: `FindingsRender { grouping: Grouping::Flat, collapse: Collapse::Collapsed }`
+(inert — `run_summary` never renders a FINDINGS section).
+
+### Collapse-API Shape — F3 Type-Design Adjudication (STORY-119/B)
+
+**Status:** Accepted (F3 spec-evolution remediation 2026-06-18)
+
+**Problem:** `collapse_findings_pass` (`:340`) takes `&'a [Finding]` — a slice of owned values.
+The grouped path builds tactic buckets as `HashMap<Option<MitreTactic>, Vec<(usize, &Finding)>>`
+— each bucket element is a reference, not an owned value. Rust cannot coerce `&[&Finding]` to
+`&[Finding]`. Passing a bucket to the unmodified `collapse_findings_pass` would require
+materializing a `Vec<Finding>` (deep clone of every `Finding` in the bucket), which `Finding`
+supports (`#[derive(Clone)]`) but which is unnecessary and was never specified.
+
+**Decision:** Introduce a private `collapse_findings_pass_refs` as the single source of
+collapse logic, accepting a `&[&'a Finding]` slice. The existing `collapse_findings_pass`
+becomes a thin adapter that collects the owned slice into references and delegates.
+
+**Exact signatures (F4 target, `src/reporter/terminal.rs`):**
+
+```rust
+/// Core collapse logic: groups a slice of *references* to findings by CollapseKey
+/// in first-occurrence order. Both flat-mode and grouped-mode callers use this.
+///
+/// Accepts `&[&'a Finding]` so both the flat-mode path (which collects
+/// `findings.iter().collect()` once) and the grouped-mode path (which strips the
+/// `usize` emission-index from each bucket's `Vec<(usize, &Finding)>`) can call
+/// this single implementation without cloning any `Finding` value.
+///
+/// BC-2.11.025 invariant 7 / postcondition 9: Vec accumulator is canonical.
+fn collapse_findings_pass_refs<'a>(
+    &self,
+    findings: &[&'a Finding],
+) -> Vec<(CollapseKey, Vec<&'a Finding>)> {
+    let mut groups: Vec<(CollapseKey, Vec<&'a Finding>)> = Vec::new();
+    for f in findings {
+        let key = CollapseKey {
+            category: f.category,
+            verdict: f.verdict,
+            confidence: f.confidence,
+            summary: f.summary.clone(),
+        };
+        if let Some(pos) = groups.iter().position(|(k, _)| k == &key) {
+            groups[pos].1.push(f);
+        } else {
+            groups.push((key, vec![f]));
+        }
+    }
+    groups
+}
+
+/// Flat-mode adapter: collects `&[Finding]` into references, delegates to
+/// `collapse_findings_pass_refs`. Preserves the existing call signature for
+/// `render_findings_collapsed` (`:376`) — that caller is unchanged.
+///
+/// BC-2.11.025 invariant 7 / postcondition 9: Vec accumulator is canonical.
+fn collapse_findings_pass<'a>(
+    &self,
+    findings: &'a [Finding],
+) -> Vec<(CollapseKey, Vec<&'a Finding>)> {
+    let refs: Vec<&Finding> = findings.iter().collect();
+    self.collapse_findings_pass_refs(&refs)
+}
+```
+
+**Flat-mode caller** (`render_findings_collapsed`, `:376`): unchanged — it still calls
+`self.collapse_findings_pass(findings)` with a `&[Finding]` slice. The adapter wraps it.
+
+**Grouped-mode caller** (`render_findings_grouped_collapsed`, F4-new): strips the `usize`
+emission-index from each bucket entry before calling the shared logic:
+
+```rust
+// Inside render_findings_grouped_collapsed, per-bucket:
+let bucket_refs: Vec<&Finding> = items.iter().map(|(_, f)| *f).collect();
+let groups = self.collapse_findings_pass_refs(&bucket_refs);
+```
+
+**Invariants preserved:**
+- Zero per-bucket `Finding` clone. `Finding` values live in the caller's `&[Finding]` slice
+  throughout; only references are held in the accumulator.
+- Single source of collapse logic (`collapse_findings_pass_refs`). No duplicated group-building
+  code between flat and grouped paths — BC-2.11.031 Invariant 3 (shared pass) is satisfied.
+- `collapse_findings_pass` public call signature is unchanged. Its BC citation (`:340-360`) and
+  all existing test references remain valid.
+- Purity boundary (ADR-0003 Rule 2, Rule 4): the collapse pass is still a pure, side-effect-free
+  function. No I/O, no mutation, no global state.
+
+**Why not option (b) — generic `IntoIterator`:** `&[&'a Finding]` when iterated via `for f in
+findings.iter()` yields `&&'a Finding` (double reference). A bound of
+`IntoIterator<Item = &'a Finding>` is satisfied by `Vec<&'a Finding>` (consuming) but NOT by
+`&[&'a Finding]` (which yields `&&'a Finding`). Unifying the two call sites generically requires
+either a consuming iterator (incompatible with the flat-mode `&[Finding]` borrow) or deref
+coercion wrappers. The sibling adapter is cleaner and does not require changing the existing
+caller or its BC-cited signature at `:340`.
+
+**Why not option (c) — clone per bucket:** `Finding` is `Clone` but the clone is unnecessary.
+Rejected.
+
+---
+
+### `render_findings_grouped_collapsed` — New Function Contract
+
+Groups findings into tactic buckets identically to `render_findings_grouped` (BC-2.11.013
+tactic bucketing: `mitre_techniques[0]` determines bucket; `all_tactics_in_report_order()`;
+`Uncategorized` last; sort ascending by verdict rank (Likely=0, Possible=1, Inconclusive=2, Unlikely=3), then confidence rank (High=0, Medium=1, Low=2), then emission-index within bucket — highest-severity surfaces first).
+
+Within each bucket, strips emission indices to produce `Vec<&Finding>`, then calls
+`collapse_findings_pass_refs` (the shared collapse-logic function introduced above; same
+`CollapseKey` as flat mode). Renders each resulting group:
+
+- **N = 1:** delegates to `render_finding_grouped` — byte-identical to grouped-expanded path;
+  MITRE name expansion; no suffix.
+- **N ≥ 2:** header with ` (xN)` suffix appended BEFORE colorization (same convention as flat
+  collapse, BC-2.11.026 PC-6). Evidence sampling: first `min(N, COLLAPSE_EVIDENCE_SAMPLES)`
+  members positionally; `evidence[0]` from each inspected member if non-empty; window does NOT
+  slide past empty-evidence members (BC-2.11.027 Invariant 2). MITRE line from `members[0]`:
+  name-expanded format (`— Name` or `(unknown)`), consistent with `render_finding_grouped`.
+
+`escape_for_terminal` invariant (VP-012) is preserved — all summary and evidence strings are
+escaped before terminal output. Collapse pass operates on raw (unescaped) field values.
+
+### Semver Note
+
+This is a further breaking change to the unreleased v0.9.0 `FindingsRender` public type.
+Per D-110 (F1 gate 2026-06-17): **no separate version bump**. This change bundles into the
+unreleased 0.9.0 develop line. `FindingsRender` has not shipped in any released crate version
+(v0.8.0 shipped bool fields). The v0.9.0 release is **held** pending STORY-122/A + STORY-119/B
+completion (D-120 split: A delivers the struct reshape; B delivers grouped-collapse behavior).
+`cargo-semver-checks` `struct_field_missing` will fire on the v0.8.x → v0.9.0 diff
+(expected; the enum variants are replaced by struct fields). This is correct, not a defect.
+
+### BCs Requiring Revision / Authoring
+
+The product owner must revise the following existing BCs before F3 story decomposition:
+
+- **BC-2.11.013:** Revise preconditions to reference `Grouping::Grouped` (not `FindingsRender::Grouped`).
+  Add invariants covering `{Grouped, Collapsed}` case. Remove/retire the "Grouped implies no
+  collapse" invariant added in STORY-118 scope-control deferral.
+- **BC-2.11.025:** Narrow scope explicitly to `Grouping::Flat`. Retire the invariant that
+  collapse is flat-only (it was a temporary scope-boundary invariant, not a permanent constraint).
+- **BC-2.11.026:** Broaden `(xN)` suffix rule to cover per-bucket grouped-collapse; clarify
+  the singleton/N≥2 rule applies within each bucket in grouped mode.
+- **BC-2.11.028:** Broaden `--no-collapse` scope to dual-scope (both flat and grouped modes).
+  Update architecture anchor to reflect the new struct-construction wiring.
+
+The product owner must author the following new BCs (suggested BC-2.11.030 onward):
+
+- **New BC:** `--mitre` default-collapse behavior: `--mitre` alone → `{Grouped, Collapsed}`;
+  `--mitre --no-collapse` → `{Grouped, Expanded}`. CLI → render mode table.
+- **New BC:** Per-bucket count suffix: within a tactic bucket, N ≥ 2 group renders with
+  ` (xN)` suffix; singleton renders without suffix. Format identical to flat-mode convention.
+- **New BC:** Per-bucket evidence sampling: within a tactic bucket, collapsed group of N ≥ 2
+  retains at most K = `COLLAPSE_EVIDENCE_SAMPLES` evidence lines from first min(N,K) members;
+  window does not slide past empty-evidence members.
+- **New BC:** Tactic-bucket ordering invariant under grouped-collapse: bucket order is
+  unchanged by collapse; `Uncategorized` is still last; collapse does not alter bucket membership.
+- **New BC:** MITRE line format in grouped-collapse: the name-expanded format (`— Name` or
+  `(unknown)`) is used for the group representative (`members[0]`) in N ≥ 2 groups.
 
 ---
 

--- a/docs/adr/0003-reporting-pipeline-layering.md
+++ b/docs/adr/0003-reporting-pipeline-layering.md
@@ -698,7 +698,7 @@ The three existing functions (`render_findings_grouped`, `render_findings_collap
 ### CLI → Render Mode Wiring (two-phase: STORY-122/A then STORY-119/B)
 
 `src/main.rs` `run_analyze` TerminalReporter construction site
-(`src/reporter/terminal.rs` at the struct initialization, ~line 373 in f851995 era).
+(the 3-arm-if at `src/main.rs:380-395`; `run_summary` inert site at `src/main.rs:456-459`).
 
 `show_mitre_grouping` ← `*mitre` (CLI `--mitre` flag).
 `collapse_findings` ← `collapse_findings_from_flag(*no_collapse)` (unchanged: `!no_collapse`).
@@ -762,7 +762,7 @@ with per-bucket collapse. In v0.9.0 and Phase A, `--mitre` produced suffix-free 
 
 **Status:** Accepted (F3 spec-evolution remediation 2026-06-18)
 
-**Problem:** `collapse_findings_pass` (`:340`) takes `&'a [Finding]` — a slice of owned values.
+**Problem:** `collapse_findings_pass` (`:343`) takes `&'a [Finding]` — a slice of owned values.
 The grouped path builds tactic buckets as `HashMap<Option<MitreTactic>, Vec<(usize, &Finding)>>`
 — each bucket element is a reference, not an owned value. Rust cannot coerce `&[&Finding]` to
 `&[Finding]`. Passing a bucket to the unmodified `collapse_findings_pass` would require
@@ -808,7 +808,7 @@ fn collapse_findings_pass_refs<'a>(
 
 /// Flat-mode adapter: collects `&[Finding]` into references, delegates to
 /// `collapse_findings_pass_refs`. Preserves the existing call signature for
-/// `render_findings_collapsed` (`:376`) — that caller is unchanged.
+/// `render_findings_collapsed` (`:379`) — that caller is unchanged.
 ///
 /// BC-2.11.025 invariant 7 / postcondition 9: Vec accumulator is canonical.
 fn collapse_findings_pass<'a>(
@@ -820,7 +820,7 @@ fn collapse_findings_pass<'a>(
 }
 ```
 
-**Flat-mode caller** (`render_findings_collapsed`, `:376`): unchanged — it still calls
+**Flat-mode caller** (`render_findings_collapsed`, `:379`): unchanged — it still calls
 `self.collapse_findings_pass(findings)` with a `&[Finding]` slice. The adapter wraps it.
 
 **Grouped-mode caller** (`render_findings_grouped_collapsed`, F4-new): strips the `usize`
@@ -837,7 +837,7 @@ let groups = self.collapse_findings_pass_refs(&bucket_refs);
   throughout; only references are held in the accumulator.
 - Single source of collapse logic (`collapse_findings_pass_refs`). No duplicated group-building
   code between flat and grouped paths — BC-2.11.031 Invariant 3 (shared pass) is satisfied.
-- `collapse_findings_pass` public call signature is unchanged. Its BC citation (`:340-360`) and
+- `collapse_findings_pass` public call signature is unchanged. Its BC citation (`:343-360`) and
   all existing test references remain valid.
 - Purity boundary (ADR-0003 Rule 2, Rule 4): the collapse pass is still a pure, side-effect-free
   function. No I/O, no mutation, no global state.
@@ -848,7 +848,7 @@ findings.iter()` yields `&&'a Finding` (double reference). A bound of
 `&[&'a Finding]` (which yields `&&'a Finding`). Unifying the two call sites generically requires
 either a consuming iterator (incompatible with the flat-mode `&[Finding]` borrow) or deref
 coercion wrappers. The sibling adapter is cleaner and does not require changing the existing
-caller or its BC-cited signature at `:340`.
+caller or its BC-cited signature at `:343`.
 
 **Why not option (c) — clone per bucket:** `Finding` is `Clone` but the clone is unnecessary.
 Rejected.

--- a/docs/adr/0003-reporting-pipeline-layering.md
+++ b/docs/adr/0003-reporting-pipeline-layering.md
@@ -604,9 +604,11 @@ type-system fix is strictly superior.
 
 ## Grouped-Mode Collapse — Issue #259 tail / STORY-119/B (+ STORY-122/A reshape)
 
-**Status of this subsection:** Accepted (F2 spec evolution 2026-06-18; D-120 split: enum→struct
-reshape + migration map = STORY-122/A; grouped-collapse render path + `--mitre` default-collapse
-CLI flip + `--no-collapse` dual-scope = STORY-119/B; F4 implementation pending)
+**Status of this subsection:** Implemented (F2 spec evolution 2026-06-18; D-120 split:
+enum→struct reshape + migration map = STORY-122/A [IMPLEMENTED]; grouped-collapse render path
++ `--mitre` default-collapse CLI flip + `--no-collapse` dual-scope = STORY-119/B [IMPLEMENTED
+2026-06-19: `render_findings_grouped_collapsed` live; `{Grouped, Collapsed}` dispatch arm
+active; `--mitre` default is now per-bucket collapsed output])
 
 *(D-120 split note: the monolithic STORY-119 was split per D-120 into STORY-122 (A — enum→struct
 reshape, 84-site migration, byte-identical, CLI unchanged) and STORY-119 (B — grouped-collapse

--- a/docs/adr/0003-reporting-pipeline-layering.md
+++ b/docs/adr/0003-reporting-pipeline-layering.md
@@ -567,6 +567,14 @@ variant after the fact.
 > enum in `FindingsRender`. Orthogonal toggles that do not constitute a rendering-mode axis
 > (e.g., `use_color`, `show_hosts_breakdown`) MAY remain as bool fields.
 >
+> **Forward-compatibility (F7-R2):** `Grouping`, `Collapse`, and `FindingsRender` are marked
+> `#[non_exhaustive]`, allowing future variants or fields to be added without a semver-breaking
+> change. Because `FindingsRender` is `#[non_exhaustive]`, external crates MUST construct it via
+> `FindingsRender::new(grouping, collapse)` rather than a struct literal — the compiler rejects
+> struct-literal construction of `#[non_exhaustive]` structs outside the defining crate. Internal
+> (same-crate) code may still use struct-literal syntax directly. See CHANGELOG.md §[0.9.0]
+> "Forward-compatibility (F7-R2)" for the shipped rationale.
+>
 > **Orthogonality realization (STORY-122/A → STORY-119/B):** The type reshape establishing
 > the struct-of-enums is STORY-122/A. The orthogonality is made real by STORY-119/B, which
 > adds grouped-mode collapse, making all four combinations valid. The v0.9.0 three-variant sum
@@ -641,6 +649,7 @@ Grouped-collapse render path + `--mitre` default-collapse + `--no-collapse` dual
 
 ```rust
 /// Grouping axis: whether to group findings by MITRE tactic.
+#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Grouping {
     /// Group by MITRE ATT&CK tactic (`--mitre`). Renders tactic-bucket headers.
@@ -650,6 +659,7 @@ pub enum Grouping {
 }
 
 /// Collapse axis: whether to collapse repeated findings.
+#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Collapse {
     /// Collapse groups sharing `(category, verdict, confidence, summary)` into
@@ -666,10 +676,22 @@ pub enum Collapse {
 /// grouped-mode collapse implemented by STORY-119/B (D-120 split, `--mitre` default-collapse flip).
 /// No `Default` derived — deliberate omission, consistent with STORY-120.
 /// ADR-0003 Binding Rule 5 (reshaped by STORY-122/A; behavior completed by STORY-119/B).
+///
+/// Construct via `FindingsRender::new(grouping, collapse)` from external crates;
+/// `#[non_exhaustive]` blocks struct-literal construction outside the defining crate
+/// to preserve the growth path (LESSON-P2.10 / F7-R2).
+#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct FindingsRender {
     pub grouping: Grouping,
     pub collapse: Collapse,
+}
+
+impl FindingsRender {
+    /// Canonical constructor for external crates.
+    pub fn new(grouping: Grouping, collapse: Collapse) -> Self {
+        Self { grouping, collapse }
+    }
 }
 ```
 
@@ -752,10 +774,10 @@ the placeholder `render_findings_grouped` to the new function. `--no-collapse` b
 dual-scope (suppresses collapse in both flat and grouped modes).
 
 Note: the shipped code at `src/main.rs:384` does not inline the grouping expression; it calls
-the named helper `grouping_from_flag(show_mitre_grouping)` (defined at `src/main.rs:514`),
+the named helper `grouping_from_flag(show_mitre_grouping)` (defined at `src/main.rs:511`),
 which encapsulates the `if show_mitre_grouping { Grouping::Grouped } else { Grouping::Flat }`
 logic. The collapse boolean is derived upstream by `collapse_findings_from_flag(*no_collapse)`
-(called at `src/main.rs:80`, defined at `src/main.rs:505`), which is `!no_collapse`. The
+(called at `src/main.rs:80`, defined at `src/main.rs:502`), which is `!no_collapse`. The
 2-if structure and all four CLI combinations in the table below remain correct.
 
 | CLI flags (Phase B) | Resulting struct | Behavior |

--- a/docs/adr/0003-reporting-pipeline-layering.md
+++ b/docs/adr/0003-reporting-pipeline-layering.md
@@ -699,27 +699,33 @@ The three existing functions (`render_findings_grouped`, `render_findings_collap
 
 `src/main.rs` `run_analyze` TerminalReporter construction site
 (`src/reporter/terminal.rs` at the struct initialization, ~line 373 in f851995 era).
-The construction expression is identical in both phases — only the reachability of the
-`{Grouped, Collapsed}` arm changes between them:
-
-```rust
-render: FindingsRender {
-    grouping: if show_mitre_grouping { Grouping::Grouped } else { Grouping::Flat },
-    collapse: if collapse_findings { Collapse::Collapsed } else { Collapse::Expanded },
-},
-```
 
 `show_mitre_grouping` ← `*mitre` (CLI `--mitre` flag).
 `collapse_findings` ← `collapse_findings_from_flag(*no_collapse)` (unchanged: `!no_collapse`).
 
+The construction expression **changes between phases**: Phase A uses the 3-arm-if form
+(byte-identical; `--mitre`→`{Grouped, Expanded}`, `{Grouped, Collapsed}` unreachable via CLI);
+Phase B (STORY-119/B Task 4) replaces it with the orthogonal 2-if form so that
+`--mitre`→`{Grouped, Collapsed}`.
+
 **Phase A — STORY-122/A (byte-identical; `--mitre` behavior unchanged):**
 
-Under STORY-122/A the construction expression above is in place, but the `collapse_findings`
-value when `--mitre` is passed is still `true` (default-on from v0.8.0 `--no-collapse`
-semantics). The `{Grouped, Collapsed}` dispatch arm exists in `render()` but routes to
-`render_findings_grouped` (the existing grouped-expanded function) as a temporary placeholder
-— `render_findings_grouped_collapsed` does not exist yet. Observable CLI behavior is
-byte-identical to v0.9.0: `--mitre` still produces suffix-free grouped output.
+Under STORY-122/A the 3-arm-if construction is used, ensuring `--mitre` alone always
+produces `{Grouped, Expanded}` — `{Grouped, Collapsed}` is structurally unreachable via
+CLI in this phase. `render_findings_grouped_collapsed` does not exist yet; the dispatch arm
+for `{Grouped, Collapsed}` exists in `render()` but the 3-arm-if never routes there.
+Observable CLI behavior is byte-identical to v0.9.0: `--mitre` still produces suffix-free
+grouped output.
+
+```rust
+render: if show_mitre_grouping {
+    FindingsRender { grouping: Grouping::Grouped, collapse: Collapse::Expanded }
+} else if collapse_findings {
+    FindingsRender { grouping: Grouping::Flat, collapse: Collapse::Collapsed }
+} else {
+    FindingsRender { grouping: Grouping::Flat, collapse: Collapse::Expanded }
+},
+```
 
 | CLI flags (Phase A) | Resulting struct | Behavior |
 |--------------------|-----------------|----------|

--- a/docs/adr/0003-reporting-pipeline-layering.md
+++ b/docs/adr/0003-reporting-pipeline-layering.md
@@ -360,6 +360,222 @@ Wireshark model and avoids the syslog anti-pattern.
 
 ---
 
+## Render-Mode Enum (Issue #62 — v0.9.0)
+
+**Status of this subsection:** Accepted (F2 spec evolution 2026-06-17; F3 scope correction 2026-06-18)
+
+### Context
+
+v0.8.0 shipped `TerminalReporter` with four boolean fields:
+
+```rust
+pub struct TerminalReporter {
+    pub use_color: bool,
+    pub show_mitre_grouping: bool,
+    pub show_hosts_breakdown: bool,
+    pub collapse_findings: bool,
+}
+```
+
+The issue #62 trigger condition ("when a 3rd render flag is added") fired when STORY-118
+(issue #259) added `collapse_findings`. Two concrete illegal-state violations resulted:
+
+1. **Nonsensical combination** (`show_mitre_grouping = true && collapse_findings = true`)
+   is a representable struct value. The type permits it; the code silently ignores
+   `collapse_findings` when `show_mitre_grouping` is true (dispatch-order enforcement only).
+   The BC-2.11.025 invariant is encoded in comments and dispatch order, not the type system.
+
+2. **Inert-value comment** at `main.rs` `run_summary`: `collapse_findings: true` with a
+   comment explaining the value does not matter. The type cannot express "irrelevant in this
+   context."
+
+### Decision
+
+**Replace `show_mitre_grouping: bool` and `collapse_findings: bool` with
+`render: FindingsRender` — a three-variant enum that makes the mutually-exclusive
+rendering modes unrepresentable as invalid combinations.**
+
+```rust
+/// Governs which rendering path the FINDINGS section uses.
+///
+/// Replaces `show_mitre_grouping: bool` + `collapse_findings: bool`
+/// from v0.8.0. The previous struct admitted `show_mitre_grouping = true
+/// && collapse_findings = true`, which was silently handled by dispatch
+/// order but was never a valid state.
+///
+/// BC-2.11.013 (Grouped), BC-2.11.025–028 (FlatCollapsed), default (FlatExpanded).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FindingsRender {
+    /// Group findings by MITRE tactic (`--mitre` flag).
+    /// Corresponds to the previous `show_mitre_grouping = true`.
+    Grouped,
+    /// Collapse repeated findings into counted groups (default, v0.8.0+).
+    /// Corresponds to the previous `collapse_findings = true, show_mitre_grouping = false`.
+    FlatCollapsed,
+    /// One display line per raw finding (pre-v0.8.0 behavior, `--no-collapse`).
+    /// Corresponds to the previous `collapse_findings = false, show_mitre_grouping = false`.
+    FlatExpanded,
+}
+
+pub struct TerminalReporter {
+    pub use_color: bool,
+    pub show_hosts_breakdown: bool,
+    pub render: FindingsRender,
+}
+```
+
+### Rationale: Illegal-State Elimination is the Primary Driver
+
+The decisive justification is **illegal-state elimination** — making the
+`show_mitre_grouping = true && collapse_findings = true` combination unrepresentable at the
+type level. Rust's `match` exhaustiveness then enforces that every call site handles all
+three modes explicitly, replacing the fragile `if/else if` dispatch chain.
+
+The Clippy `fn_params_excessive_bools` lint (`max-fn-params-bools` default: `3`) provides
+corroborating tooling consensus (the current four bools exceed the machine-enforced
+threshold) but is not the primary driver. The illegal-state argument is decisive on its own:
+two mutually-exclusive bools encode `2^2 = 4` representable states, of which only 3 are
+valid. The enum encodes exactly 3 states and no others.
+
+This is confirmed by external research (`.factory/research/issue-62-enum-modes-design-validation.md`):
+- Rust API Guidelines C-NEWTYPE recommends deliberate types when invariants exist.
+- "Parse, don't validate" (Alexis King): enums over bool-pairs when combinations matter.
+- Clippy's machine-enforced default threshold verified directly against rust-lang.org docs.
+
+### Why Orthogonal Flags Stay as Bools
+
+`use_color` and `show_hosts_breakdown` are **orthogonal** — all four combinations are valid
+and meaningful:
+
+- `use_color` applies uniformly across every output section (headers, findings, warnings).
+  It is controlled by `--no-color` and terminal detection, independent of how findings are
+  grouped. It is not part of the findings-render axis.
+- `show_hosts_breakdown` gates the HOSTS section, which is rendered before the FINDINGS
+  section and is independent of it. It is used by the `summary` subcommand, which never
+  renders a FINDINGS section at all — making `FindingsRender` irrelevant for that path.
+
+Folding either into `FindingsRender` would be a category error: it would create combinations
+that are semantically incoherent (e.g., `FindingsRender::GroupedWithColor`) and would
+introduce new illegal states rather than eliminating them.
+
+The hybrid design — one enum for the mutually-exclusive axis, two bools for orthogonal
+toggles — is confirmed as the idiomatic Rust recommendation by research Q3: "Keep genuinely
+orthogonal booleans as separate, clearly-named fields while extracting only the
+mutually-exclusive axis into an enum."
+
+### Migration Map
+
+Every construction site translates old bool pairs to enum variants as follows:
+
+| Old fields | New field | Notes |
+|-----------|-----------|-------|
+| `show_mitre_grouping: true, collapse_findings: false` | `render: FindingsRender::Grouped` | — |
+| `show_mitre_grouping: true, collapse_findings: true` | `render: FindingsRender::Grouped` | Was previously nonsensical; grouped wins per dispatch order |
+| `show_mitre_grouping: false, collapse_findings: true` | `render: FindingsRender::FlatCollapsed` | — |
+| `show_mitre_grouping: false, collapse_findings: false` | `render: FindingsRender::FlatExpanded` | Pre-v0.8.0 behavior |
+
+The `--mitre` / `--no-collapse` → bool resolution stays at the `main()` call site
+(`src/main.rs` lines 79-80), unchanged by this refactor:
+
+```rust
+// main() call site — unchanged:
+*mitre,                              // → show_mitre_grouping: bool
+collapse_findings_from_flag(*no_collapse),  // → collapse_findings: bool
+```
+
+Inside `run_analyze`, the in-scope parameters are `show_mitre_grouping: bool` and
+`collapse_findings: bool` (function signature `src/main.rs` lines 107-108).
+The `run_analyze` signature is unchanged. The bool → enum translation at the
+`TerminalReporter` construction site (`src/main.rs` ~line 373) becomes:
+
+```rust
+// at the TerminalReporter construction site inside run_analyze;
+// show_mitre_grouping and collapse_findings are the in-scope params:
+render: if show_mitre_grouping {
+    FindingsRender::Grouped
+} else if collapse_findings {
+    FindingsRender::FlatCollapsed
+} else {
+    FindingsRender::FlatExpanded
+},
+```
+
+`collapse_findings_from_flag` is unchanged. `show_mitre_grouping` is `true` exactly
+when `*mitre` is `true`; `collapse_findings` is `true` exactly when `!no_collapse`
+is `true`. The observable behavior is identical to the migration table above.
+
+The `run_summary` inert-value site (`collapse_findings: true` with comment) becomes
+`render: FindingsRender::FlatCollapsed` — structurally expressing "if this reporter
+were ever used to render findings, it would use the v0.8.0 default."
+
+### Semver Consequence: v0.8.x → v0.9.0
+
+Removing the public fields `show_mitre_grouping` and `collapse_findings` and adding the
+public field `render: FindingsRender` is a **breaking change** to the public struct API.
+Under Cargo's SemVer model and RFC 1105, removing or replacing a reachable public field is
+classified as a major (breaking) change. For a `0.y.z` crate, the `y` component is the
+breaking component; `0.8.x → 0.9.0` is therefore the correct and required version bump.
+
+This is confirmed by research Q4 (verified directly against `doc.rust-lang.org/cargo/
+reference/semver.html` and RFC 1105). The caret specifier `"0.8.x"` in `Cargo.toml`
+resolves to `>=0.8.x, <0.9.0`, so consumers pinned in the 0.8.x line will not auto-receive
+0.9.0 — the intended containment behavior for a breaking change.
+
+The `cargo-semver-checks` `struct_field_missing` lint will fire as expected when run against
+the 0.8.x baseline. This is correct, not a defect. The recommendation from research is to
+run `cargo-semver-checks` in the release flow to make the classification machine-visible.
+
+### `Default` Derive: Deliberate Omission
+
+`Default` is **NOT derived** on `FindingsRender`. Rationale:
+
+RFC 3107 permits `#[derive(Default)]` with `#[default]` on a unit variant. The natural
+candidate would be `FlatCollapsed` (matching today's default `analyze` behavior). However:
+
+- Deriving `Default` makes the default variant part of the public stability commitment.
+  Changing it post-0.9.0 would be a silent behavioral break not caught by the compiler or
+  `cargo-semver-checks`.
+- The current codebase has exactly two construction paths (`run_analyze` and `run_summary`),
+  both of which set `render` explicitly. There is no site that would benefit from a
+  `Default::default()` call — all sites carry enough context to pick the correct variant.
+- Explicit construction is preferable here: `render: FindingsRender::FlatCollapsed` at each
+  site documents the intent, whereas `Default::default()` would obscure which variant is
+  being selected.
+
+If a future caller needs a default (e.g., a test helper builder pattern), `Default` can be
+added then as a documented, deliberate API commitment. It is backwards-compatible to add
+`Default` in a later minor release; it is not backwards-compatible to change the default
+variant after the fact.
+
+### Binding Rule
+
+> **Rule 5 (render-mode type):** `TerminalReporter`'s findings rendering mode MUST be
+> expressed as `FindingsRender`. Adding a new rendering mode requires adding a new variant
+> to `FindingsRender` and updating all exhaustive `match` arms. A bool field on
+> `TerminalReporter` that encodes a mutually-exclusive rendering mode is prohibited; such a
+> field MUST be folded into `FindingsRender` or a successor enum. Orthogonal toggles
+> (properties that do not create illegal states when combined with existing fields) MAY
+> remain as bool fields.
+
+### Alternatives Considered
+
+**Pre-split for STORY-119 (grouped-mode collapse):** Add `GroupedCollapsed` and
+`GroupedExpanded` variants now, anticipating a future feature. Rejected as YAGNI — the
+STORY-119 cycle will have its own F1/F2 and can amend the enum at that time. The current
+three-variant enum exactly models the current three modes with no phantom states.
+
+**Builder / typestate pattern:** A `TerminalReporterBuilder` with typestate enforcement.
+Warranted for multi-step construction with cross-field invariants. Rejected: `TerminalReporter`
+construction is one-shot mode selection with no sequenced protocol. A plain enum is the
+correct, minimal tool.
+
+**Remain as bools, add documentation only:** The existing dispatch-order invariant is already
+documented in comments and BCs. Rejected: the illegal state is still constructible; the
+compiler provides no enforcement; new contributors can silently violate the invariant. The
+type-system fix is strictly superior.
+
+---
+
 ## Validation
 
 This decision was validated through targeted Perplexity queries on 2026-04-08:

--- a/docs/adr/0003-reporting-pipeline-layering.md
+++ b/docs/adr/0003-reporting-pipeline-layering.md
@@ -235,7 +235,7 @@ human readability is another display-layer transform that MUST NOT mutate the ca
 
 **Aggregate identical findings at the terminal-display layer only.** The `Finding` stream
 and all machine-readable reporters (JSON, CSV) are unchanged. `TerminalReporter::render`
-applies a private collapse pass before rendering when `collapse_findings` is `true`.
+applies a private collapse pass before rendering when `render.collapse == Collapse::Collapsed`.
 
 ### Aggregation Key
 
@@ -307,6 +307,11 @@ accuracy and is widely criticized (see validation report §3.1 sources [9][16]).
 preserves every raw `Finding`; the collapse is strictly a terminal-display lens.
 
 ### Flat Mode Only for v0.8.0 (STORY-118)
+
+> **NOTE (superseded by v0.9.0):** The following describes pre-v0.9.0 behavior only.
+> STORY-119/B (PR #269) extended collapse to grouped (`--mitre`) mode; all four
+> `Grouping` × `Collapse` combinations are now valid. See the "Grouped-Mode Collapse"
+> subsection below for current behavior.
 
 Collapse applies only when `show_mitre_grouping = false` (the default flat mode).
 

--- a/docs/adr/0003-reporting-pipeline-layering.md
+++ b/docs/adr/0003-reporting-pipeline-layering.md
@@ -751,6 +751,13 @@ constructs `{Grouped, Collapsed}` instead of `{Grouped, Expanded}`. Second, it i
 the placeholder `render_findings_grouped` to the new function. `--no-collapse` becomes
 dual-scope (suppresses collapse in both flat and grouped modes).
 
+Note: the shipped code at `src/main.rs:384` does not inline the grouping expression; it calls
+the named helper `grouping_from_flag(show_mitre_grouping)` (defined at `src/main.rs:514`),
+which encapsulates the `if show_mitre_grouping { Grouping::Grouped } else { Grouping::Flat }`
+logic. The collapse boolean is derived upstream by `collapse_findings_from_flag(*no_collapse)`
+(called at `src/main.rs:80`, defined at `src/main.rs:505`), which is `!no_collapse`. The
+2-if structure and all four CLI combinations in the table below remain correct.
+
 | CLI flags (Phase B) | Resulting struct | Behavior |
 |--------------------|-----------------|----------|
 | *(default)* | `{Flat, Collapsed}` | Flat collapse — unchanged default. |

--- a/docs/adr/0003-reporting-pipeline-layering.md
+++ b/docs/adr/0003-reporting-pipeline-layering.md
@@ -736,10 +736,13 @@ render: if show_mitre_grouping {
 
 **Phase B — STORY-119/B (behavior flip; `--mitre` default changes):**
 
-STORY-119/B introduces `render_findings_grouped_collapsed` and repoints the
-`{Grouped, Collapsed}` dispatch arm from the placeholder to the new function. No change to
-the construction expression. `--no-collapse` becomes dual-scope (suppresses collapse in both
-flat and grouped modes).
+STORY-119/B makes two coordinated changes. First, it replaces the 3-arm-if construction with
+the orthogonal 2-if form (`grouping: if show_mitre_grouping { Grouped } else { Flat },
+collapse: if collapse_findings { Collapsed } else { Expanded }`), so `--mitre` alone now
+constructs `{Grouped, Collapsed}` instead of `{Grouped, Expanded}`. Second, it introduces
+`render_findings_grouped_collapsed` and repoints the `{Grouped, Collapsed}` dispatch arm from
+the placeholder `render_findings_grouped` to the new function. `--no-collapse` becomes
+dual-scope (suppresses collapse in both flat and grouped modes).
 
 | CLI flags (Phase B) | Resulting struct | Behavior |
 |--------------------|-----------------|----------|

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -151,12 +151,13 @@ pub enum Commands {
         #[arg(long)]
         mitre: bool,
 
-        /// Disable terminal finding-collapse (default: collapse ON).
-        /// By default, repeated findings sharing the same (category, verdict,
-        /// confidence, summary) are collapsed into one display group with a
-        /// `(xN)` count suffix. Pass --no-collapse to restore one-line-per-finding
-        /// output identical to pre-v0.8.0 behavior.
-        /// BC-2.11.028 precondition 2; mirrors the --mitre / --dns boolean precedent.
+        /// Disable collapsing of repeated findings in both flat and grouped
+        /// (--mitre) terminal output. By default, collapse is enabled in both
+        /// modes. When --mitre is used, collapse groups identical findings
+        /// within each MITRE tactic bucket with a `(xN)` count suffix.
+        /// Pass --no-collapse to restore one-line-per-finding output in both modes.
+        /// Has no effect on --output json or --output csv.
+        /// BC-2.11.028 precondition 2; dual-scope since STORY-119.
         #[arg(long)]
         no_collapse: bool,
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -31,20 +31,13 @@ pub enum OutputFormat {
     Csv,
 }
 
-/// CLI surface.
-///
-/// LESSON-P1.04 ("no unwired CLI flags" convention): every flag and
-/// option here must be consumed somewhere in `src/main.rs`. Declaring a
-/// flag in clap that has no behavioral effect misleads users who read
-/// `--help` and write scripts against the surface. The brownfield-ingest
-/// Phase C synthesis identified 5 unwired flags (`--verbose`,
-/// `--threats`, `--beacon`, `--filter` on `analyze`; `--services` on
-/// `summary`) which have been removed in this PR. A 6th — `--hosts` on
-/// `summary` — was previously unwired and has been *wired* to gate a
-/// per-host breakdown in the terminal reporter (LESSON-P1.03).
-///
-/// When adding a new flag here, verify the consumer path in `main.rs`
-/// in the same change. CI does not yet enforce this — see DEBT register.
+// "no unwired CLI flags" convention (LESSON-P1.04): every flag and
+// option here must be consumed somewhere in `src/main.rs`. Declaring a
+// flag in clap that has no behavioral effect misleads users who read
+// `--help` and write scripts against the surface.
+//
+// When adding a new flag here, verify the consumer path in `main.rs`
+// in the same change. CI does not yet enforce this — see DEBT register.
 #[derive(Parser, Debug)]
 #[command(
     name = "wirerust",
@@ -88,32 +81,32 @@ pub struct Cli {
 
     /// Override the overlapping-segment anomaly threshold (default: 50).
     /// Per flow direction; accepted range 0–255 (Snort's
-    /// `overlap_limit` range). See LESSON-P2.05 in the reassembly config.
+    /// `overlap_limit` range).
     #[arg(long, global = true, value_parser = clap::value_parser!(u32).range(0..=255))]
     pub overlap_threshold: Option<u32>,
 
     /// Override the small-segment anomaly threshold (default: 100).
     /// Length of a consecutive run of undersized segments, per flow
     /// direction, above which the anomaly fires. Accepted range 0–2048
-    /// (Snort's `small_segments` count range). See LESSON-P2.05.
+    /// (Snort's `small_segments` count range).
     #[arg(long, global = true, value_parser = clap::value_parser!(u32).range(0..=2048))]
     pub small_segment_threshold: Option<u32>,
 
     /// Override the small-segment payload-size cutoff in bytes
     /// (default: 16). A segment shorter than this counts as "small";
     /// 0 disables small-segment detection. Accepted range 0–2048
-    /// (Snort's `small_segments` size range). See LESSON-P2.05.
+    /// (Snort's `small_segments` size range).
     #[arg(long, global = true, value_parser = clap::value_parser!(u16).range(0..=2048))]
     pub small_segment_max_bytes: Option<u16>,
 
     /// Override the ports exempt from small-segment detection
     /// (default: 23,513 — telnet, rlogin). Comma-separated; a flow is
-    /// exempt if either endpoint port matches. See LESSON-P2.05.
+    /// exempt if either endpoint port matches.
     #[arg(long, global = true, value_delimiter = ',')]
     pub small_segment_ignore_ports: Option<Vec<u16>>,
 
     /// Override the out-of-window anomaly threshold (default: 100).
-    /// Per flow direction; see LESSON-P2.05.
+    /// Per flow direction.
     #[arg(long, global = true)]
     pub out_of_window_threshold: Option<u32>,
 
@@ -159,7 +152,7 @@ pub enum Commands {
         /// within each MITRE tactic bucket with a `(xN)` count suffix.
         /// Pass --no-collapse to restore one-line-per-finding output in both modes.
         /// Has no effect on --output json or --output csv.
-        /// BC-2.11.028 precondition 2; dual-scope since STORY-119.
+        // BC-2.11.028 precondition 2; dual-scope since STORY-119.
         #[arg(long)]
         no_collapse: bool,
 
@@ -167,51 +160,55 @@ pub enum Commands {
         #[arg(short, long)]
         all: bool,
 
-        /// Analyze Modbus TCP traffic (port 502, requires stream reassembly)
-        /// (BC-2.14.023 — default-off; included by --all)
+        /// Analyze Modbus TCP traffic (port 502, requires stream reassembly).
+        /// Default-off; included by --all.
+        // BC-2.14.023
         #[arg(long)]
         modbus: bool,
 
         /// Per-flow write-burst threshold: fires T0806+T1692.001 when more than N
-        /// write-class FCs are observed within any 1-second window (BC-2.14.024).
+        /// write-class FCs are observed within any 1-second window.
         /// Default: 20. Must be >= 1.
+        // BC-2.14.024
         #[arg(long, default_value_t = 20)]
         modbus_write_burst_threshold: u32,
 
         /// Per-flow sustained-rate threshold: fires T0806+T1692.001 when the average
-        /// write-FC rate exceeds M writes/second over a contiguous window of >= 2s
-        /// (BC-2.14.024). Default: 10. Must be >= 1.
+        /// write-FC rate exceeds M writes/second over a contiguous window of >= 2s.
+        /// Default: 10. Must be >= 1.
         #[arg(long, default_value_t = 10)]
         modbus_write_sustained_threshold: u32,
 
-        /// Analyze DNP3 TCP traffic (port 20000, requires stream reassembly)
-        /// (BC-2.15.021 — default-off; included by --all)
+        /// Analyze DNP3 TCP traffic (port 20000, requires stream reassembly).
+        /// Default-off; included by --all.
+        // BC-2.15.021
         #[arg(long)]
         dnp3: bool,
 
         /// Per-flow direct-operate burst threshold: fires T1692.001 when more than N
-        /// Control-class FCs are observed within the detection window (BC-2.15.010 /
-        /// BC-2.15.017). Default: 10.
+        /// Control-class FCs are observed within the detection window. Default: 10.
+        // BC-2.15.010 / BC-2.15.017
         #[arg(long, default_value_t = DNPXX_DIRECT_OPERATE_THRESHOLD_DEFAULT)]
         dnp3_direct_operate_threshold: u32,
 
         /// Analyze ARP traffic for spoofing, GARP anomalies, malformed frames, and
-        /// L2/L3 sender-MAC mismatch (BC-2.16.011 — default-off; included by --all).
+        /// L2/L3 sender-MAC mismatch. Default-off; included by --all.
+        // BC-2.16.011
         #[arg(long)]
         arp: bool,
 
         /// D1 spoof escalation threshold: number of MAC rebinds within
         /// ARP_FLAP_WINDOW_SECS (60 s) before a HIGH severity finding is emitted.
         /// Default: 3. Set to 1 to fire HIGH on the very first rebind.
-        /// BC-2.16.012 primary deliverable (STORY-114).
+        // BC-2.16.012 / STORY-114
         #[arg(long, default_value_t = 3)]
         arp_spoof_threshold: u32,
 
         /// D3 storm rate threshold: frames/second per source MAC above which a
         /// MEDIUM/Anomaly storm finding is emitted. Default: 50 (wirerust engineering
         /// default — not derived from any external standard). ICS/OT operators with
-        /// PLCs or RTUs should typically lower this to 5–20/s (BC-2.16.013).
-        /// BC-2.16.013 primary deliverable (STORY-115).
+        /// PLCs or RTUs should typically lower this to 5–20/s.
+        // BC-2.16.013 / STORY-115
         #[arg(long, default_value_t = 50)]
         arp_storm_rate: u32,
     },
@@ -222,11 +219,11 @@ pub enum Commands {
         #[arg(required = true)]
         targets: Vec<PathBuf>,
 
-        /// Include per-host breakdown of source/destination IPs
-        /// (LESSON-P1.03 — previously a no-op flag; now wired to
-        /// expand the terminal output's `Hosts: N` count into an
-        /// itemized list. The JSON reporter has always emitted the
-        /// full `unique_hosts` array independently of this flag.)
+        /// Include per-host breakdown of source/destination IPs.
+        /// Expands the terminal output's `Hosts: N` count into an
+        /// itemized list. The JSON reporter always emits the full
+        /// `unique_hosts` array independently of this flag.
+        // LESSON-P1.03
         #[arg(long)]
         hosts: bool,
     },

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -150,7 +150,6 @@ pub enum Commands {
         /// Group findings by MITRE ATT&CK tactic and show technique names;
         /// collapses identical findings within each tactic bucket with a
         /// `(xN)` count suffix by default (pass --no-collapse to disable).
-        /// F-PASS-A-001: doc-comment updated to match shipped collapse behavior.
         #[arg(long)]
         mitre: bool,
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -147,7 +147,10 @@ pub enum Commands {
         #[arg(long)]
         tls: bool,
 
-        /// Group findings by MITRE ATT&CK tactic and show technique names
+        /// Group findings by MITRE ATT&CK tactic and show technique names;
+        /// collapses identical findings within each tactic bucket with a
+        /// `(xN)` count suffix by default (pass --no-collapse to disable).
+        /// F-PASS-A-001: doc-comment updated to match shipped collapse behavior.
         #[arg(long)]
         mitre: bool,
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -375,23 +375,14 @@ fn run_analyze(
                 // `analyze` does not expose a per-host breakdown flag —
                 // that is `summary`-subcommand-only (LESSON-P1.03).
                 show_hosts_breakdown: false,
-                // BC-2.11.028: render mode selection (3-arm if for byte-identical STORY-122/A;
-                // orthogonal 2-if form in STORY-119/B).
-                render: if show_mitre_grouping {
-                    FindingsRender {
-                        grouping: Grouping::Grouped,
-                        collapse: Collapse::Expanded,
-                    }
-                } else if collapse_findings {
-                    FindingsRender {
-                        grouping: Grouping::Flat,
-                        collapse: Collapse::Collapsed,
-                    }
-                } else {
-                    FindingsRender {
-                        grouping: Grouping::Flat,
-                        collapse: Collapse::Expanded,
-                    }
+                // BC-2.11.028 / BC-2.11.030: orthogonal 2-if struct wiring (STORY-119/B CLI flip).
+                // --mitre alone (show_mitre_grouping=true, collapse_findings=true) → {Grouped, Collapsed}.
+                // --mitre --no-collapse (show_mitre_grouping=true, collapse_findings=false) → {Grouped, Expanded}.
+                // default (show_mitre_grouping=false, collapse_findings=true) → {Flat, Collapsed}.
+                // --no-collapse only (show_mitre_grouping=false, collapse_findings=false) → {Flat, Expanded}.
+                render: FindingsRender {
+                    grouping: if show_mitre_grouping { Grouping::Grouped } else { Grouping::Flat },
+                    collapse: if collapse_findings { Collapse::Collapsed } else { Collapse::Expanded },
                 },
             };
             reporter.render(&summary, &all_findings, &analyzer_summaries)

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,7 +37,7 @@ use wirerust::reassembly::{ReassemblyConfig, TcpReassembler};
 use wirerust::reporter::Reporter;
 use wirerust::reporter::csv::CsvReporter;
 use wirerust::reporter::json::JsonReporter;
-use wirerust::reporter::terminal::{FindingsRender, TerminalReporter};
+use wirerust::reporter::terminal::{Collapse, FindingsRender, Grouping, TerminalReporter};
 use wirerust::summary::Summary;
 
 fn main() -> Result<()> {
@@ -375,15 +375,14 @@ fn run_analyze(
                 // `analyze` does not expose a per-host breakdown flag —
                 // that is `summary`-subcommand-only (LESSON-P1.03).
                 show_hosts_breakdown: false,
-                // BC-2.11.028: three-way render mode selection.
-                // show_mitre_grouping wins over collapse_findings (same precedence as
-                // the pre-v0.9.0 if-chain dispatch order).
+                // BC-2.11.028: render mode selection (3-arm if for byte-identical STORY-122/A;
+                // orthogonal 2-if form in STORY-119/B).
                 render: if show_mitre_grouping {
-                    FindingsRender::Grouped
+                    FindingsRender { grouping: Grouping::Grouped, collapse: Collapse::Expanded }
                 } else if collapse_findings {
-                    FindingsRender::FlatCollapsed
+                    FindingsRender { grouping: Grouping::Flat, collapse: Collapse::Collapsed }
                 } else {
-                    FindingsRender::FlatExpanded
+                    FindingsRender { grouping: Grouping::Flat, collapse: Collapse::Expanded }
                 },
             };
             reporter.render(&summary, &all_findings, &analyzer_summaries)
@@ -445,8 +444,7 @@ fn run_summary(
                 use_color,
                 show_hosts_breakdown,
                 // BC-2.11.028 invariant 4: render field is inert for run_summary — no FINDINGS section.
-                // FlatCollapsed expresses the v0.8.0 default intent for any hypothetical future use.
-                render: FindingsRender::FlatCollapsed,
+                render: FindingsRender { grouping: Grouping::Flat, collapse: Collapse::Collapsed },
             };
             reporter.render(&summary, &[], &[])
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -381,8 +381,16 @@ fn run_analyze(
                 // default (show_mitre_grouping=false, collapse_findings=true) → {Flat, Collapsed}.
                 // --no-collapse only (show_mitre_grouping=false, collapse_findings=false) → {Flat, Expanded}.
                 render: FindingsRender {
-                    grouping: if show_mitre_grouping { Grouping::Grouped } else { Grouping::Flat },
-                    collapse: if collapse_findings { Collapse::Collapsed } else { Collapse::Expanded },
+                    grouping: if show_mitre_grouping {
+                        Grouping::Grouped
+                    } else {
+                        Grouping::Flat
+                    },
+                    collapse: if collapse_findings {
+                        Collapse::Collapsed
+                    } else {
+                        Collapse::Expanded
+                    },
                 },
             };
             reporter.render(&summary, &all_findings, &analyzer_summaries)

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,7 +37,7 @@ use wirerust::reassembly::{ReassemblyConfig, TcpReassembler};
 use wirerust::reporter::Reporter;
 use wirerust::reporter::csv::CsvReporter;
 use wirerust::reporter::json::JsonReporter;
-use wirerust::reporter::terminal::TerminalReporter;
+use wirerust::reporter::terminal::{FindingsRender, TerminalReporter};
 use wirerust::summary::Summary;
 
 fn main() -> Result<()> {
@@ -372,14 +372,19 @@ fn run_analyze(
         _ => {
             let reporter = TerminalReporter {
                 use_color,
-                show_mitre_grouping,
                 // `analyze` does not expose a per-host breakdown flag —
                 // that is `summary`-subcommand-only (LESSON-P1.03).
                 show_hosts_breakdown: false,
-                // BC-2.11.028: `collapse_findings = !no_collapse`.
-                // Wired from `--no-collapse` flag: true → collapse OFF; false → collapse ON.
-                // Mirrors exactly how `*mitre` becomes `show_mitre_grouping`.
-                collapse_findings,
+                // BC-2.11.028: three-way render mode selection.
+                // show_mitre_grouping wins over collapse_findings (same precedence as
+                // the pre-v0.9.0 if-chain dispatch order).
+                render: if show_mitre_grouping {
+                    FindingsRender::Grouped
+                } else if collapse_findings {
+                    FindingsRender::FlatCollapsed
+                } else {
+                    FindingsRender::FlatExpanded
+                },
             };
             reporter.render(&summary, &all_findings, &analyzer_summaries)
         }
@@ -438,13 +443,10 @@ fn run_summary(
         _ => {
             let reporter = TerminalReporter {
                 use_color,
-                show_mitre_grouping: false,
                 show_hosts_breakdown,
-                // BC-2.11.028 invariant 4: `run_summary` emits no FINDINGS section;
-                // this value is inert. Set to `true` for completeness (Rust requires
-                // all struct fields to be initialized). Collapse is analyze-scoped;
-                // run_summary emits no FINDINGS section (BC-2.11.028 invariant 4).
-                collapse_findings: true,
+                // BC-2.11.028 invariant 4: render field is inert for run_summary — no FINDINGS section.
+                // FlatCollapsed expresses the v0.8.0 default intent for any hypothetical future use.
+                render: FindingsRender::FlatCollapsed,
             };
             reporter.render(&summary, &[], &[])
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -378,11 +378,20 @@ fn run_analyze(
                 // BC-2.11.028: render mode selection (3-arm if for byte-identical STORY-122/A;
                 // orthogonal 2-if form in STORY-119/B).
                 render: if show_mitre_grouping {
-                    FindingsRender { grouping: Grouping::Grouped, collapse: Collapse::Expanded }
+                    FindingsRender {
+                        grouping: Grouping::Grouped,
+                        collapse: Collapse::Expanded,
+                    }
                 } else if collapse_findings {
-                    FindingsRender { grouping: Grouping::Flat, collapse: Collapse::Collapsed }
+                    FindingsRender {
+                        grouping: Grouping::Flat,
+                        collapse: Collapse::Collapsed,
+                    }
                 } else {
-                    FindingsRender { grouping: Grouping::Flat, collapse: Collapse::Expanded }
+                    FindingsRender {
+                        grouping: Grouping::Flat,
+                        collapse: Collapse::Expanded,
+                    }
                 },
             };
             reporter.render(&summary, &all_findings, &analyzer_summaries)
@@ -444,7 +453,10 @@ fn run_summary(
                 use_color,
                 show_hosts_breakdown,
                 // BC-2.11.028 invariant 4: render field is inert for run_summary — no FINDINGS section.
-                render: FindingsRender { grouping: Grouping::Flat, collapse: Collapse::Collapsed },
+                render: FindingsRender {
+                    grouping: Grouping::Flat,
+                    collapse: Collapse::Collapsed,
+                },
             };
             reporter.render(&summary, &[], &[])
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -381,11 +381,7 @@ fn run_analyze(
                 // default (show_mitre_grouping=false, collapse_findings=true) → {Flat, Collapsed}.
                 // --no-collapse only (show_mitre_grouping=false, collapse_findings=false) → {Flat, Expanded}.
                 render: FindingsRender {
-                    grouping: if show_mitre_grouping {
-                        Grouping::Grouped
-                    } else {
-                        Grouping::Flat
-                    },
+                    grouping: grouping_from_flag(show_mitre_grouping),
                     collapse: if collapse_findings {
                         Collapse::Collapsed
                     } else {
@@ -510,6 +506,19 @@ fn collapse_findings_from_flag(no_collapse: bool) -> bool {
     !no_collapse
 }
 
+/// Maps the `--mitre` flag to the `FindingsRender` `grouping` field
+/// (BC-2.11.030 PC-2 through PC-5).
+///
+/// When `--mitre` is present (`show_mitre_grouping = true`), grouping is `Grouped`.
+/// When `--mitre` is absent (`show_mitre_grouping = false`), grouping is `Flat`.
+fn grouping_from_flag(show_mitre_grouping: bool) -> Grouping {
+    if show_mitre_grouping {
+        Grouping::Grouped
+    } else {
+        Grouping::Flat
+    }
+}
+
 fn resolve_targets(target: &Path) -> Result<Vec<std::path::PathBuf>> {
     if target.is_file() {
         return Ok(vec![target.to_path_buf()]);
@@ -534,7 +543,8 @@ fn resolve_targets(target: &Path) -> Result<Vec<std::path::PathBuf>> {
 
 #[cfg(test)]
 mod tests {
-    use super::collapse_findings_from_flag;
+    use super::{collapse_findings_from_flag, grouping_from_flag};
+    use wirerust::reporter::terminal::Grouping;
 
     /// BC-2.11.028: flag absent (false) → collapse ON (true);
     /// --no-collapse present (true) → collapse OFF (false).
@@ -550,6 +560,27 @@ mod tests {
         assert!(
             !collapse_findings_from_flag(true),
             "--no-collapse (no_collapse=true) must yield collapse_findings=false"
+        );
+    }
+
+    /// BC-2.11.030 PC-2/PC-4: `--mitre` flag polarity guard.
+    ///
+    /// Guards against swapping `Grouped`/`Flat` in `grouping_from_flag` —
+    /// a regression that would ship silently if the construction-site mapping
+    /// were only tested via tautological literal copies.
+    #[test]
+    fn test_bc_2_11_030_grouping_flag_polarity() {
+        // --mitre present (show_mitre_grouping=true) → Grouped.
+        assert_eq!(
+            grouping_from_flag(true),
+            Grouping::Grouped,
+            "--mitre present (show_mitre_grouping=true) must yield Grouping::Grouped"
+        );
+        // --mitre absent (show_mitre_grouping=false) → Flat.
+        assert_eq!(
+            grouping_from_flag(false),
+            Grouping::Flat,
+            "--mitre absent (show_mitre_grouping=false) must yield Grouping::Flat"
         );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -380,14 +380,14 @@ fn run_analyze(
                 // --mitre --no-collapse (show_mitre_grouping=true, collapse_findings=false) → {Grouped, Expanded}.
                 // default (show_mitre_grouping=false, collapse_findings=true) → {Flat, Collapsed}.
                 // --no-collapse only (show_mitre_grouping=false, collapse_findings=false) → {Flat, Expanded}.
-                render: FindingsRender {
-                    grouping: grouping_from_flag(show_mitre_grouping),
-                    collapse: if collapse_findings {
+                render: FindingsRender::new(
+                    grouping_from_flag(show_mitre_grouping),
+                    if collapse_findings {
                         Collapse::Collapsed
                     } else {
                         Collapse::Expanded
                     },
-                },
+                ),
             };
             reporter.render(&summary, &all_findings, &analyzer_summaries)
         }
@@ -448,10 +448,7 @@ fn run_summary(
                 use_color,
                 show_hosts_breakdown,
                 // BC-2.11.028 invariant 4: render field is inert for run_summary — no FINDINGS section.
-                render: FindingsRender {
-                    grouping: Grouping::Flat,
-                    collapse: Collapse::Collapsed,
-                },
+                render: FindingsRender::new(Grouping::Flat, Collapse::Collapsed),
             };
             reporter.render(&summary, &[], &[])
         }

--- a/src/reporter/terminal.rs
+++ b/src/reporter/terminal.rs
@@ -3,9 +3,11 @@
 //! Renders the capture summary, per-host breakdown (gated by
 //! `show_hosts_breakdown` per LESSON-P1.03), protocols, services,
 //! findings, and per-analyzer detail tables for TTY output. The
-//! `render: FindingsRender` field selects among three mutually-exclusive
-//! FINDINGS rendering modes: `Grouped` (MITRE tactic grouping, `--mitre`),
-//! `FlatCollapsed` (default v0.8.0+), and `FlatExpanded` (`--no-collapse`).
+//! `render: FindingsRender` field is a struct-of-two-orthogonal-enums
+//! (`Grouping` × `Collapse`) that selects the FINDINGS rendering path:
+//! `Grouping::Grouped` (MITRE tactic grouping, `--mitre`) or
+//! `Grouping::Flat` (flat list); `Collapse::Collapsed` (default) or
+//! `Collapse::Expanded` (`--no-collapse`). All four combinations are valid.
 //! MITRE-tactic grouping reorganizes the FINDINGS section by MITRE ATT&CK
 //! tactic and expands each finding's MITRE line with the technique name from
 //! [`crate::mitre`].
@@ -122,9 +124,10 @@ pub struct TerminalReporter {
     /// always-present `Hosts: N` count line in the header is shown
     /// regardless; this gate only controls the expanded itemized list.
     pub show_hosts_breakdown: bool,
-    /// Render mode for the FINDINGS section. Controls mutual exclusion between
-    /// MITRE grouping, flat-collapsed, and flat-expanded rendering.
-    /// ADR-0003 Binding Rule 5; BC-2.11.025 / BC-2.11.026 / BC-2.11.027 / BC-2.11.028.
+    /// Render mode for the FINDINGS section. A struct-of-two-orthogonal-enums:
+    /// `grouping` (Grouped vs Flat) and `collapse` (Collapsed vs Expanded).
+    /// All four combinations are valid (no combination is illegal).
+    /// ADR-0003 Binding Rule 5; BC-2.11.013 / BC-2.11.026 / BC-2.11.027 / BC-2.11.028.
     pub render: FindingsRender,
 }
 
@@ -211,7 +214,6 @@ impl Reporter for TerminalReporter {
                     // introduces render_findings_grouped_collapsed and repoints this arm.
                     // {Grouped, Collapsed} is unreachable via CLI in this story (--mitre alone maps
                     // to {Grouped, Expanded} until STORY-119/B flips the CLI default).
-                    // STORY-122 GREEN: real migration replaces this stub.
                     self.render_findings_grouped(&mut out, findings);
                 }
                 (Grouping::Flat, Collapse::Collapsed) => {
@@ -427,8 +429,9 @@ impl TerminalReporter {
     /// header is `## Tactic Name`; sections appear in
     /// [`all_tactics_in_report_order`] order with an Uncategorized bucket
     /// last that holds findings with no technique or an unknown ID.
-    /// Within each bucket, findings sort by verdict-desc, then
-    /// confidence-desc, then original emission order (stable).
+    /// Within each bucket, findings sort ascending by verdict-rank
+    /// (Likely=0, Possible=1, Inconclusive=2, Unlikely=3), then ascending by
+    /// confidence-rank (High=0, Medium=1, Low=2), then original emission order (stable).
     /// BC-2.11.013: tactic bucketing uses `mitre_techniques[0]` (first element).
     fn render_findings_grouped(&self, out: &mut String, findings: &[Finding]) {
         // Bucket by tactic. Attach original index for stable tertiary sort.

--- a/src/reporter/terminal.rs
+++ b/src/reporter/terminal.rs
@@ -91,23 +91,26 @@ struct CollapseKey {
     summary: String,
 }
 
-/// Render mode for the FINDINGS section of a terminal report.
-///
-/// Encodes the three mutually-exclusive rendering modes as a single enum,
-/// eliminating the impossible state `show_mitre_grouping = true &&
-/// collapse_findings = true` that existed in v0.8.0.
-/// ADR-0003 Binding Rule 5 — Render-Mode Enum (Issue #62 — v0.9.0).
+/// Grouping axis for the FINDINGS section.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum FindingsRender {
-    /// Group findings by MITRE tactic (`--mitre` flag).
-    /// Corresponds to the previous `show_mitre_grouping = true`.
+pub enum Grouping {
     Grouped,
-    /// Collapse repeated findings into counted groups (default, v0.8.0+).
-    /// Corresponds to the previous `collapse_findings = true, show_mitre_grouping = false`.
-    FlatCollapsed,
-    /// One display line per raw finding (pre-v0.8.0 behavior, `--no-collapse`).
-    /// Corresponds to the previous `collapse_findings = false, show_mitre_grouping = false`.
-    FlatExpanded,
+    Flat,
+}
+
+/// Collapse axis for the FINDINGS section.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Collapse {
+    Collapsed,
+    Expanded,
+}
+
+/// Rendering mode for the FINDINGS section of [`TerminalReporter`].
+/// No [`Default`] is derived — deliberate, consistent with STORY-120.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FindingsRender {
+    pub grouping: Grouping,
+    pub collapse: Collapse,
 }
 
 pub struct TerminalReporter {
@@ -199,24 +202,22 @@ impl Reporter for TerminalReporter {
         // Findings
         if !findings.is_empty() {
             out.push_str(&self.section("FINDINGS"));
-            match self.render {
-                FindingsRender::Grouped => {
-                    // Grouped (--mitre) path: structurally suffix-free per BC-2.11.025
-                    // invariant 5. Collapse does not apply — impossible state eliminated
-                    // by type. render_finding_prefix stays unchanged.
+            match (self.render.grouping, self.render.collapse) {
+                (Grouping::Grouped, Collapse::Expanded) => {
                     self.render_findings_grouped(&mut out, findings);
                 }
-                FindingsRender::FlatCollapsed => {
-                    // Flat + collapse path (STORY-118 / BC-2.11.025 / BC-2.11.026 /
-                    // BC-2.11.027): groups findings by CollapseKey in first-occurrence
-                    // order, renders each group with optional (xN) suffix and up to K=3
-                    // sampled evidence lines.
+                (Grouping::Grouped, Collapse::Collapsed) => {
+                    // TEMPORARY (STORY-122/A): routes to render_findings_grouped until STORY-119/B
+                    // introduces render_findings_grouped_collapsed and repoints this arm.
+                    // {Grouped, Collapsed} is unreachable via CLI in this story (--mitre alone maps
+                    // to {Grouped, Expanded} until STORY-119/B flips the CLI default).
+                    // STORY-122 GREEN: real migration replaces this stub.
+                    self.render_findings_grouped(&mut out, findings);
+                }
+                (Grouping::Flat, Collapse::Collapsed) => {
                     self.render_findings_collapsed(&mut out, findings);
                 }
-                FindingsRender::FlatExpanded => {
-                    // Per ADR 0003: the Finding struct stores raw bytes; the
-                    // terminal reporter is responsible for escaping untrusted
-                    // content (summary + evidence) before writing to a TTY.
+                (Grouping::Flat, Collapse::Expanded) => {
                     for f in findings {
                         self.render_finding_flat(&mut out, f);
                     }

--- a/src/reporter/terminal.rs
+++ b/src/reporter/terminal.rs
@@ -210,11 +210,7 @@ impl Reporter for TerminalReporter {
                     self.render_findings_grouped(&mut out, findings);
                 }
                 (Grouping::Grouped, Collapse::Collapsed) => {
-                    // TEMPORARY (STORY-122/A): routes to render_findings_grouped until STORY-119/B
-                    // introduces render_findings_grouped_collapsed and repoints this arm.
-                    // {Grouped, Collapsed} is unreachable via CLI in this story (--mitre alone maps
-                    // to {Grouped, Expanded} until STORY-119/B flips the CLI default).
-                    self.render_findings_grouped(&mut out, findings);
+                    self.render_findings_grouped_collapsed(&mut out, findings);
                 }
                 (Grouping::Flat, Collapse::Collapsed) => {
                     self.render_findings_collapsed(&mut out, findings);
@@ -329,23 +325,22 @@ impl TerminalReporter {
         }
     }
 
-    /// Groups findings by `CollapseKey` in first-occurrence order using a
-    /// `Vec<(CollapseKey, Vec<&Finding>)>` accumulator with linear-scan
-    /// `PartialEq` matching (no HashMap / IndexMap — `ThreatCategory`, `Verdict`,
-    /// and `Confidence` do not derive `Hash` in v0.8.0).
+    /// Shared collapse-logic helper: groups a slice of finding references by
+    /// `CollapseKey` in first-occurrence order.
     ///
-    /// Each finding's four-tuple `(category, verdict, confidence, summary)` is
-    /// compared by raw bytes (the summary is not escaped before key construction;
-    /// escape is a render-time operation). Groups appear in first-occurrence order —
-    /// the position of the first member that created the group.
+    /// This is the single source of collapse logic (ADR-0003 "Collapse-API Shape";
+    /// F2 design-note §5.2.1). `collapse_findings_pass` (the flat-mode wrapper)
+    /// delegates to this function. `render_findings_grouped_collapsed` calls this
+    /// directly per bucket.
     ///
-    /// BC-2.11.025 invariant 7 / postcondition 9: Vec accumulator is canonical.
-    fn collapse_findings_pass<'a>(
+    /// BC-2.11.025 invariant 7 / postcondition 9: Vec accumulator is canonical —
+    /// linear-scan `PartialEq`, no `HashMap`, no `IndexMap`.
+    fn collapse_findings_pass_refs<'a>(
         &self,
-        findings: &'a [Finding],
+        refs: &[&'a Finding],
     ) -> Vec<(CollapseKey, Vec<&'a Finding>)> {
         let mut groups: Vec<(CollapseKey, Vec<&'a Finding>)> = Vec::new();
-        for f in findings {
+        for f in refs {
             let key = CollapseKey {
                 category: f.category,
                 verdict: f.verdict,
@@ -360,6 +355,20 @@ impl TerminalReporter {
             }
         }
         groups
+    }
+
+    /// Flat-mode collapse adapter. Collects the `&[Finding]` parameter into
+    /// `Vec<&Finding>` and delegates to `collapse_findings_pass_refs`.
+    ///
+    /// Uses the `findings` PARAMETER — `TerminalReporter` has no `findings` field.
+    ///
+    /// BC-2.11.025 / ADR-0003 "Collapse-API Shape".
+    fn collapse_findings_pass<'a>(
+        &self,
+        findings: &'a [Finding],
+    ) -> Vec<(CollapseKey, Vec<&'a Finding>)> {
+        let refs: Vec<&Finding> = findings.iter().collect();
+        self.collapse_findings_pass_refs(&refs)
     }
 
     /// Renders the FINDINGS section in collapsed flat mode.
@@ -484,6 +493,31 @@ impl TerminalReporter {
                 self.render_finding_grouped(out, f);
             }
         }
+    }
+
+    /// Renders the FINDINGS section grouped by MITRE tactic WITH per-bucket collapse.
+    ///
+    /// Per-tactic-bucket grouping identical to `render_findings_grouped` (BC-2.11.013),
+    /// then per-bucket sort (BC-2.11.033 PC-5 / BC-2.11.014), then per-bucket
+    /// `collapse_findings_pass_refs` (BC-2.11.033 Invariant 3), then collapsed
+    /// group rendering with `(xN)` suffix (BC-2.11.031), K=3 evidence sampling
+    /// (BC-2.11.032), and MITRE em-dash line from `members[0]` (BC-2.11.034).
+    ///
+    /// Singletons (N=1) render via `render_finding_grouped` (byte-identical to
+    /// `{Grouped, Expanded}` for that finding).
+    ///
+    /// STORY-119/B GREEN: implement per-bucket collapse rendering here.
+    fn render_findings_grouped_collapsed(&self, _out: &mut String, _findings: &[Finding]) {
+        // BC-5.38.001: non-trivial body — todo!() until GREEN phase.
+        // "If I include this real implementation, will the test for this function pass
+        // trivially without any implementer work?" Yes — therefore todo!() here.
+        // Self-check per BC-5.38.005 invariant 1.
+        todo!(
+            "STORY-119/B GREEN: render_findings_grouped_collapsed — \
+             per-bucket sort + collapse_findings_pass_refs + (xN) headers + \
+             K=3 evidence sampling + MITRE em-dash from members[0] \
+             (BC-2.11.031/032/033/034)"
+        )
     }
 }
 

--- a/src/reporter/terminal.rs
+++ b/src/reporter/terminal.rs
@@ -118,6 +118,7 @@ struct CollapseKey {
 }
 
 /// Grouping axis for the FINDINGS section.
+#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Grouping {
     Grouped,
@@ -125,6 +126,7 @@ pub enum Grouping {
 }
 
 /// Collapse axis for the FINDINGS section.
+#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Collapse {
     Collapsed,
@@ -133,10 +135,25 @@ pub enum Collapse {
 
 /// Rendering mode for the FINDINGS section of [`TerminalReporter`].
 /// No [`Default`] is derived — deliberate, consistent with STORY-120.
+///
+/// Construct with [`FindingsRender::new`] from external crates; struct-literal
+/// construction is blocked by `#[non_exhaustive]` to preserve the growth path
+/// (ADR-0003 / LESSON-P2.10).
+#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct FindingsRender {
     pub grouping: Grouping,
     pub collapse: Collapse,
+}
+
+impl FindingsRender {
+    /// Construct a [`FindingsRender`] with the given grouping and collapse axes.
+    ///
+    /// This is the canonical construction path for code outside the `wirerust`
+    /// crate. Internal code (same crate) may use struct-literal syntax directly.
+    pub fn new(grouping: Grouping, collapse: Collapse) -> Self {
+        Self { grouping, collapse }
+    }
 }
 
 pub struct TerminalReporter {

--- a/src/reporter/terminal.rs
+++ b/src/reporter/terminal.rs
@@ -65,28 +65,28 @@ fn escape_for_terminal(s: &str) -> String {
     out
 }
 
-/// Escape control bytes for safe terminal display in the grouped-collapse rendering path.
+/// Ascending sort rank for [`Verdict`]: lower value → appears first in a sorted bucket.
 ///
-/// Identical to [`escape_for_terminal`] for C1 (U+0080–U+009F) and backslash,
-/// but uses two-digit hex (`\xNN`) instead of unicode (`\u{N}`) for C0 (U+0000–U+001F)
-/// and DEL (U+007F). This matches BC-2.11.031 Precondition 5 / VP-012 as exercised
-/// by the grouped-collapse acceptance tests (AC-023).
-fn escape_for_terminal_grouped(s: &str) -> String {
-    let mut out = String::with_capacity(s.len());
-    for c in s.chars() {
-        if c.is_ascii_control() {
-            // C0 (0x00–0x1F) and DEL (0x7F): two-digit lowercase hex escape.
-            out.push_str(&format!("\\x{:02x}", c as u32));
-        } else if ('\u{80}'..='\u{9f}').contains(&c) || c == '\\' {
-            // C1 range and backslash: delegate to escape_default (same as flat path).
-            for e in c.escape_default() {
-                out.push(e);
-            }
-        } else {
-            out.push(c);
-        }
+/// BC-2.11.014 / BC-2.11.033 PC-5: both `render_findings_grouped` and
+/// `render_findings_grouped_collapsed` share this single source (BC-014 single-source rule).
+fn verdict_rank(v: Verdict) -> u8 {
+    match v {
+        Verdict::Likely => 0,
+        Verdict::Possible => 1,
+        Verdict::Inconclusive => 2,
+        Verdict::Unlikely => 3,
     }
-    out
+}
+
+/// Ascending sort rank for [`Confidence`]: lower value → appears first in a sorted bucket.
+///
+/// BC-2.11.014 / BC-2.11.033 PC-6: both grouped render functions share this single source.
+fn confidence_rank(c: Confidence) -> u8 {
+    match c {
+        Confidence::High => 0,
+        Confidence::Medium => 1,
+        Confidence::Low => 2,
+    }
 }
 
 /// Maximum number of representative evidence lines rendered per collapsed group.
@@ -481,22 +481,7 @@ impl TerminalReporter {
             buckets.entry(tactic).or_default().push((i, f));
         }
 
-        fn verdict_rank(v: Verdict) -> u8 {
-            match v {
-                Verdict::Likely => 0,
-                Verdict::Possible => 1,
-                Verdict::Inconclusive => 2,
-                Verdict::Unlikely => 3,
-            }
-        }
-        fn confidence_rank(c: Confidence) -> u8 {
-            match c {
-                Confidence::High => 0,
-                Confidence::Medium => 1,
-                Confidence::Low => 2,
-            }
-        }
-
+        // verdict_rank / confidence_rank: module-level single-source (BC-014).
         for (_, items) in buckets.iter_mut() {
             items.sort_by_key(|(idx, f)| {
                 (verdict_rank(f.verdict), confidence_rank(f.confidence), *idx)
@@ -543,24 +528,8 @@ impl TerminalReporter {
             buckets.entry(tactic).or_default().push((i, f));
         }
 
-        // Step 2: sort helper ranks (same as render_findings_grouped).
-        fn verdict_rank(v: Verdict) -> u8 {
-            match v {
-                Verdict::Likely => 0,
-                Verdict::Possible => 1,
-                Verdict::Inconclusive => 2,
-                Verdict::Unlikely => 3,
-            }
-        }
-        fn confidence_rank(c: Confidence) -> u8 {
-            match c {
-                Confidence::High => 0,
-                Confidence::Medium => 1,
-                Confidence::Low => 2,
-            }
-        }
-
         // Sort each bucket ascending by (verdict_rank, confidence_rank, emission-index).
+        // verdict_rank / confidence_rank: module-level single-source (BC-014).
         for (_, items) in buckets.iter_mut() {
             items.sort_by_key(|(idx, f)| {
                 (verdict_rank(f.verdict), confidence_rank(f.confidence), *idx)
@@ -569,23 +538,13 @@ impl TerminalReporter {
 
         // Step 3: render buckets in all_tactics_in_report_order(), Uncategorized last.
         let render_collapsed_bucket = |out: &mut String, items: &[(usize, &Finding)]| {
-            // Build a slice of &Finding refs in sorted order for collapse pass.
-            // Per-bucket collapse: group by summary only (BC-2.11.033 PC-5/6 — the
-            // sort-then-collapse semantics require verdict/confidence to determine the
-            // representative, not group membership; findings with the same summary but
-            // different severities form one group whose representative is the
-            // highest-severity post-sort members[0]).
-            let refs: Vec<&Finding> = items.iter().map(|(_, f)| *f).collect();
-            // Inline summary-keyed collapse (linear-scan, insertion-order preserved).
-            let mut groups: Vec<Vec<&Finding>> = Vec::new();
-            for f in &refs {
-                if let Some(pos) = groups.iter().position(|g| g[0].summary == f.summary) {
-                    groups[pos].push(f);
-                } else {
-                    groups.push(vec![f]);
-                }
-            }
-            for members in &groups {
+            // Build sorted &Finding refs and delegate to the shared collapse helper.
+            // BC-2.11.033 Inv3 / BC-2.11.025 Inv1 / BC-2.11.031 PC-3: use the shared
+            // four-tuple (category, verdict, confidence, summary) collapse key via
+            // collapse_findings_pass_refs — no inline summary-only keying.
+            let bucket_refs: Vec<&Finding> = items.iter().map(|(_, f)| *f).collect();
+            let groups = self.collapse_findings_pass_refs(&bucket_refs);
+            for (_key, members) in &groups {
                 let n = members.len();
                 if n == 1 {
                     // Singleton: byte-identical to {Grouped, Expanded}.
@@ -594,12 +553,13 @@ impl TerminalReporter {
                     // N >= 2: build header with (xN) suffix, colorize the full
                     // string (suffix is inside the ANSI color span — BC-2.11.031 PC-3).
                     let rep = members[0];
-                    let escaped_summary = escape_for_terminal_grouped(&rep.summary);
-                    // Debug format (title-case) for verdict and confidence:
-                    // "Likely" / "High" — consistent with BC-2.11.033 PC-5/6 test
-                    // expectation for grouped-collapse group headers.
+                    // escape_for_terminal (char::escape_default, U+NN format) —
+                    // BC-2.11.031 PC-5 / BC-2.11.032 PC-6 / VP-012 / ADR-0003.
+                    let escaped_summary = escape_for_terminal(&rep.summary);
+                    // Display format (`{}`) for verdict and confidence → UPPERCASE output
+                    // (`LIKELY`, `HIGH`) per BC-2.11.031 PC-1 / canonical vector.
                     let header_text = format!(
-                        "[{}] {:?} ({:?}) - {} (x{})",
+                        "[{}] {} ({}) - {} (x{})",
                         rep.category, rep.verdict, rep.confidence, escaped_summary, n
                     );
                     let colored = if self.use_color {
@@ -619,10 +579,11 @@ impl TerminalReporter {
 
                     // Evidence sampling: first min(N, K) members positionally.
                     // Window does NOT slide past empty-evidence members (BC-2.11.032 Inv2).
+                    // escape_for_terminal (char::escape_default) — BC-2.11.032 PC-6 / VP-012.
                     let window = members.len().min(COLLAPSE_EVIDENCE_SAMPLES);
                     for member in &members[..window] {
                         if let Some(ev) = member.evidence.first() {
-                            let escaped_ev = escape_for_terminal_grouped(ev);
+                            let escaped_ev = escape_for_terminal(ev);
                             out.push_str(&format!("    > {escaped_ev}\n"));
                         }
                     }

--- a/src/reporter/terminal.rs
+++ b/src/reporter/terminal.rs
@@ -65,6 +65,30 @@ fn escape_for_terminal(s: &str) -> String {
     out
 }
 
+/// Escape control bytes for safe terminal display in the grouped-collapse rendering path.
+///
+/// Identical to [`escape_for_terminal`] for C1 (U+0080–U+009F) and backslash,
+/// but uses two-digit hex (`\xNN`) instead of unicode (`\u{N}`) for C0 (U+0000–U+001F)
+/// and DEL (U+007F). This matches BC-2.11.031 Precondition 5 / VP-012 as exercised
+/// by the grouped-collapse acceptance tests (AC-023).
+fn escape_for_terminal_grouped(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        if c.is_ascii_control() {
+            // C0 (0x00–0x1F) and DEL (0x7F): two-digit lowercase hex escape.
+            out.push_str(&format!("\\x{:02x}", c as u32));
+        } else if ('\u{80}'..='\u{9f}').contains(&c) || c == '\\' {
+            // C1 range and backslash: delegate to escape_default (same as flat path).
+            for e in c.escape_default() {
+                out.push(e);
+            }
+        } else {
+            out.push(c);
+        }
+    }
+    out
+}
+
 /// Maximum number of representative evidence lines rendered per collapsed group.
 ///
 /// BC-2.11.027 invariant 1: K = 3 is a hardcoded named constant, not a magic number.
@@ -498,26 +522,139 @@ impl TerminalReporter {
     /// Renders the FINDINGS section grouped by MITRE tactic WITH per-bucket collapse.
     ///
     /// Per-tactic-bucket grouping identical to `render_findings_grouped` (BC-2.11.013),
-    /// then per-bucket sort (BC-2.11.033 PC-5 / BC-2.11.014), then per-bucket
+    /// then per-bucket sort ascending by (verdict_rank, confidence_rank, emission-index)
+    /// (BC-2.11.033 PC-5 / BC-2.11.014), then per-bucket
     /// `collapse_findings_pass_refs` (BC-2.11.033 Invariant 3), then collapsed
     /// group rendering with `(xN)` suffix (BC-2.11.031), K=3 evidence sampling
     /// (BC-2.11.032), and MITRE em-dash line from `members[0]` (BC-2.11.034).
     ///
     /// Singletons (N=1) render via `render_finding_grouped` (byte-identical to
     /// `{Grouped, Expanded}` for that finding).
-    ///
-    /// STORY-119/B GREEN: implement per-bucket collapse rendering here.
-    fn render_findings_grouped_collapsed(&self, _out: &mut String, _findings: &[Finding]) {
-        // BC-5.38.001: non-trivial body — todo!() until GREEN phase.
-        // "If I include this real implementation, will the test for this function pass
-        // trivially without any implementer work?" Yes — therefore todo!() here.
-        // Self-check per BC-5.38.005 invariant 1.
-        todo!(
-            "STORY-119/B GREEN: render_findings_grouped_collapsed — \
-             per-bucket sort + collapse_findings_pass_refs + (xN) headers + \
-             K=3 evidence sampling + MITRE em-dash from members[0] \
-             (BC-2.11.031/032/033/034)"
-        )
+    fn render_findings_grouped_collapsed(&self, out: &mut String, findings: &[Finding]) {
+        // Step 1: bucket by tactic (same as render_findings_grouped, BC-2.11.013).
+        let mut buckets: std::collections::HashMap<Option<MitreTactic>, Vec<(usize, &Finding)>> =
+            std::collections::HashMap::new();
+        for (i, f) in findings.iter().enumerate() {
+            let tactic = f
+                .mitre_techniques
+                .first()
+                .map(|id| id.as_str())
+                .and_then(technique_tactic);
+            buckets.entry(tactic).or_default().push((i, f));
+        }
+
+        // Step 2: sort helper ranks (same as render_findings_grouped).
+        fn verdict_rank(v: Verdict) -> u8 {
+            match v {
+                Verdict::Likely => 0,
+                Verdict::Possible => 1,
+                Verdict::Inconclusive => 2,
+                Verdict::Unlikely => 3,
+            }
+        }
+        fn confidence_rank(c: Confidence) -> u8 {
+            match c {
+                Confidence::High => 0,
+                Confidence::Medium => 1,
+                Confidence::Low => 2,
+            }
+        }
+
+        // Sort each bucket ascending by (verdict_rank, confidence_rank, emission-index).
+        for (_, items) in buckets.iter_mut() {
+            items.sort_by_key(|(idx, f)| {
+                (verdict_rank(f.verdict), confidence_rank(f.confidence), *idx)
+            });
+        }
+
+        // Step 3: render buckets in all_tactics_in_report_order(), Uncategorized last.
+        let render_collapsed_bucket = |out: &mut String, items: &[(usize, &Finding)]| {
+            // Build a slice of &Finding refs in sorted order for collapse pass.
+            // Per-bucket collapse: group by summary only (BC-2.11.033 PC-5/6 — the
+            // sort-then-collapse semantics require verdict/confidence to determine the
+            // representative, not group membership; findings with the same summary but
+            // different severities form one group whose representative is the
+            // highest-severity post-sort members[0]).
+            let refs: Vec<&Finding> = items.iter().map(|(_, f)| *f).collect();
+            // Inline summary-keyed collapse (linear-scan, insertion-order preserved).
+            let mut groups: Vec<Vec<&Finding>> = Vec::new();
+            for f in &refs {
+                if let Some(pos) = groups.iter().position(|g| g[0].summary == f.summary) {
+                    groups[pos].push(f);
+                } else {
+                    groups.push(vec![f]);
+                }
+            }
+            for members in &groups {
+                let n = members.len();
+                if n == 1 {
+                    // Singleton: byte-identical to {Grouped, Expanded}.
+                    self.render_finding_grouped(out, members[0]);
+                } else {
+                    // N >= 2: build header with (xN) suffix, colorize the full
+                    // string (suffix is inside the ANSI color span — BC-2.11.031 PC-3).
+                    let rep = members[0];
+                    let escaped_summary = escape_for_terminal_grouped(&rep.summary);
+                    // Debug format (title-case) for verdict and confidence:
+                    // "Likely" / "High" — consistent with BC-2.11.033 PC-5/6 test
+                    // expectation for grouped-collapse group headers.
+                    let header_text = format!(
+                        "[{}] {:?} ({:?}) - {} (x{})",
+                        rep.category, rep.verdict, rep.confidence, escaped_summary, n
+                    );
+                    let colored = if self.use_color {
+                        match rep.verdict {
+                            Verdict::Likely => match rep.confidence {
+                                Confidence::High => header_text.red().bold().to_string(),
+                                _ => header_text.yellow().to_string(),
+                            },
+                            Verdict::Possible => header_text.yellow().to_string(),
+                            Verdict::Inconclusive => header_text.cyan().to_string(),
+                            Verdict::Unlikely => header_text.dimmed().to_string(),
+                        }
+                    } else {
+                        header_text
+                    };
+                    out.push_str(&format!("  {colored}\n"));
+
+                    // Evidence sampling: first min(N, K) members positionally.
+                    // Window does NOT slide past empty-evidence members (BC-2.11.032 Inv2).
+                    let window = members.len().min(COLLAPSE_EVIDENCE_SAMPLES);
+                    for member in &members[..window] {
+                        if let Some(ev) = member.evidence.first() {
+                            let escaped_ev = escape_for_terminal_grouped(ev);
+                            out.push_str(&format!("    > {escaped_ev}\n"));
+                        }
+                    }
+
+                    // MITRE line from members[0] with em-dash name expansion (BC-2.11.034).
+                    if !rep.mitre_techniques.is_empty() {
+                        let ids = rep.mitre_techniques.join(", ");
+                        match rep
+                            .mitre_techniques
+                            .first()
+                            .and_then(|id| technique_name(id.as_str()))
+                        {
+                            Some(name) => {
+                                out.push_str(&format!("    MITRE: {ids} \u{2014} {name}\n"))
+                            }
+                            None => out.push_str(&format!("    MITRE: {ids} (unknown)\n")),
+                        }
+                    }
+                }
+            }
+        };
+
+        for tactic in all_tactics_in_report_order() {
+            if let Some(items) = buckets.get(&Some(*tactic)) {
+                out.push_str(&format!("  ## {tactic}\n"));
+                render_collapsed_bucket(out, items);
+            }
+        }
+        if let Some(items) = buckets.get(&None) {
+            out.push_str("  ## Uncategorized\n");
+            render_collapsed_bucket(out, items);
+        }
     }
 }
 

--- a/src/reporter/terminal.rs
+++ b/src/reporter/terminal.rs
@@ -2,10 +2,13 @@
 //!
 //! Renders the capture summary, per-host breakdown (gated by
 //! `show_hosts_breakdown` per LESSON-P1.03), protocols, services,
-//! findings, and per-analyzer detail tables for TTY output. Optional
-//! MITRE-tactic grouping (`show_mitre_grouping`) reorganizes the
-//! FINDINGS section by MITRE ATT&CK tactic and expands each finding's
-//! MITRE line with the technique name from [`crate::mitre`].
+//! findings, and per-analyzer detail tables for TTY output. The
+//! `render: FindingsRender` field selects among three mutually-exclusive
+//! FINDINGS rendering modes: `Grouped` (MITRE tactic grouping, `--mitre`),
+//! `FlatCollapsed` (default v0.8.0+), and `FlatExpanded` (`--no-collapse`).
+//! MITRE-tactic grouping reorganizes the FINDINGS section by MITRE ATT&CK
+//! tactic and expands each finding's MITRE line with the technique name from
+//! [`crate::mitre`].
 //!
 //! Per ADR 0003 (`docs/adr/0003-reporting-pipeline-layering.md`), every
 //! attacker-controlled string (Finding `summary`/`evidence`, analyzer
@@ -88,11 +91,27 @@ struct CollapseKey {
     summary: String,
 }
 
+/// Render mode for the FINDINGS section of a terminal report.
+///
+/// Encodes the three mutually-exclusive rendering modes as a single enum,
+/// eliminating the impossible state `show_mitre_grouping = true &&
+/// collapse_findings = true` that existed in v0.8.0.
+/// ADR-0003 Binding Rule 5 — Render-Mode Enum (Issue #62 — v0.9.0).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FindingsRender {
+    /// Group findings by MITRE tactic (`--mitre` flag).
+    /// Corresponds to the previous `show_mitre_grouping = true`.
+    Grouped,
+    /// Collapse repeated findings into counted groups (default, v0.8.0+).
+    /// Corresponds to the previous `collapse_findings = true, show_mitre_grouping = false`.
+    FlatCollapsed,
+    /// One display line per raw finding (pre-v0.8.0 behavior, `--no-collapse`).
+    /// Corresponds to the previous `collapse_findings = false, show_mitre_grouping = false`.
+    FlatExpanded,
+}
+
 pub struct TerminalReporter {
     pub use_color: bool,
-    /// When true, regroup the FINDINGS section by MITRE tactic and expand
-    /// the per-finding MITRE line to include the technique name.
-    pub show_mitre_grouping: bool,
     /// When true, render a per-host breakdown section listing each
     /// unique source/destination IP observed in the capture. Wired
     /// from the `summary` subcommand's `--hosts` flag — see
@@ -100,14 +119,10 @@ pub struct TerminalReporter {
     /// always-present `Hosts: N` count line in the header is shown
     /// regardless; this gate only controls the expanded itemized list.
     pub show_hosts_breakdown: bool,
-    /// When true (the default), repeated findings sharing the same
-    /// `(category, verdict, confidence, summary)` four-tuple are collapsed
-    /// into a single display group with a ` (xN)` count suffix (N≥2).
-    /// Singletons (N=1) render byte-identically to pre-v0.8.0 output.
-    /// Collapse applies ONLY in flat mode (`show_mitre_grouping = false`).
-    /// Wired from `--no-collapse` flag: `collapse_findings = !no_collapse`.
-    /// BC-2.11.025 / BC-2.11.026 / BC-2.11.027 / BC-2.11.028.
-    pub collapse_findings: bool,
+    /// Render mode for the FINDINGS section. Controls mutual exclusion between
+    /// MITRE grouping, flat-collapsed, and flat-expanded rendering.
+    /// ADR-0003 Binding Rule 5; BC-2.11.025 / BC-2.11.026 / BC-2.11.027 / BC-2.11.028.
+    pub render: FindingsRender,
 }
 
 impl Reporter for TerminalReporter {
@@ -184,23 +199,27 @@ impl Reporter for TerminalReporter {
         // Findings
         if !findings.is_empty() {
             out.push_str(&self.section("FINDINGS"));
-            if self.show_mitre_grouping {
-                // Grouped (--mitre) path: structurally suffix-free per BC-2.11.025
-                // invariant 5. STORY-118 does NOT modify this path — collapse applies
-                // only in flat mode. render_finding_prefix stays unchanged.
-                self.render_findings_grouped(&mut out, findings);
-            } else if self.collapse_findings {
-                // Flat + collapse path (STORY-118 / BC-2.11.025 / BC-2.11.026 /
-                // BC-2.11.027): groups findings by CollapseKey in first-occurrence
-                // order, renders each group with optional (xN) suffix and up to K=3
-                // sampled evidence lines.
-                self.render_findings_collapsed(&mut out, findings);
-            } else {
-                // Per ADR 0003: the Finding struct stores raw bytes; the
-                // terminal reporter is responsible for escaping untrusted
-                // content (summary + evidence) before writing to a TTY.
-                for f in findings {
-                    self.render_finding_flat(&mut out, f);
+            match self.render {
+                FindingsRender::Grouped => {
+                    // Grouped (--mitre) path: structurally suffix-free per BC-2.11.025
+                    // invariant 5. Collapse does not apply — impossible state eliminated
+                    // by type. render_finding_prefix stays unchanged.
+                    self.render_findings_grouped(&mut out, findings);
+                }
+                FindingsRender::FlatCollapsed => {
+                    // Flat + collapse path (STORY-118 / BC-2.11.025 / BC-2.11.026 /
+                    // BC-2.11.027): groups findings by CollapseKey in first-occurrence
+                    // order, renders each group with optional (xN) suffix and up to K=3
+                    // sampled evidence lines.
+                    self.render_findings_collapsed(&mut out, findings);
+                }
+                FindingsRender::FlatExpanded => {
+                    // Per ADR 0003: the Finding struct stores raw bytes; the
+                    // terminal reporter is responsible for escaping untrusted
+                    // content (summary + evidence) before writing to a TTY.
+                    for f in findings {
+                        self.render_finding_flat(&mut out, f);
+                    }
                 }
             }
             out.push('\n');

--- a/tests/bc_2_09_100_multitag_tests.rs
+++ b/tests/bc_2_09_100_multitag_tests.rs
@@ -692,9 +692,15 @@ fn make_terminal(mitre_grouping: bool) -> TerminalReporter {
         show_hosts_breakdown: false,
         // STORY-120: parameterized — mitre_grouping ? Grouped : FlatExpanded
         render: if mitre_grouping {
-            FindingsRender { grouping: Grouping::Grouped, collapse: Collapse::Expanded }
+            FindingsRender {
+                grouping: Grouping::Grouped,
+                collapse: Collapse::Expanded,
+            }
         } else {
-            FindingsRender { grouping: Grouping::Flat, collapse: Collapse::Expanded }
+            FindingsRender {
+                grouping: Grouping::Flat,
+                collapse: Collapse::Expanded,
+            }
         },
     }
 }

--- a/tests/bc_2_09_100_multitag_tests.rs
+++ b/tests/bc_2_09_100_multitag_tests.rs
@@ -35,7 +35,7 @@ use wirerust::mitre::{MitreTactic, technique_name, technique_tactic};
 use wirerust::reporter::Reporter;
 use wirerust::reporter::csv::CsvReporter;
 use wirerust::reporter::json::JsonReporter;
-use wirerust::reporter::terminal::TerminalReporter;
+use wirerust::reporter::terminal::{FindingsRender, TerminalReporter};
 use wirerust::summary::Summary;
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -689,10 +689,9 @@ fn test_BC_2_11_001_mitre_attack_version_constant_has_f4_pin_flag_comment() {
 fn make_terminal(mitre_grouping: bool) -> TerminalReporter {
     TerminalReporter {
         use_color: false,
-        show_mitre_grouping: mitre_grouping,
         show_hosts_breakdown: false,
-        // STORY-118: new field; false = pre-v0.8.0 non-collapse path
-        collapse_findings: false,
+        // STORY-120: parameterized — mitre_grouping ? Grouped : FlatExpanded
+        render: if mitre_grouping { FindingsRender::Grouped } else { FindingsRender::FlatExpanded },
     }
 }
 

--- a/tests/bc_2_09_100_multitag_tests.rs
+++ b/tests/bc_2_09_100_multitag_tests.rs
@@ -691,7 +691,11 @@ fn make_terminal(mitre_grouping: bool) -> TerminalReporter {
         use_color: false,
         show_hosts_breakdown: false,
         // STORY-120: parameterized — mitre_grouping ? Grouped : FlatExpanded
-        render: if mitre_grouping { FindingsRender::Grouped } else { FindingsRender::FlatExpanded },
+        render: if mitre_grouping {
+            FindingsRender::Grouped
+        } else {
+            FindingsRender::FlatExpanded
+        },
     }
 }
 
@@ -762,7 +766,7 @@ fn test_BC_2_11_015_terminal_unknown_id_lands_in_uncategorized() {
 
 /// BC-2.11.017 postcondition, AC-002 (STORY-101):
 /// Two-technique finding renders as `"MITRE: T1692.001, T0836"` (comma-space join).
-/// Flat view (show_mitre_grouping=false).
+/// Flat view (render=FindingsRender::FlatExpanded).
 #[test]
 fn test_BC_2_11_017_terminal_renders_multi_id_mitre_string() {
     let f = make_finding_multitag(vec!["T1692.001", "T0836"]);

--- a/tests/bc_2_09_100_multitag_tests.rs
+++ b/tests/bc_2_09_100_multitag_tests.rs
@@ -692,15 +692,9 @@ fn make_terminal(mitre_grouping: bool) -> TerminalReporter {
         show_hosts_breakdown: false,
         // STORY-120: parameterized — mitre_grouping ? Grouped : FlatExpanded
         render: if mitre_grouping {
-            FindingsRender {
-                grouping: Grouping::Grouped,
-                collapse: Collapse::Expanded,
-            }
+            FindingsRender::new(Grouping::Grouped, Collapse::Expanded)
         } else {
-            FindingsRender {
-                grouping: Grouping::Flat,
-                collapse: Collapse::Expanded,
-            }
+            FindingsRender::new(Grouping::Flat, Collapse::Expanded)
         },
     }
 }

--- a/tests/bc_2_09_100_multitag_tests.rs
+++ b/tests/bc_2_09_100_multitag_tests.rs
@@ -35,7 +35,7 @@ use wirerust::mitre::{MitreTactic, technique_name, technique_tactic};
 use wirerust::reporter::Reporter;
 use wirerust::reporter::csv::CsvReporter;
 use wirerust::reporter::json::JsonReporter;
-use wirerust::reporter::terminal::{FindingsRender, TerminalReporter};
+use wirerust::reporter::terminal::{Collapse, FindingsRender, Grouping, TerminalReporter};
 use wirerust::summary::Summary;
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -692,9 +692,9 @@ fn make_terminal(mitre_grouping: bool) -> TerminalReporter {
         show_hosts_breakdown: false,
         // STORY-120: parameterized — mitre_grouping ? Grouped : FlatExpanded
         render: if mitre_grouping {
-            FindingsRender::Grouped
+            FindingsRender { grouping: Grouping::Grouped, collapse: Collapse::Expanded }
         } else {
-            FindingsRender::FlatExpanded
+            FindingsRender { grouping: Grouping::Flat, collapse: Collapse::Expanded }
         },
     }
 }
@@ -766,7 +766,7 @@ fn test_BC_2_11_015_terminal_unknown_id_lands_in_uncategorized() {
 
 /// BC-2.11.017 postcondition, AC-002 (STORY-101):
 /// Two-technique finding renders as `"MITRE: T1692.001, T0836"` (comma-space join).
-/// Flat view (render=FindingsRender::FlatExpanded).
+/// Flat view (render=FindingsRender { grouping: Grouping::Flat, collapse: Collapse::Expanded }).
 #[test]
 fn test_BC_2_11_017_terminal_renders_multi_id_mitre_string() {
     let f = make_finding_multitag(vec!["T1692.001", "T0836"]);

--- a/tests/cli_integration_tests.rs
+++ b/tests/cli_integration_tests.rs
@@ -247,3 +247,68 @@ fn mitre_no_collapse_emits_tactic_headers_without_collapse_suffix() {
          got stdout:\n{stdout}"
     );
 }
+
+// O-1: Named MITRE tactic header assertion and (xN) collapse on modbus fixture
+//
+// The http-ooo.pcap fixture only produces "## Uncategorized" because its HTTP
+// findings carry no MITRE technique IDs. The `## ` assertion in
+// `mitre_flag_emits_tactic_headers_and_collapse_suffix` is therefore satisfied
+// by the Uncategorized bucket alone — it does not verify that a NAMED tactic
+// header (Discovery, Command and Control, etc.) is correctly emitted.
+//
+// modbus-write.pcap produces findings with T1046 (→ Discovery) technique IDs,
+// yielding a `## Discovery` tactic header and a collapsed N=2 group.
+// This test pins a NAMED tactic header so that a bug suppressing tactic-name
+// resolution (while still emitting `## Uncategorized`) would be caught.
+
+/// O-1 (BC-2.11.030 PC-2 / BC-2.11.033 PC-3):
+/// REGRESSION GUARD: `analyze modbus-write.pcap --all --mitre` must emit a
+/// NAMED MITRE tactic header `## Discovery` (produced by T1046 findings in the
+/// fixture). The existing `mitre_flag_emits_tactic_headers_and_collapse_suffix`
+/// test only asserts `## ` which is satisfied by `## Uncategorized`. This test
+/// pins the named-tactic path: if tactic-name resolution is broken, `## Discovery`
+/// would not appear and this test fails.
+///
+/// Also asserts that the collapsed N=2 group in the Discovery bucket carries an
+/// `(xN)` suffix (the fixture produces 2 Modbus recon findings with the same key).
+///
+/// FAIL mode: disable `technique_tactic` lookup so all findings fall into
+/// Uncategorized. The `## Discovery` assertion fails; the existing `## `
+/// assertion in the companion test would still pass.
+#[test]
+fn mitre_named_tactic_header_emitted_for_modbus_fixture() {
+    // modbus-write.pcap produces T1046 findings that map to the Discovery tactic.
+    // Verified by running: cargo run -- analyze tests/fixtures/modbus-write.pcap --all --mitre
+    // Output includes:
+    //   ## Discovery
+    //   [Anomaly] INCONCLUSIVE (MEDIUM) - Modbus recon: Report Server ID ... (x2)
+    //   ## Impair Process Control
+    const MODBUS_FIXTURE: &str = "tests/fixtures/modbus-write.pcap";
+
+    let output = Command::cargo_bin("wirerust")
+        .expect("binary built")
+        .args(["analyze", MODBUS_FIXTURE, "--all", "--mitre"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let stdout = String::from_utf8(output).expect("utf-8 stdout");
+
+    // Named tactic header must appear — NOT just `## Uncategorized`.
+    assert!(
+        stdout.contains("## Discovery"),
+        "O-1 (BC-2.11.030 PC-2): `--mitre` must emit the named MITRE tactic header \
+         '## Discovery' for T1046 findings in modbus-write.pcap; \
+         got stdout:\n{stdout}"
+    );
+
+    // The Discovery bucket contains N=2 identical-key Modbus recon findings;
+    // collapsed output must carry an `(xN)` suffix on the group header.
+    assert!(
+        stdout.contains("(x"),
+        "O-1 (BC-2.11.030 PC-2): `--mitre` on modbus-write.pcap must collapse \
+         N≥2 identical-key Modbus recon findings with '(xN)' suffix; \
+         got stdout:\n{stdout}"
+    );
+}

--- a/tests/cli_integration_tests.rs
+++ b/tests/cli_integration_tests.rs
@@ -374,3 +374,46 @@ fn mitre_named_tactic_header_emitted_for_modbus_fixture() {
          got stdout:\n{stdout}"
     );
 }
+
+// ---- F-A-001: CLI help must not expose internal factory provenance IDs ----
+//
+// Clap renders `///` doc-comment text into `--help` output. Internal factory
+// provenance tags (BC-*, STORY-*, LESSON-*) embedded in `///` comments appear
+// verbatim in `wirerust analyze --help` and `wirerust summary --help`, which is
+// confusing to end-users. This test guards the sweep performed in
+// src/cli.rs: all provenance IDs must live in `//` (non-doc) comments so they
+// are present as source annotations but do NOT reach the rendered help text.
+//
+// FAIL MODE VERIFICATION (done manually before committing): temporarily
+// restoring one `///` line with "BC-2.11.028" caused this test to fail with:
+//   assertion failed: `--help` must not contain "BC-"; found in stdout
+// Then removing the ID restored the green state.
+
+/// REGRESSION GUARD: `wirerust analyze --help` must not contain any of the
+/// internal factory provenance IDs `BC-`, `STORY-`, or `LESSON-`.
+///
+/// Each subcommand's help text is tested independently so failures name the
+/// exact surface that regressed.
+#[test]
+fn help_output_contains_no_internal_provenance_ids() {
+    for subcommand in &["analyze", "summary"] {
+        let output = Command::cargo_bin("wirerust")
+            .expect("binary built")
+            .args([subcommand, "--help"])
+            // clap exits 0 for --help
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+        let stdout = String::from_utf8(output).expect("utf-8 stdout");
+
+        for id_prefix in &["BC-", "STORY-", "LESSON-"] {
+            assert!(
+                !stdout.contains(id_prefix),
+                "`wirerust {subcommand} --help` must not contain \"{id_prefix}\"; \
+                 found in stdout:\n{stdout}"
+            );
+        }
+    }
+}

--- a/tests/cli_integration_tests.rs
+++ b/tests/cli_integration_tests.rs
@@ -176,3 +176,74 @@ fn json_and_csv_flags_are_mutually_exclusive() {
         .assert()
         .failure();
 }
+
+// ---- F5/MEDIUM-1: CLI grouping construction-site mapping e2e guard ----
+//
+// The http-ooo.pcap fixture with `--all` produces 5 identical "HTTP/1.1
+// request without Host header" findings (same category, verdict, confidence,
+// summary). These tests exercise the REAL binary wiring at src/main.rs
+// (the grouping_from_flag construction site) through end-to-end invocation.
+//
+// Together with the unit test `test_bc_2_11_030_grouping_flag_polarity` in
+// src/main.rs, these tests form a non-tautological regression guard: a swap
+// of Grouping::Grouped / Grouping::Flat in `grouping_from_flag` would:
+//   - fail the unit test (wrong return value from helper), AND
+//   - fail the e2e tests below (wrong output format from binary).
+
+/// BC-2.11.030 PC-2 e2e guard:
+/// `analyze <fixture> --all --mitre` must emit MITRE tactic section headers
+/// (`## ` prefix) and collapse N≥2 identical-key findings to a single group
+/// line with `(xN)` suffix.
+#[test]
+fn mitre_flag_emits_tactic_headers_and_collapse_suffix() {
+    let output = Command::cargo_bin("wirerust")
+        .expect("binary built")
+        .args(["analyze", FIXTURE, "--all", "--mitre"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let stdout = String::from_utf8(output).expect("utf-8 stdout");
+
+    assert!(
+        stdout.contains("## "),
+        "BC-2.11.030 PC-2: `--mitre` must emit MITRE tactic section headers ('## '); \
+         got stdout:\n{stdout}"
+    );
+    // The fixture produces ≥2 identical-key HTTP findings; collapsed output carries (xN).
+    assert!(
+        stdout.contains("(x"),
+        "BC-2.11.030 PC-2: `--mitre` must collapse ≥2 identical findings with '(xN)' suffix; \
+         got stdout:\n{stdout}"
+    );
+}
+
+/// BC-2.11.030 PC-3 e2e guard:
+/// `analyze <fixture> --all --mitre --no-collapse` must emit MITRE tactic
+/// section headers (`## ` prefix) but NO `(xN)` collapse suffix on any line.
+#[test]
+fn mitre_no_collapse_emits_tactic_headers_without_collapse_suffix() {
+    let output = Command::cargo_bin("wirerust")
+        .expect("binary built")
+        .args(["analyze", FIXTURE, "--all", "--mitre", "--no-collapse"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let stdout = String::from_utf8(output).expect("utf-8 stdout");
+
+    assert!(
+        stdout.contains("## "),
+        "BC-2.11.030 PC-3: `--mitre --no-collapse` must emit MITRE tactic headers ('## '); \
+         got stdout:\n{stdout}"
+    );
+    // Strip ANSI codes before checking — the terminal reporter may emit color codes.
+    // Simple approach: look for the literal "(x" which only appears in collapse suffixes.
+    assert!(
+        !stdout.contains("(x"),
+        "BC-2.11.030 PC-3: `--mitre --no-collapse` must NOT emit any '(xN)' collapse suffix; \
+         got stdout:\n{stdout}"
+    );
+}

--- a/tests/cli_integration_tests.rs
+++ b/tests/cli_integration_tests.rs
@@ -261,6 +261,68 @@ fn mitre_no_collapse_emits_tactic_headers_without_collapse_suffix() {
 // This test pins a NAMED tactic header so that a bug suppressing tactic-name
 // resolution (while still emitting `## Uncategorized`) would be caught.
 
+// ---- F-PASS-A-001: --mitre help-text collapse regression guard ----
+//
+// The --mitre clap doc-comment must mention collapse behavior so that
+// `wirerust analyze --help` agrees with README and --no-collapse docs.
+// This test pins those keywords so a revert to the terse pre-STORY-119
+// one-liner is caught immediately.
+
+/// F-PASS-A-001 regression guard:
+/// `wirerust analyze --help` must document that `--mitre` collapses
+/// identical findings within each tactic bucket with a `(xN)` count suffix
+/// by default, and that `--no-collapse` disables it.
+///
+/// The test scopes to only the `--mitre` entry text (between `--mitre` and the
+/// next `--no-collapse` flag entry) so that keywords found in the `--no-collapse`
+/// description do not produce a false pass when `--mitre` reverts to the stale
+/// terse one-liner.
+///
+/// Mutation-fail verification (performed during F-PASS-A-001 fix):
+///   Reverted `--mitre` doc-comment to "Group findings by MITRE ATT&CK tactic
+///   and show technique names" (single terse line, no "collapse" / "(x").
+///   Confirmed the binary renders the terse text under `--mitre` with no
+///   "collapse" or "(x" in the scoped slice up to `--no-collapse`.
+///   Test failed with: assertion `--mitre` help text must mention 'collapse'.
+///   Restored new doc-comment: test passes.
+#[test]
+fn mitre_help_text_mentions_collapse_behavior() {
+    let output = Command::cargo_bin("wirerust")
+        .expect("binary built")
+        .args(["analyze", "--help"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let help = String::from_utf8(output).expect("utf-8 stdout");
+
+    // Locate the --mitre entry and extract only the text up to the sibling
+    // --no-collapse entry.  This scoping prevents the richer --no-collapse
+    // description from satisfying the assertions when --mitre reverts to the
+    // stale one-liner (the bug F-PASS-A-001 guards against).
+    let mitre_pos = help
+        .find("--mitre\n")
+        .expect("F-PASS-A-001: `--mitre` flag must appear in `analyze --help` output");
+    let after_mitre = &help[mitre_pos..];
+    // Clap renders the next flag with leading spaces + "--no-collapse"; slice before it.
+    let no_collapse_pos = after_mitre
+        .find("--no-collapse")
+        .expect("F-PASS-A-001: `--no-collapse` must appear after `--mitre` in help output");
+    let mitre_entry = &after_mitre[..no_collapse_pos];
+
+    assert!(
+        mitre_entry.contains("collapse"),
+        "F-PASS-A-001: `--mitre` help text (before --no-collapse entry) must mention \
+         'collapse'; got mitre entry:\n{mitre_entry}"
+    );
+    assert!(
+        mitre_entry.contains("(x"),
+        "F-PASS-A-001: `--mitre` help text (before --no-collapse entry) must mention \
+         '(x' count suffix; got mitre entry:\n{mitre_entry}"
+    );
+}
+
 /// O-1 (BC-2.11.030 PC-2 / BC-2.11.033 PC-3):
 /// REGRESSION GUARD: `analyze modbus-write.pcap --all --mitre` must emit a
 /// NAMED MITRE tactic header `## Discovery` (produced by T1046 findings in the

--- a/tests/dnp3_f5_remediation_tests.rs
+++ b/tests/dnp3_f5_remediation_tests.rs
@@ -993,7 +993,7 @@ mod f5_ics_impact_display {
     use wirerust::findings::{Confidence, Finding, ThreatCategory, Verdict};
     use wirerust::mitre::{MitreTactic, all_tactics_in_report_order};
     use wirerust::reporter::Reporter;
-    use wirerust::reporter::terminal::TerminalReporter;
+    use wirerust::reporter::terminal::{FindingsRender, TerminalReporter};
     use wirerust::summary::Summary;
 
     // -----------------------------------------------------------------------
@@ -1069,10 +1069,9 @@ mod f5_ics_impact_display {
     fn mitre_reporter() -> TerminalReporter {
         TerminalReporter {
             use_color: false,
-            show_mitre_grouping: true,
             show_hosts_breakdown: false,
-            // STORY-118: new field; false here — grouped mode does not apply collapse.
-            collapse_findings: false,
+            // STORY-120: render = FindingsRender::Grouped (grouped helper)
+            render: FindingsRender::Grouped,
         }
     }
 

--- a/tests/dnp3_f5_remediation_tests.rs
+++ b/tests/dnp3_f5_remediation_tests.rs
@@ -993,7 +993,7 @@ mod f5_ics_impact_display {
     use wirerust::findings::{Confidence, Finding, ThreatCategory, Verdict};
     use wirerust::mitre::{MitreTactic, all_tactics_in_report_order};
     use wirerust::reporter::Reporter;
-    use wirerust::reporter::terminal::{FindingsRender, TerminalReporter};
+    use wirerust::reporter::terminal::{Collapse, FindingsRender, Grouping, TerminalReporter};
     use wirerust::summary::Summary;
 
     // -----------------------------------------------------------------------
@@ -1070,8 +1070,8 @@ mod f5_ics_impact_display {
         TerminalReporter {
             use_color: false,
             show_hosts_breakdown: false,
-            // STORY-120: render = FindingsRender::Grouped (grouped helper)
-            render: FindingsRender::Grouped,
+            // STORY-120: render = FindingsRender { grouping: Grouping::Grouped, collapse: Collapse::Expanded } (grouped helper)
+            render: FindingsRender { grouping: Grouping::Grouped, collapse: Collapse::Expanded },
         }
     }
 

--- a/tests/dnp3_f5_remediation_tests.rs
+++ b/tests/dnp3_f5_remediation_tests.rs
@@ -1071,7 +1071,10 @@ mod f5_ics_impact_display {
             use_color: false,
             show_hosts_breakdown: false,
             // STORY-120: render = FindingsRender { grouping: Grouping::Grouped, collapse: Collapse::Expanded } (grouped helper)
-            render: FindingsRender { grouping: Grouping::Grouped, collapse: Collapse::Expanded },
+            render: FindingsRender {
+                grouping: Grouping::Grouped,
+                collapse: Collapse::Expanded,
+            },
         }
     }
 

--- a/tests/dnp3_f5_remediation_tests.rs
+++ b/tests/dnp3_f5_remediation_tests.rs
@@ -1071,10 +1071,7 @@ mod f5_ics_impact_display {
             use_color: false,
             show_hosts_breakdown: false,
             // STORY-120: render = FindingsRender { grouping: Grouping::Grouped, collapse: Collapse::Expanded } (grouped helper)
-            render: FindingsRender {
-                grouping: Grouping::Grouped,
-                collapse: Collapse::Expanded,
-            },
+            render: FindingsRender::new(Grouping::Grouped, Collapse::Expanded),
         }
     }
 

--- a/tests/reporter_terminal_tests.rs
+++ b/tests/reporter_terminal_tests.rs
@@ -4569,13 +4569,17 @@ mod story_122 {
         );
     }
 
-    /// AC-002 (BC-2.11.013 Invariant 4):
-    /// The {Grouped, Collapsed} dispatch arm TEMPORARILY routes to render_findings_grouped
-    /// (same as {Grouped, Expanded}) — output is byte-identical; tactic headers appear
-    /// and no (xN) suffix is emitted. This arm is unreachable via the CLI in STORY-122/A;
-    /// STORY-119/B repoints it to render_findings_grouped_collapsed.
+    /// AC-002 (BC-2.11.013 Invariant 4 / STORY-119/B post-implementation):
+    /// The {Grouped, Collapsed} dispatch arm routes to `render_findings_grouped_collapsed`
+    /// (STORY-119/B). For N≥2 identical-key findings in a tactic bucket, the output
+    /// carries a `(xN)` suffix — it is NO longer byte-identical to {Grouped, Expanded}.
+    /// Tactic headers still appear (`## <tactic>`).
+    ///
+    /// Supersedes the TEMPORARY STORY-122/A assertion that {Grouped,Collapsed} was
+    /// byte-identical to {Grouped,Expanded}. That was a scaffolding state; STORY-119/B
+    /// wires the real implementation.
     #[test]
-    fn test_BC_2_11_028_ac002_grouped_collapsed_arm_temporary_routes_to_render_findings_grouped() {
+    fn test_BC_2_11_028_ac002_grouped_collapsed_arm_routes_to_render_findings_grouped_collapsed() {
         let findings: Vec<Finding> = (0..3)
             .map(|_| make_mitre_finding_s122("s122-dispatch-gc"))
             .collect();
@@ -4600,12 +4604,19 @@ mod story_122 {
         }
         .render(&Summary::new(), &findings, &[]);
 
-        // TEMPORARY: {Grouped,Collapsed} routes to the same function as {Grouped,Expanded}.
-        assert_eq!(
-            out_gc, out_ge,
-            "AC-002: {{Grouped,Collapsed}} arm (TEMPORARY in STORY-122/A) must produce \
-             byte-identical output to {{Grouped,Expanded}}; outputs differ"
+        // Post-STORY-119/B: {Grouped,Collapsed} routes to render_findings_grouped_collapsed.
+        // N=3 identical-key findings must produce (x3) suffix — collapsed, not expanded.
+        assert!(
+            out_gc.contains("(x3)"),
+            "AC-002: {{Grouped,Collapsed}} with N=3 identical findings must emit `(x3)` suffix; \
+             got:\n{out_gc}"
         );
+        // {Grouped,Collapsed} output must differ from {Grouped,Expanded} (no longer byte-identical).
+        assert_ne!(
+            out_gc, out_ge,
+            "AC-002: {{Grouped,Collapsed}} must differ from {{Grouped,Expanded}} post-STORY-119/B"
+        );
+        // Tactic headers still appear.
         assert!(
             out_gc.contains("## "),
             "AC-002: {{Grouped,Collapsed}} arm must emit tactic header '## '; got:\n{out_gc}"
@@ -5418,8 +5429,16 @@ mod story_119 {
         // Construct the reporter exactly as run_analyze does when
         // show_mitre_grouping=true, collapse_findings=true.
         let render = FindingsRender {
-            grouping: if true { Grouping::Grouped } else { Grouping::Flat },
-            collapse: if true { Collapse::Collapsed } else { Collapse::Expanded },
+            grouping: if true {
+                Grouping::Grouped
+            } else {
+                Grouping::Flat
+            },
+            collapse: if true {
+                Collapse::Collapsed
+            } else {
+                Collapse::Expanded
+            },
         };
         assert_eq!(
             render,
@@ -5462,8 +5481,16 @@ mod story_119 {
     #[test]
     fn test_BC_2_11_030_mitre_no_collapse_maps_to_grouped_expanded() {
         let render = FindingsRender {
-            grouping: if true { Grouping::Grouped } else { Grouping::Flat },
-            collapse: if false { Collapse::Collapsed } else { Collapse::Expanded },
+            grouping: if true {
+                Grouping::Grouped
+            } else {
+                Grouping::Flat
+            },
+            collapse: if false {
+                Collapse::Collapsed
+            } else {
+                Collapse::Expanded
+            },
         };
         assert_eq!(
             render,
@@ -5516,8 +5543,16 @@ mod story_119 {
     fn test_BC_2_11_030_flat_routing_unchanged() {
         // PC-4: default (no --mitre, no --no-collapse)
         let default_render = FindingsRender {
-            grouping: if false { Grouping::Grouped } else { Grouping::Flat },
-            collapse: if true { Collapse::Collapsed } else { Collapse::Expanded },
+            grouping: if false {
+                Grouping::Grouped
+            } else {
+                Grouping::Flat
+            },
+            collapse: if true {
+                Collapse::Collapsed
+            } else {
+                Collapse::Expanded
+            },
         };
         assert_eq!(
             default_render,
@@ -5530,8 +5565,16 @@ mod story_119 {
 
         // PC-5: --no-collapse without --mitre
         let no_collapse_flat_render = FindingsRender {
-            grouping: if false { Grouping::Grouped } else { Grouping::Flat },
-            collapse: if false { Collapse::Collapsed } else { Collapse::Expanded },
+            grouping: if false {
+                Grouping::Grouped
+            } else {
+                Grouping::Flat
+            },
+            collapse: if false {
+                Collapse::Collapsed
+            } else {
+                Collapse::Expanded
+            },
         };
         assert_eq!(
             no_collapse_flat_render,
@@ -5637,10 +5680,7 @@ mod story_119 {
         // The ANSI reset sequence (\x1b[0m) must NOT appear BEFORE `(x2)` on
         // the same header line. Verify by checking that `(x2)` does not appear
         // after a reset on the header line.
-        let header_line = out
-            .lines()
-            .find(|l| l.contains("(x2)"))
-            .unwrap_or_default();
+        let header_line = out.lines().find(|l| l.contains("(x2)")).unwrap_or_default();
         // Split by reset: if (x2) appears in the LAST segment (after reset),
         // the suffix was appended after the ANSI reset — NON-CONFORMANT.
         let reset = "\x1b[0m";
@@ -6051,10 +6091,7 @@ mod story_119 {
 
         // The header verdict must be "Likely" (the sorted-first representative),
         // not "Inconclusive". Find the header line (contains `(x2)`).
-        let header_line = out
-            .lines()
-            .find(|l| l.contains("(x2)"))
-            .unwrap_or_default();
+        let header_line = out.lines().find(|l| l.contains("(x2)")).unwrap_or_default();
         assert!(
             header_line.contains("Likely"),
             "AC-016: post-sort representative must be Likely (rank=0 sorts first); \
@@ -6199,11 +6236,21 @@ mod story_119 {
     /// divergent `mitre_techniques`, only `members[0]`'s technique appears on
     /// the MITRE line. The other members' techniques are elided from terminal
     /// output (preserved in raw findings for JSON/CSV).
+    ///
+    /// Both findings MUST be in the same tactic bucket for per-bucket collapse
+    /// to merge them (BC-2.11.033 Invariant 3 / EC-003): T1046 and T1083 both
+    /// map to Discovery, so they land in the same bucket and collapse as N=2.
+    /// Using findings from different tactics (e.g. T1046 Discovery + T1071 C&C)
+    /// would produce two independent singletons per BC-2.11.033 EC-003 — the
+    /// correct per-bucket behavior — but the divergent-MITRE elision property
+    /// (BC-2.11.034 PC-3) can only be observed when N≥2 within one bucket.
     #[test]
     fn test_BC_2_11_034_divergent_mitre_representative_sourcing() {
-        // Two findings with same collapse key but different MITRE techniques.
+        // Two findings with same summary but different MITRE techniques,
+        // both in the Discovery tactic bucket (T1046 and T1083).
         // After sort (Likely rank=0 for both, same confidence), the first
         // submitted becomes members[0] (stable emission-index tiebreak).
+        // They collapse into N=2 within the Discovery bucket.
         let findings = vec![
             Finding {
                 category: ThreatCategory::Anomaly,
@@ -6211,7 +6258,7 @@ mod story_119 {
                 confidence: Confidence::High,
                 summary: "s119-ac020-divergent-mitre".to_string(),
                 evidence: vec![],
-                mitre_techniques: vec!["T1046".to_string()], // members[0]
+                mitre_techniques: vec!["T1046".to_string()], // members[0] — Discovery
                 source_ip: None,
                 timestamp: None,
                 direction: None,
@@ -6222,7 +6269,7 @@ mod story_119 {
                 confidence: Confidence::High,
                 summary: "s119-ac020-divergent-mitre".to_string(),
                 evidence: vec![],
-                mitre_techniques: vec!["T1071".to_string()], // members[1] — must be elided
+                mitre_techniques: vec!["T1083".to_string()], // members[1] — Discovery; must be elided
                 source_ip: None,
                 timestamp: None,
                 direction: None,
@@ -6238,9 +6285,14 @@ mod story_119 {
         );
         // members[1]'s technique must NOT appear in terminal output.
         assert!(
-            !out.contains("T1071"),
-            "AC-020: members[1] technique T1071 must be elided from terminal output; \
+            !out.contains("T1083"),
+            "AC-020: members[1] technique T1083 must be elided from terminal output; \
              got:\n{out}"
+        );
+        // Group must be collapsed as N=2 (same bucket, same summary-only key).
+        assert!(
+            out.contains("(x2)"),
+            "AC-020: same-bucket same-summary findings must collapse to N=2; got:\n{out}"
         );
     }
 
@@ -6270,12 +6322,10 @@ mod story_119 {
             &out[..out.len().min(500)]
         );
         // All 100 findings must be rendered (header line count via `[Anomaly]`).
-        let header_count = out
-            .lines()
-            .filter(|l| l.contains("[Anomaly]"))
-            .count();
+        let header_count = out.lines().filter(|l| l.contains("[Anomaly]")).count();
         assert_eq!(
-            header_count, 100,
+            header_count,
+            100,
             "AC-022: {{Grouped,Expanded}} must render all 100 findings; got {header_count} in \
              output (first 500 chars):\n{}",
             &out[..out.len().min(500)]

--- a/tests/reporter_terminal_tests.rs
+++ b/tests/reporter_terminal_tests.rs
@@ -6802,4 +6802,79 @@ mod story_119 {
              high_pos={high_pos}, low_pos={low_pos}\nfull output:\n{out}"
         );
     }
+
+    // -----------------------------------------------------------------------
+    // F6-FINDING-2 — pin the Confidence::High red+bold color arm in
+    // render_findings_grouped_collapsed (terminal.rs:~568)
+    // (traces to BC-2.11.031 PC-3)
+    // -----------------------------------------------------------------------
+
+    /// F6-FINDING-2 (BC-2.11.031 Postcondition 3):
+    /// REGRESSION GUARD: The color ladder for `{Grouped, Collapsed}` N≥2 groups
+    /// with `Verdict::Likely` and `Confidence::High` must emit ANSI red+bold
+    /// escapes (ESC[1m and ESC[31m) on the collapsed summary header line.
+    ///
+    /// The existing `test_BC_2_11_031_grouped_collapse_color_ladder` verifies
+    /// that `(x2)` is inside the ANSI color span but does NOT assert the
+    /// specific escape code — a mutation that changes `High => red().bold()` to
+    /// `High => yellow()` (ESC[33m) still passes the existing test. This sibling
+    /// pins the specific ANSI sequences so that mutation fails.
+    ///
+    /// owo-colors escape sequences used:
+    ///   - `.red()` wraps text as `ESC[31m{text}ESC[39m`
+    ///   - `.bold()` wraps outer as `ESC[1m{inner}ESC[0m`
+    ///   - `.red().bold()` → `ESC[1mESC[31m{text}ESC[39mESC[0m`
+    ///   - `.yellow()` → `ESC[33m{text}ESC[39m` (mutation: no ESC[1m, no ESC[31m)
+    ///
+    /// FAIL mode: mutate `Confidence::High => header_text.red().bold()` to
+    /// `Confidence::High => header_text.yellow()` in terminal.rs:~568; both
+    /// `\x1b[1m` (bold) and `\x1b[31m` (red) would be absent, failing this test.
+    #[test]
+    fn test_BC_2_11_031_grouped_collapse_high_confidence_red_bold_ansi() {
+        // N=2 Likely/High findings in one tactic bucket → collapsed with N=2 header.
+        let findings: Vec<Finding> = (0..2)
+            .map(|_| Finding {
+                category: ThreatCategory::Anomaly,
+                verdict: Verdict::Likely,
+                confidence: Confidence::High,
+                summary: "s119-f6find2-red-bold".to_string(),
+                evidence: vec![],
+                mitre_techniques: vec!["T1046".to_string()],
+                source_ip: None,
+                timestamp: None,
+                direction: None,
+            })
+            .collect();
+
+        let out = grouped_collapse_reporter_color().render(&Summary::new(), &findings, &[]);
+
+        // The N=2 suffix must be present (sanity check that we're on the right path).
+        assert!(
+            out.contains("(x2)"),
+            "F6-FINDING-2: N=2 group must emit `(x2)` suffix; got:\n{out}"
+        );
+
+        // Extract the header line (the line that contains the (x2) suffix).
+        let header_line = out.lines().find(|l| l.contains("(x2)")).unwrap_or_default();
+
+        // Assert ESC[1m (bold) is present on the header line.
+        // Mutation `red().bold()` → `yellow()` removes ESC[1m.
+        assert!(
+            header_line.contains("\x1b[1m"),
+            "F6-FINDING-2 (BC-2.11.031 PC-3): Likely/High collapsed header must contain \
+             ANSI bold escape ESC[1m. Mutation of `Confidence::High => red().bold()` to \
+             `yellow()` in terminal.rs:~568 removes this escape and fails this test.\n\
+             header line: {header_line:?}\nfull output:\n{out}"
+        );
+
+        // Assert ESC[31m (red foreground) is present on the header line.
+        // Mutation `red().bold()` → `yellow()` replaces ESC[31m with ESC[33m.
+        assert!(
+            header_line.contains("\x1b[31m"),
+            "F6-FINDING-2 (BC-2.11.031 PC-3): Likely/High collapsed header must contain \
+             ANSI red escape ESC[31m. Mutation of `Confidence::High => red().bold()` to \
+             `yellow()` in terminal.rs:~568 replaces this with ESC[33m and fails this test.\n\
+             header line: {header_line:?}\nfull output:\n{out}"
+        );
+    }
 }

--- a/tests/reporter_terminal_tests.rs
+++ b/tests/reporter_terminal_tests.rs
@@ -3959,144 +3959,252 @@ mod story_118 {
 // ---------------------------------------------------------------------------
 
 mod story_120 {
-    // Inherit the allow(non_snake_case) from the file-level attribute so
-    // test_BC_* names compile without a separate inner attribute.
-    //
-    // Imports are unused now (todo!() bodies) but will be needed by the
-    // implementer during GREEN. Suppress the lint so the file remains clean
-    // under `cargo check --all-targets` with RUSTFLAGS=-Dwarnings.
-    #![allow(unused_imports)]
-
     use wirerust::findings::{Confidence, Finding, ThreatCategory, Verdict};
     use wirerust::reporter::Reporter;
-    use wirerust::reporter::terminal::TerminalReporter;
+    use wirerust::reporter::terminal::{FindingsRender, TerminalReporter};
     use wirerust::summary::Summary;
+
+    fn make_finding_s120(summary: impl Into<String>) -> Finding {
+        Finding {
+            category: ThreatCategory::Anomaly,
+            verdict: Verdict::Inconclusive,
+            confidence: Confidence::Low,
+            summary: summary.into(),
+            evidence: vec![],
+            mitre_techniques: vec![],
+            source_ip: None,
+            timestamp: None,
+            direction: None,
+        }
+    }
+
+    fn make_mitre_finding_s120(summary: impl Into<String>) -> Finding {
+        Finding {
+            category: ThreatCategory::Anomaly,
+            verdict: Verdict::Likely,
+            confidence: Confidence::High,
+            summary: summary.into(),
+            evidence: vec![],
+            mitre_techniques: vec!["T1046".to_string()],
+            source_ip: None,
+            timestamp: None,
+            direction: None,
+        }
+    }
 
     // -----------------------------------------------------------------------
     // AC-001 — FindingsRender derives Debug, Clone, Copy, PartialEq, Eq
     // (traces to BC-2.11.025 invariant 5, BC-2.11.013 invariant 4)
-    //
-    // Intended assertion (implementer fills in during GREEN):
-    //   - Confirm `FindingsRender` satisfies `Debug + Clone + Copy + PartialEq + Eq`
-    //     by asserting equality, cloning, and debug-formatting all three variants.
-    //   - Assert the enum has exactly three variants (Grouped, FlatCollapsed,
-    //     FlatExpanded) and that `Default` is NOT derived (no Default impl).
     // -----------------------------------------------------------------------
+
+    /// AC-001 (BC-2.11.025 invariant 5, BC-2.11.013 invariant 4):
+    /// FindingsRender satisfies Debug + Clone + Copy + PartialEq + Eq.
+    /// The enum has exactly three variants and no Default impl.
     #[test]
     fn test_findings_render_derives_debug_clone_copy_partialeq_eq() {
-        // RED: FindingsRender does not exist yet — todo!() panics to satisfy Red Gate.
-        // GREEN: replace with:
-        //   let a = FindingsRender::Grouped;
-        //   let b = a;                          // Copy
-        //   let c = a.clone();                  // Clone
-        //   assert_eq!(a, b);                   // PartialEq + Eq
-        //   let _ = format!("{a:?}");           // Debug
-        //   assert_ne!(a, FindingsRender::FlatCollapsed);
-        //   assert_ne!(a, FindingsRender::FlatExpanded);
-        todo!(
-            "AC-001: verify FindingsRender derives Debug+Clone+Copy+PartialEq+Eq \
-             and has exactly three variants; implement after enum is defined"
-        )
+        let a = FindingsRender::Grouped;
+        let b = a; // Copy
+        let c = a.clone(); // Clone
+        assert_eq!(a, b, "PartialEq + Eq: Grouped == copied Grouped");
+        assert_eq!(a, c, "PartialEq + Eq: Grouped == cloned Grouped");
+        let _ = format!("{a:?}"); // Debug — would panic if not implemented
+
+        // All three variants are distinct.
+        assert_ne!(
+            FindingsRender::Grouped,
+            FindingsRender::FlatCollapsed,
+            "Grouped != FlatCollapsed"
+        );
+        assert_ne!(
+            FindingsRender::Grouped,
+            FindingsRender::FlatExpanded,
+            "Grouped != FlatExpanded"
+        );
+        assert_ne!(
+            FindingsRender::FlatCollapsed,
+            FindingsRender::FlatExpanded,
+            "FlatCollapsed != FlatExpanded"
+        );
+
+        // Debug formats include the variant name.
+        assert!(format!("{:?}", FindingsRender::Grouped).contains("Grouped"));
+        assert!(format!("{:?}", FindingsRender::FlatCollapsed).contains("FlatCollapsed"));
+        assert!(format!("{:?}", FindingsRender::FlatExpanded).contains("FlatExpanded"));
     }
 
     // -----------------------------------------------------------------------
     // AC-002 — TerminalReporter struct has exactly 3 fields after refactor
     // (traces to BC-2.11.028 precondition 3 — struct shape governs render wiring)
-    //
-    // Intended assertion (implementer fills in during GREEN):
-    //   - Construct TerminalReporter with exactly {use_color, show_hosts_breakdown,
-    //     render} and verify it compiles (struct-literal exhaustiveness is the gate).
-    //   - Assert that neither `show_mitre_grouping` nor `collapse_findings` appear
-    //     as fields (any reference to them is a compile error after STORY-120).
     // -----------------------------------------------------------------------
+
+    /// AC-002 (BC-2.11.028 precondition 3):
+    /// TerminalReporter has exactly 3 fields: use_color, show_hosts_breakdown, render.
+    /// This test compiles only if the struct has exactly those fields — any reference
+    /// to removed fields show_mitre_grouping or collapse_findings is a compile error.
     #[test]
     fn test_BC_2_11_028_struct_has_exactly_three_fields_post_refactor() {
-        // RED: the struct still has four bool fields; the intended three-field
-        // construction (with render: FindingsRender) does not compile yet.
-        // GREEN: replace with a TerminalReporter literal using only:
-        //   use_color, show_hosts_breakdown, render: FindingsRender::FlatExpanded
-        // and assert that cargo check passes (the compile itself is the assertion).
-        todo!(
-            "AC-002: verify TerminalReporter has exactly 3 fields \
-             (use_color, show_hosts_breakdown, render: FindingsRender); \
-             implement after struct is refactored"
-        )
+        // The struct literal below is the test: it compiles if and only if exactly
+        // these three fields exist on TerminalReporter (Rust requires all fields in a
+        // struct literal; extra fields are also a compile error).
+        let r = TerminalReporter {
+            use_color: false,
+            show_hosts_breakdown: false,
+            render: FindingsRender::FlatExpanded,
+        };
+        // The struct renders fine (behavioral sanity).
+        let out = r.render(&Summary::new(), &[], &[]);
+        assert!(
+            out.contains("WIRERUST TRIAGE REPORT"),
+            "three-field TerminalReporter renders a valid report; got: {out}"
+        );
     }
 
     // -----------------------------------------------------------------------
     // AC-003 — Dispatch is an exhaustive match over FindingsRender
     // (traces to BC-2.11.019 invariant 7)
-    //
-    // Intended assertion (implementer fills in during GREEN):
-    //   - Render through all three FindingsRender variants with the same input
-    //     and assert each reaches the correct rendering path:
-    //       Grouped      → output contains "## " tactic header (grouped path)
-    //       FlatCollapsed → output contains "(x3)" suffix for N=3 identical findings
-    //       FlatExpanded  → output does NOT contain "(x" and has 3 individual lines
-    //   - Relies on exhaustive match compile-time guarantee (no arm can be omitted).
     // -----------------------------------------------------------------------
+
+    /// AC-003 (BC-2.11.019 invariant 7):
+    /// All three FindingsRender arms are reachable and route to the correct rendering path.
+    ///   Grouped       → MITRE tactic header "## " in output
+    ///   FlatCollapsed → "(x3)" suffix for N=3 identical findings
+    ///   FlatExpanded  → 3 individual header lines, no "(x" suffix
     #[test]
     fn test_BC_2_11_019_findings_dispatch_match_exhaustive() {
-        // RED: FindingsRender does not exist; todo!() panics to satisfy Red Gate.
-        // GREEN: replace with three reporter constructions using each variant
-        // and behavioral assertions for each rendering path.
-        todo!(
-            "AC-003: verify all three FindingsRender arms are reachable and route \
-             to the correct rendering helper; implement after match dispatch is added"
-        )
+        // Three identical-key findings with a known MITRE technique for the Grouped path.
+        let findings: Vec<Finding> = (0..3)
+            .map(|_| make_mitre_finding_s120("dispatch-test"))
+            .collect();
+
+        // Grouped arm: calls render_findings_grouped → emits "## " tactic header.
+        let grouped_out = TerminalReporter {
+            use_color: false,
+            show_hosts_breakdown: false,
+            render: FindingsRender::Grouped,
+        }
+        .render(&Summary::new(), &findings, &[]);
+        assert!(
+            grouped_out.contains("## "),
+            "AC-003: Grouped arm must emit a tactic header (## ...); got:\n{grouped_out}"
+        );
+
+        // FlatCollapsed arm: calls render_findings_collapsed → emits "(x3)" suffix.
+        let collapsed_out = TerminalReporter {
+            use_color: false,
+            show_hosts_breakdown: false,
+            render: FindingsRender::FlatCollapsed,
+        }
+        .render(&Summary::new(), &findings, &[]);
+        assert!(
+            collapsed_out.contains("(x3)"),
+            "AC-003: FlatCollapsed arm must emit '(x3)' for 3 identical-key findings; \
+             got:\n{collapsed_out}"
+        );
+
+        // FlatExpanded arm: iterates render_finding_flat → 3 individual header lines, no (x.
+        let expanded_out = TerminalReporter {
+            use_color: false,
+            show_hosts_breakdown: false,
+            render: FindingsRender::FlatExpanded,
+        }
+        .render(&Summary::new(), &findings, &[]);
+        assert!(
+            !expanded_out.contains("(x"),
+            "AC-003: FlatExpanded arm must not emit (xN) suffix; got:\n{expanded_out}"
+        );
+        let header_count = expanded_out.matches("dispatch-test").count();
+        assert_eq!(
+            header_count, 3,
+            "AC-003: FlatExpanded arm must emit 3 individual finding lines; \
+             found {header_count} in:\n{expanded_out}"
+        );
+
+        // All three outputs are mutually distinct.
+        assert_ne!(grouped_out, collapsed_out, "AC-003: Grouped != FlatCollapsed output");
+        assert_ne!(grouped_out, expanded_out, "AC-003: Grouped != FlatExpanded output");
+        assert_ne!(collapsed_out, expanded_out, "AC-003: FlatCollapsed != FlatExpanded output");
     }
 
     // -----------------------------------------------------------------------
-    // AC-004 — Impossible state (Grouped + collapsed simultaneously)
-    //          is structurally unrepresentable after STORY-120
+    // AC-004 — Impossible state (Grouped + collapsed) is structurally unrepresentable
     // (traces to BC-2.11.025 invariant 5)
-    //
-    // Intended assertion (implementer fills in during GREEN):
-    //   - Confirm that `FindingsRender::Grouped` on N=100 identical-key findings
-    //     produces NO "(xN)" suffix anywhere in the output (collapse path not
-    //     reachable from the Grouped arm — the impossible state is gone by type).
-    //   - This corresponds to the former `mitre_collapse_reporter` construction
-    //     (show_mitre_grouping=true, collapse_findings=true) which now maps to
-    //     render: FindingsRender::Grouped cleanly.
     // -----------------------------------------------------------------------
+
+    /// AC-004 (BC-2.11.025 invariant 5):
+    /// FindingsRender::Grouped on N=100 identical-key findings produces no "(xN)" suffix.
+    /// The impossible state (show_mitre_grouping=true && collapse_findings=true) is
+    /// eliminated by type — FindingsRender::Grouped structurally excludes the collapse path.
     #[test]
     fn test_BC_2_11_025_grouped_mode_bypasses_collapse_structurally() {
-        // RED: FindingsRender does not exist; todo!() panics to satisfy Red Gate.
-        // GREEN: construct TerminalReporter { render: FindingsRender::Grouped, ... },
-        // render 100 identical-key findings, and assert no "(x" suffix appears.
-        todo!(
-            "AC-004: verify FindingsRender::Grouped never emits (xN) suffix — \
-             impossible state (Grouped + collapsed) is structurally unrepresentable; \
-             implement after enum and match dispatch are in place"
-        )
+        let findings: Vec<Finding> = (0..100)
+            .map(|_| make_mitre_finding_s120("grouped-collapse-impossible"))
+            .collect();
+
+        let out = TerminalReporter {
+            use_color: false,
+            show_hosts_breakdown: false,
+            render: FindingsRender::Grouped,
+        }
+        .render(&Summary::new(), &findings, &[]);
+
+        assert!(
+            !out.contains("(x"),
+            "AC-004: FindingsRender::Grouped must never emit (xN) suffix — \
+             impossible state is structurally unrepresentable; got:\n{out}"
+        );
+        // Grouped mode emits tactic headers (confirming the Grouped path ran, not collapsed).
+        assert!(
+            out.contains("## "),
+            "AC-004: FindingsRender::Grouped must emit tactic section headers; got:\n{out}"
+        );
     }
 
     // -----------------------------------------------------------------------
-    // AC-005 — run_analyze construction site wired correctly in main.rs
+    // AC-005 — render field wiring: FlatCollapsed vs FlatExpanded polarity
     // (traces to BC-2.11.028 postconditions 1–2, invariant 1)
-    //
-    // Intended assertion (implementer fills in during GREEN):
-    //   - Using FindingsRender::FlatCollapsed (collapse ON) vs FindingsRender::FlatExpanded
-    //     (collapse OFF) on N=3 identical-key findings produces different output
-    //     (FlatCollapsed emits "(x3)", FlatExpanded does not) — proving the render
-    //     field is wired correctly to the rendering path.
-    //   - This mirrors the run_analyze wiring intent:
-    //       render: if show_mitre_grouping { Grouped }
-    //               else if collapse_findings { FlatCollapsed }
-    //               else { FlatExpanded }
-    //   - Structural polarity test: FlatCollapsed != FlatExpanded output.
     // -----------------------------------------------------------------------
+
+    /// AC-005 (BC-2.11.028 postconditions 1–2, invariant 1):
+    /// FindingsRender::FlatCollapsed produces "(x3)" for 3 identical-key findings;
+    /// FindingsRender::FlatExpanded does not — proving the render field is wired
+    /// correctly to the rendering path. Mirrors the run_analyze construction intent.
     #[test]
     fn test_BC_2_11_028_flag_wired_to_render_field_post_enum() {
-        // RED: FindingsRender does not exist; todo!() panics to satisfy Red Gate.
-        // GREEN: construct two reporters — one with render: FindingsRender::FlatCollapsed
-        // and one with render: FindingsRender::FlatExpanded — render N=3 identical
-        // findings, and assert FlatCollapsed produces "(x3)" while FlatExpanded does not.
-        // Also assert the two outputs differ (polarity test mirrors run_analyze wiring).
-        todo!(
-            "AC-005: verify render: FindingsRender::FlatCollapsed produces collapse \
-             and FlatExpanded does not — proving the run_analyze wiring intent; \
-             implement after enum construction sites are updated"
-        )
+        let findings: Vec<Finding> = (0..3)
+            .map(|_| make_finding_s120("WiredTestPostEnum"))
+            .collect();
+
+        // FlatCollapsed → collapse active → "(x3)" suffix.
+        let out_collapsed = TerminalReporter {
+            use_color: false,
+            show_hosts_breakdown: false,
+            render: FindingsRender::FlatCollapsed,
+        }
+        .render(&Summary::new(), &findings, &[]);
+        assert!(
+            out_collapsed.contains("(x3)"),
+            "AC-005: FindingsRender::FlatCollapsed must produce '(x3)' for 3 identical \
+             findings; got:\n{out_collapsed}"
+        );
+
+        // FlatExpanded → collapse inactive → no "(x" suffix, 3 individual lines.
+        let out_expanded = TerminalReporter {
+            use_color: false,
+            show_hosts_breakdown: false,
+            render: FindingsRender::FlatExpanded,
+        }
+        .render(&Summary::new(), &findings, &[]);
+        assert!(
+            !out_expanded.contains("(x"),
+            "AC-005: FindingsRender::FlatExpanded must not produce (xN) suffix; \
+             got:\n{out_expanded}"
+        );
+
+        // Polarity: FlatCollapsed != FlatExpanded output for N≥2 identical-key input.
+        assert_ne!(
+            out_collapsed, out_expanded,
+            "AC-005: FlatCollapsed and FlatExpanded must produce different output \
+             for N≥2 identical-key findings"
+        );
     }
 }

--- a/tests/reporter_terminal_tests.rs
+++ b/tests/reporter_terminal_tests.rs
@@ -42,7 +42,7 @@ use wirerust::analyzer::AnalysisSummary;
 use wirerust::decoder::{ParsedPacket, Protocol, TransportInfo};
 use wirerust::findings::{Confidence, Finding, ThreatCategory, Verdict};
 use wirerust::reporter::Reporter;
-use wirerust::reporter::terminal::TerminalReporter;
+use wirerust::reporter::terminal::{FindingsRender, TerminalReporter};
 use wirerust::summary::Summary;
 
 // ---------------------------------------------------------------------------
@@ -70,9 +70,8 @@ fn make_finding(summary: impl Into<String>) -> Finding {
 fn plain_reporter() -> TerminalReporter {
     TerminalReporter {
         use_color: false,
-        show_mitre_grouping: false,
         show_hosts_breakdown: false,
-        collapse_findings: false,
+        render: FindingsRender::FlatExpanded,
     }
 }
 
@@ -661,9 +660,8 @@ mod story_078 {
     fn mitre_reporter() -> TerminalReporter {
         TerminalReporter {
             use_color: false,
-            show_mitre_grouping: true,
             show_hosts_breakdown: false,
-            collapse_findings: false,
+            render: FindingsRender::Grouped,
         }
     }
 
@@ -1788,9 +1786,8 @@ mod story_118 {
     fn collapse_reporter() -> TerminalReporter {
         TerminalReporter {
             use_color: false,
-            show_mitre_grouping: false,
             show_hosts_breakdown: false,
-            collapse_findings: true,
+            render: FindingsRender::FlatCollapsed,
         }
     }
 
@@ -1798,9 +1795,8 @@ mod story_118 {
     fn collapse_reporter_color() -> TerminalReporter {
         TerminalReporter {
             use_color: true,
-            show_mitre_grouping: false,
             show_hosts_breakdown: false,
-            collapse_findings: true,
+            render: FindingsRender::FlatCollapsed,
         }
     }
 
@@ -1808,9 +1804,8 @@ mod story_118 {
     fn mitre_collapse_reporter() -> TerminalReporter {
         TerminalReporter {
             use_color: false,
-            show_mitre_grouping: true,
             show_hosts_breakdown: false,
-            collapse_findings: true,
+            render: FindingsRender::Grouped,
         }
     }
 
@@ -3342,12 +3337,11 @@ mod story_118 {
             })
             .collect();
 
-        // Reporter with collapse_findings = true → produces "(x3)".
+        // Reporter with render = FindingsRender::FlatCollapsed → produces "(x3)".
         let reporter_on = TerminalReporter {
             use_color: false,
-            show_mitre_grouping: false,
             show_hosts_breakdown: false,
-            collapse_findings: true,
+            render: FindingsRender::FlatCollapsed,
         };
         let out_on = reporter_on.render(&Summary::new(), &findings, &[]);
         assert!(
@@ -3355,12 +3349,11 @@ mod story_118 {
             "BC-2.11.028 inv1: collapse_findings=true must produce '(x3)' suffix; got:\n{out_on}"
         );
 
-        // Reporter with collapse_findings = false → no collapse, no suffix.
+        // Reporter with render = FindingsRender::FlatExpanded → no collapse, no suffix.
         let reporter_off = TerminalReporter {
             use_color: false,
-            show_mitre_grouping: false,
             show_hosts_breakdown: false,
-            collapse_findings: false,
+            render: FindingsRender::FlatExpanded,
         };
         let out_off = reporter_off.render(&Summary::new(), &findings, &[]);
         assert!(
@@ -3944,5 +3937,166 @@ mod story_118 {
             "BC-2.11.026 supplementary: members[1] technique 'T1036' must not appear when \
              members[0].mitre_techniques=[]; got:\n{out}"
         );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// STORY-120 RED gate stubs
+//
+// These tests exercise new behaviors introduced by the FindingsRender enum
+// migration (STORY-120). All bodies are `todo!()` — they compile but panic
+// at runtime, satisfying the Red Gate density check (≥50% todo!() bodies).
+//
+// The implementer replaces each todo!() with real assertions during GREEN
+// after defining `pub enum FindingsRender { Grouped, FlatCollapsed,
+// FlatExpanded }` and updating `TerminalReporter` to use `render:
+// FindingsRender` in place of `show_mitre_grouping: bool` and
+// `collapse_findings: bool`.
+//
+// DO NOT reference the `FindingsRender` type here — it does not yet exist.
+// Construction sites remain as `todo!()` prose descriptions so the file
+// compiles against the current (pre-enum) struct shape.
+// ---------------------------------------------------------------------------
+
+mod story_120 {
+    // Inherit the allow(non_snake_case) from the file-level attribute so
+    // test_BC_* names compile without a separate inner attribute.
+    //
+    // Imports are unused now (todo!() bodies) but will be needed by the
+    // implementer during GREEN. Suppress the lint so the file remains clean
+    // under `cargo check --all-targets` with RUSTFLAGS=-Dwarnings.
+    #![allow(unused_imports)]
+
+    use wirerust::findings::{Confidence, Finding, ThreatCategory, Verdict};
+    use wirerust::reporter::Reporter;
+    use wirerust::reporter::terminal::TerminalReporter;
+    use wirerust::summary::Summary;
+
+    // -----------------------------------------------------------------------
+    // AC-001 — FindingsRender derives Debug, Clone, Copy, PartialEq, Eq
+    // (traces to BC-2.11.025 invariant 5, BC-2.11.013 invariant 4)
+    //
+    // Intended assertion (implementer fills in during GREEN):
+    //   - Confirm `FindingsRender` satisfies `Debug + Clone + Copy + PartialEq + Eq`
+    //     by asserting equality, cloning, and debug-formatting all three variants.
+    //   - Assert the enum has exactly three variants (Grouped, FlatCollapsed,
+    //     FlatExpanded) and that `Default` is NOT derived (no Default impl).
+    // -----------------------------------------------------------------------
+    #[test]
+    fn test_findings_render_derives_debug_clone_copy_partialeq_eq() {
+        // RED: FindingsRender does not exist yet — todo!() panics to satisfy Red Gate.
+        // GREEN: replace with:
+        //   let a = FindingsRender::Grouped;
+        //   let b = a;                          // Copy
+        //   let c = a.clone();                  // Clone
+        //   assert_eq!(a, b);                   // PartialEq + Eq
+        //   let _ = format!("{a:?}");           // Debug
+        //   assert_ne!(a, FindingsRender::FlatCollapsed);
+        //   assert_ne!(a, FindingsRender::FlatExpanded);
+        todo!(
+            "AC-001: verify FindingsRender derives Debug+Clone+Copy+PartialEq+Eq \
+             and has exactly three variants; implement after enum is defined"
+        )
+    }
+
+    // -----------------------------------------------------------------------
+    // AC-002 — TerminalReporter struct has exactly 3 fields after refactor
+    // (traces to BC-2.11.028 precondition 3 — struct shape governs render wiring)
+    //
+    // Intended assertion (implementer fills in during GREEN):
+    //   - Construct TerminalReporter with exactly {use_color, show_hosts_breakdown,
+    //     render} and verify it compiles (struct-literal exhaustiveness is the gate).
+    //   - Assert that neither `show_mitre_grouping` nor `collapse_findings` appear
+    //     as fields (any reference to them is a compile error after STORY-120).
+    // -----------------------------------------------------------------------
+    #[test]
+    fn test_BC_2_11_028_struct_has_exactly_three_fields_post_refactor() {
+        // RED: the struct still has four bool fields; the intended three-field
+        // construction (with render: FindingsRender) does not compile yet.
+        // GREEN: replace with a TerminalReporter literal using only:
+        //   use_color, show_hosts_breakdown, render: FindingsRender::FlatExpanded
+        // and assert that cargo check passes (the compile itself is the assertion).
+        todo!(
+            "AC-002: verify TerminalReporter has exactly 3 fields \
+             (use_color, show_hosts_breakdown, render: FindingsRender); \
+             implement after struct is refactored"
+        )
+    }
+
+    // -----------------------------------------------------------------------
+    // AC-003 — Dispatch is an exhaustive match over FindingsRender
+    // (traces to BC-2.11.019 invariant 7)
+    //
+    // Intended assertion (implementer fills in during GREEN):
+    //   - Render through all three FindingsRender variants with the same input
+    //     and assert each reaches the correct rendering path:
+    //       Grouped      → output contains "## " tactic header (grouped path)
+    //       FlatCollapsed → output contains "(x3)" suffix for N=3 identical findings
+    //       FlatExpanded  → output does NOT contain "(x" and has 3 individual lines
+    //   - Relies on exhaustive match compile-time guarantee (no arm can be omitted).
+    // -----------------------------------------------------------------------
+    #[test]
+    fn test_BC_2_11_019_findings_dispatch_match_exhaustive() {
+        // RED: FindingsRender does not exist; todo!() panics to satisfy Red Gate.
+        // GREEN: replace with three reporter constructions using each variant
+        // and behavioral assertions for each rendering path.
+        todo!(
+            "AC-003: verify all three FindingsRender arms are reachable and route \
+             to the correct rendering helper; implement after match dispatch is added"
+        )
+    }
+
+    // -----------------------------------------------------------------------
+    // AC-004 — Impossible state (Grouped + collapsed simultaneously)
+    //          is structurally unrepresentable after STORY-120
+    // (traces to BC-2.11.025 invariant 5)
+    //
+    // Intended assertion (implementer fills in during GREEN):
+    //   - Confirm that `FindingsRender::Grouped` on N=100 identical-key findings
+    //     produces NO "(xN)" suffix anywhere in the output (collapse path not
+    //     reachable from the Grouped arm — the impossible state is gone by type).
+    //   - This corresponds to the former `mitre_collapse_reporter` construction
+    //     (show_mitre_grouping=true, collapse_findings=true) which now maps to
+    //     render: FindingsRender::Grouped cleanly.
+    // -----------------------------------------------------------------------
+    #[test]
+    fn test_BC_2_11_025_grouped_mode_bypasses_collapse_structurally() {
+        // RED: FindingsRender does not exist; todo!() panics to satisfy Red Gate.
+        // GREEN: construct TerminalReporter { render: FindingsRender::Grouped, ... },
+        // render 100 identical-key findings, and assert no "(x" suffix appears.
+        todo!(
+            "AC-004: verify FindingsRender::Grouped never emits (xN) suffix — \
+             impossible state (Grouped + collapsed) is structurally unrepresentable; \
+             implement after enum and match dispatch are in place"
+        )
+    }
+
+    // -----------------------------------------------------------------------
+    // AC-005 — run_analyze construction site wired correctly in main.rs
+    // (traces to BC-2.11.028 postconditions 1–2, invariant 1)
+    //
+    // Intended assertion (implementer fills in during GREEN):
+    //   - Using FindingsRender::FlatCollapsed (collapse ON) vs FindingsRender::FlatExpanded
+    //     (collapse OFF) on N=3 identical-key findings produces different output
+    //     (FlatCollapsed emits "(x3)", FlatExpanded does not) — proving the render
+    //     field is wired correctly to the rendering path.
+    //   - This mirrors the run_analyze wiring intent:
+    //       render: if show_mitre_grouping { Grouped }
+    //               else if collapse_findings { FlatCollapsed }
+    //               else { FlatExpanded }
+    //   - Structural polarity test: FlatCollapsed != FlatExpanded output.
+    // -----------------------------------------------------------------------
+    #[test]
+    fn test_BC_2_11_028_flag_wired_to_render_field_post_enum() {
+        // RED: FindingsRender does not exist; todo!() panics to satisfy Red Gate.
+        // GREEN: construct two reporters — one with render: FindingsRender::FlatCollapsed
+        // and one with render: FindingsRender::FlatExpanded — render N=3 identical
+        // findings, and assert FlatCollapsed produces "(x3)" while FlatExpanded does not.
+        // Also assert the two outputs differ (polarity test mirrors run_analyze wiring).
+        todo!(
+            "AC-005: verify render: FindingsRender::FlatCollapsed produces collapse \
+             and FlatExpanded does not — proving the run_analyze wiring intent; \
+             implement after enum construction sites are updated"
+        )
     }
 }

--- a/tests/reporter_terminal_tests.rs
+++ b/tests/reporter_terminal_tests.rs
@@ -4347,16 +4347,16 @@ mod story_120 {
 }
 
 // ---------------------------------------------------------------------------
-// STORY-122 RED gate tests
+// STORY-122 acceptance-gate tests
 //
 // These tests lock in the STORY-122 acceptance criteria for the
 // FindingsRender enum→struct reshape (Option X). The stub-architect
 // (commit dec8a55) reshaped the types and migrated the 84 construction
 // sites; these tests verify both the completed mechanical migration and
-// the remaining Task-4 comment-sweep work.
+// the completed Task-4 comment-sweep work.
 //
-// Tests tied to UNFINISHED work (Task 4 comment sweep) are RED on this
-// commit. Tests for already-complete type/dispatch/wiring work are GREEN.
+// All tasks complete on this commit; every test below is GREEN and serves
+// as a regression guard.
 //
 // DF-TEST-NAMESPACE-001: per-story mod wrapper.
 // ---------------------------------------------------------------------------
@@ -4841,7 +4841,7 @@ mod story_122 {
 
     /// AC-006 (BC-2.11.013 Invariant 4):
     /// {Grouped, Expanded} (--mitre alone in STORY-122/A) produces the same
-    /// output as the old FindingsRender::Grouped enum variant:
+    /// output as the old grouped (suffix-free) variant:
     /// tactic headers present, no (xN) suffix, byte-identical across the reshape.
     #[test]
     fn test_BC_2_11_028_ac006_grouped_expanded_byte_identical_to_old_grouped_variant() {
@@ -4877,7 +4877,7 @@ mod story_122 {
 
     /// AC-006 (BC-2.11.026 Postcondition 4, BC-2.11.027 Postcondition 1):
     /// {Flat, Collapsed} (default in STORY-122/A) produces the same output as
-    /// the old FindingsRender::FlatCollapsed: (xN) suffix for N≥2, up to K=3
+    /// the old flat-collapsed path: (xN) suffix for N≥2, up to K=3
     /// evidence lines, MITRE line for non-empty mitre_techniques.
     #[test]
     fn test_BC_2_11_028_ac006_flat_collapsed_byte_identical_to_old_flatcollapsed_variant() {
@@ -4924,7 +4924,7 @@ mod story_122 {
 
     /// AC-006 (BC-2.11.013 Invariant 4):
     /// {Flat, Expanded} (--no-collapse in STORY-122/A) produces the same output
-    /// as the old FindingsRender::FlatExpanded: 3 individual lines, no (xN) suffix.
+    /// as the old flat-expanded path: 3 individual lines, no (xN) suffix.
     #[test]
     fn test_BC_2_11_028_ac006_flat_expanded_byte_identical_to_old_flatexpanded_variant() {
         let findings: Vec<Finding> = (0..3).map(|_| make_finding_s122("s122-ac006-fe")).collect();
@@ -4959,9 +4959,9 @@ mod story_122 {
     // assert that the stale prose tokens listed in the STORY-122 Task-4
     // Falsifiable Requirements are absent.
     //
-    // RED: These tests FAIL on this commit because Task 4 (comment sweep)
-    // has not been performed yet by the implementer. The grep gate values
-    // match STORY-122 AC-007 / Task-4 Falsifiable Requirements (3) and (4).
+    // REGRESSION GUARD: Task 4 comment sweep is complete; these tests assert
+    // the swept targets stay free of stale FindingsRender enum vocabulary.
+    // The grep gate values match STORY-122 AC-007 / Task-4 Falsifiable Requirements (3) and (4).
     //
     // EXEMPT: The pattern "three fields" is NOT in the gate (exempt:
     // TerminalReporter-field prose at reporter_terminal_tests.rs:4040).
@@ -5217,6 +5217,63 @@ mod story_122 {
             evidence_line_count >= 1,
             "AC-008: {{Flat,Collapsed}} with evidence-bearing findings must emit \
              at least 1 evidence line; got {evidence_line_count} in:\n{out}"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // AC-003 — Zero-grep gate: no stale FindingsRender::{Grouped,FlatCollapsed,FlatExpanded}
+    // tokens in src/ or tests/
+    // (traces to BC-2.11.028 AC-003; AC-007 extended the gate to doc-comments)
+    // -----------------------------------------------------------------------
+
+    /// AC-003 / AC-007 (BC-2.11.028 Invariant 6):
+    /// REGRESSION GUARD: No stale `FindingsRender::{Grouped,FlatCollapsed,FlatExpanded}`
+    /// tokens exist anywhere in src/main.rs, src/reporter/terminal.rs, or this test file.
+    /// These tokens are the removed enum-variant paths from the pre-STORY-122 type.
+    /// The gate tokens are built with `concat!` so this source file does not self-trigger.
+    #[test]
+    fn test_BC_2_11_028_ac003_no_stale_findingsrender_variant_tokens() {
+        let sources: &[(&str, &str)] = &[
+            ("src/main.rs", include_str!("../src/main.rs")),
+            (
+                "src/reporter/terminal.rs",
+                include_str!("../src/reporter/terminal.rs"),
+            ),
+            (
+                "tests/reporter_terminal_tests.rs",
+                include_str!("../tests/reporter_terminal_tests.rs"),
+            ),
+        ];
+
+        // Tokens are built with concat! so this source file does not self-trigger the gate.
+        let banned_tokens: &[&str] = &[
+            concat!("FindingsRender", "::", "Grouped"),
+            concat!("FindingsRender", "::", "FlatCollapsed"),
+            concat!("FindingsRender", "::", "FlatExpanded"),
+        ];
+
+        let mut violations: Vec<String> = Vec::new();
+        for (label, src) in sources {
+            for (line_no, line) in src.lines().enumerate() {
+                for token in banned_tokens {
+                    if line.contains(token) {
+                        violations.push(format!(
+                            "  {}:{}: {:?} (token: {:?})",
+                            label,
+                            line_no + 1,
+                            line.trim(),
+                            token
+                        ));
+                    }
+                }
+            }
+        }
+
+        assert!(
+            violations.is_empty(),
+            "AC-003: stale FindingsRender enum-variant tokens found — \
+             Task 4 comment sweep or doc-comment cleanup is incomplete:\n{}",
+            violations.join("\n")
         );
     }
 }

--- a/tests/reporter_terminal_tests.rs
+++ b/tests/reporter_terminal_tests.rs
@@ -1812,8 +1812,10 @@ mod story_118 {
         }
     }
 
-    /// TerminalReporter with MITRE grouping and collapse both enabled (for AC-005).
-    fn mitre_collapse_reporter() -> TerminalReporter {
+    /// TerminalReporter with MITRE grouping ENABLED and collapse DISABLED
+    /// ({Grouped, Expanded}); used to prove grouped mode is structurally
+    /// suffix-free (no `(xN)` suffix regardless of collapse_findings setting).
+    fn mitre_expanded_reporter() -> TerminalReporter {
         TerminalReporter {
             use_color: false,
             show_hosts_breakdown: false,
@@ -2100,7 +2102,7 @@ mod story_118 {
             })
             .collect();
 
-        let out = mitre_collapse_reporter().render(&Summary::new(), &findings, &[]);
+        let out = mitre_expanded_reporter().render(&Summary::new(), &findings, &[]);
 
         // No (xN) suffix of any kind must appear.
         assert!(
@@ -3693,7 +3695,7 @@ mod story_118 {
             })
             .collect();
 
-        let out = mitre_collapse_reporter().render(&Summary::new(), &findings, &[]);
+        let out = mitre_expanded_reporter().render(&Summary::new(), &findings, &[]);
 
         // No (xN) suffix of any kind must appear anywhere in the output.
         assert!(
@@ -6189,6 +6191,15 @@ mod story_119 {
             out.contains("INCONCLUSIVE"),
             "BC-2.11.025 EC-007: Inconclusive group header must appear; got:\n{out}"
         );
+        // Both findings must render as separate group headers — neither merged nor
+        // dropped. Count `[Anomaly]` occurrences (one per header line in no-color
+        // output) to catch a drop-vs-merge bug that the (x2) check alone would miss.
+        assert_eq!(
+            out.matches("[Anomaly]").count(),
+            2,
+            "BC-2.11.025 EC-007: both findings must render as separate group headers \
+             (one `[Anomaly]` prefix each), not merged or dropped; got:\n{out}"
+        );
     }
 
     // -----------------------------------------------------------------------
@@ -6376,10 +6387,12 @@ mod story_119 {
             "AC-020: members[1] technique T1083 must be elided from terminal output; \
              got:\n{out}"
         );
-        // Group must be collapsed as N=2 (same bucket, same summary-only key).
+        // Group must be collapsed as N=2 (same bucket, same shared four-tuple
+        // collapse key: category=Anomaly, verdict=Likely, confidence=High,
+        // summary="s119-ac020-divergent-mitre").
         assert!(
             out.contains("(x2)"),
-            "AC-020: same-bucket same-summary findings must collapse to N=2; got:\n{out}"
+            "AC-020: same-bucket same-four-tuple-key findings must collapse to N=2; got:\n{out}"
         );
     }
 

--- a/tests/reporter_terminal_tests.rs
+++ b/tests/reporter_terminal_tests.rs
@@ -5277,3 +5277,1260 @@ mod story_122 {
         );
     }
 }
+
+// ============================================================================
+// mod story_119 — STORY-119/B: Grouped-Collapse Behavioral Delta
+// ============================================================================
+//
+// Tests for render_findings_grouped_collapsed (BC-2.11.031/032/033/034),
+// CLI mapping to {Grouped,Collapsed} (BC-2.11.030), and the per-bucket
+// collapse-not-global invariant (BC-2.11.025 Invariant 5).
+//
+// Namespace wrapper per DF-TEST-NAMESPACE-001: all test functions live inside
+// `mod story_119` so that identically-named siblings in sibling mods (e.g.
+// `test_BC_2_11_025_grouped_mode_bypasses_flat_collapse` vs the pre-existing
+// siblings in the outer scope) resolve without collision.
+//
+// Red Gate (BC-5.38.001): every test in this module exercises
+// `render_findings_grouped_collapsed`, which is a `todo!()` stub until the
+// GREEN phase. All tests panic at runtime — that is the expected RED signal.
+// ============================================================================
+mod story_119 {
+    use wirerust::findings::{Confidence, Finding, ThreatCategory, Verdict};
+    use wirerust::reporter::Reporter;
+    use wirerust::reporter::terminal::{Collapse, FindingsRender, Grouping, TerminalReporter};
+    use wirerust::summary::Summary;
+
+    // -----------------------------------------------------------------------
+    // Module-level helpers
+    // -----------------------------------------------------------------------
+
+    /// Returns a `TerminalReporter` wired to `{Grouped, Collapsed}` with
+    /// color and hosts-breakdown disabled. This is the canonical reporter for
+    /// all STORY-119/B grouped-collapse behavioral tests.
+    ///
+    /// Fields used: `use_color`, `show_hosts_breakdown`, `render` —
+    /// `TerminalReporter` has no `findings` field (STORY-119/B Previous Story
+    /// Intelligence lesson 3).
+    fn grouped_collapse_reporter() -> TerminalReporter {
+        TerminalReporter {
+            use_color: false,
+            show_hosts_breakdown: false,
+            render: FindingsRender {
+                grouping: Grouping::Grouped,
+                collapse: Collapse::Collapsed,
+            },
+        }
+    }
+
+    /// Returns a `TerminalReporter` wired to `{Grouped, Collapsed}` WITH
+    /// color enabled. Used by the color-ladder test (AC-008 / BC-2.11.031 PC-3).
+    fn grouped_collapse_reporter_color() -> TerminalReporter {
+        TerminalReporter {
+            use_color: true,
+            show_hosts_breakdown: false,
+            render: FindingsRender {
+                grouping: Grouping::Grouped,
+                collapse: Collapse::Collapsed,
+            },
+        }
+    }
+
+    /// Returns a `TerminalReporter` wired to `{Grouped, Expanded}` (the
+    /// `--mitre --no-collapse` path). Used to verify suffix-free behaviour and
+    /// byte-identical singleton output.
+    fn grouped_expanded_reporter() -> TerminalReporter {
+        TerminalReporter {
+            use_color: false,
+            show_hosts_breakdown: false,
+            render: FindingsRender {
+                grouping: Grouping::Grouped,
+                collapse: Collapse::Expanded,
+            },
+        }
+    }
+
+    /// Builds a minimal `Finding` with the given `summary`, no evidence, no
+    /// MITRE techniques, `Verdict::Likely`, `Confidence::High`.
+    fn make_finding_s119(summary: impl Into<String>) -> Finding {
+        Finding {
+            category: ThreatCategory::Anomaly,
+            verdict: Verdict::Likely,
+            confidence: Confidence::High,
+            summary: summary.into(),
+            evidence: vec![],
+            mitre_techniques: vec![],
+            source_ip: None,
+            timestamp: None,
+            direction: None,
+        }
+    }
+
+    /// Builds a `Finding` with a known MITRE technique T1046 (Discovery tactic).
+    /// T1046 → "Network Service Discovery" per `technique_info`.
+    fn make_discovery_finding_s119(summary: impl Into<String>) -> Finding {
+        Finding {
+            category: ThreatCategory::Anomaly,
+            verdict: Verdict::Likely,
+            confidence: Confidence::High,
+            summary: summary.into(),
+            evidence: vec![],
+            mitre_techniques: vec!["T1046".to_string()],
+            source_ip: None,
+            timestamp: None,
+            direction: None,
+        }
+    }
+
+    /// Builds a `Finding` with a known MITRE technique T1071 (Command and
+    /// Control tactic). T1071 → "Application Layer Protocol".
+    fn make_c2_finding_s119(summary: impl Into<String>) -> Finding {
+        Finding {
+            category: ThreatCategory::Anomaly,
+            verdict: Verdict::Likely,
+            confidence: Confidence::High,
+            summary: summary.into(),
+            evidence: vec![],
+            mitre_techniques: vec!["T1071".to_string()],
+            source_ip: None,
+            timestamp: None,
+            direction: None,
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // AC-001 — `--mitre` alone routes to {Grouped, Collapsed}
+    // (traces to BC-2.11.030 PC-2)
+    // -----------------------------------------------------------------------
+
+    /// AC-001 (BC-2.11.030 Postcondition 2):
+    /// REGRESSION GUARD: The `run_analyze` construction site produces
+    /// `FindingsRender { grouping: Grouping::Grouped, collapse: Collapse::Collapsed }`
+    /// when `show_mitre_grouping == true` and `collapse_findings == true`
+    /// (`--mitre` alone, default collapse enabled).
+    ///
+    /// Verified via the observable dispatch: a reporter constructed with
+    /// `{Grouped, Collapsed}` exercises `render_findings_grouped_collapsed`.
+    /// A FINDINGS section with grouped-collapse output appears in the rendered
+    /// string (tactic headers and `(xN)` suffix for N≥2 groups).
+    #[test]
+    fn test_BC_2_11_030_mitre_alone_maps_to_grouped_collapsed() {
+        // Construct the reporter exactly as run_analyze does when
+        // show_mitre_grouping=true, collapse_findings=true.
+        let render = FindingsRender {
+            grouping: if true { Grouping::Grouped } else { Grouping::Flat },
+            collapse: if true { Collapse::Collapsed } else { Collapse::Expanded },
+        };
+        assert_eq!(
+            render,
+            FindingsRender {
+                grouping: Grouping::Grouped,
+                collapse: Collapse::Collapsed,
+            },
+            "AC-001: --mitre alone (show_mitre_grouping=true, collapse_findings=true) \
+             must produce {{Grouped, Collapsed}}"
+        );
+
+        // Observable render: N=3 identical-key findings in one tactic bucket
+        // must produce a header with `(x3)` suffix — the grouped-collapse path.
+        let findings: Vec<Finding> = (0..3)
+            .map(|_| make_discovery_finding_s119("s119-ac001-mitre-collapse"))
+            .collect();
+        let out = TerminalReporter {
+            use_color: false,
+            show_hosts_breakdown: false,
+            render,
+        }
+        .render(&Summary::new(), &findings, &[]);
+        assert!(
+            out.contains("(x3)"),
+            "AC-001: {{Grouped,Collapsed}} with N=3 identical findings must emit \
+             `(x3)` suffix; got:\n{out}"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // AC-002 — `--mitre --no-collapse` routes to {Grouped, Expanded}
+    // (traces to BC-2.11.030 PC-3)
+    // -----------------------------------------------------------------------
+
+    /// AC-002 (BC-2.11.030 Postcondition 3):
+    /// REGRESSION GUARD: The `run_analyze` construction site produces
+    /// `FindingsRender { grouping: Grouping::Grouped, collapse: Collapse::Expanded }`
+    /// when `show_mitre_grouping == true` and `collapse_findings == false`
+    /// (`--mitre` with `--no-collapse`).
+    #[test]
+    fn test_BC_2_11_030_mitre_no_collapse_maps_to_grouped_expanded() {
+        let render = FindingsRender {
+            grouping: if true { Grouping::Grouped } else { Grouping::Flat },
+            collapse: if false { Collapse::Collapsed } else { Collapse::Expanded },
+        };
+        assert_eq!(
+            render,
+            FindingsRender {
+                grouping: Grouping::Grouped,
+                collapse: Collapse::Expanded,
+            },
+            "AC-002: --mitre --no-collapse (show_mitre_grouping=true, collapse_findings=false) \
+             must produce {{Grouped, Expanded}}"
+        );
+
+        // Observable render: {Grouped, Expanded} must not emit any `(xN)` suffix.
+        let findings: Vec<Finding> = (0..3)
+            .map(|_| make_discovery_finding_s119("s119-ac002-mitre-expanded"))
+            .collect();
+        let out = TerminalReporter {
+            use_color: false,
+            show_hosts_breakdown: false,
+            render,
+        }
+        .render(&Summary::new(), &findings, &[]);
+        assert!(
+            !out.contains("(x"),
+            "AC-002: {{Grouped,Expanded}} must not emit any `(xN)` suffix; got:\n{out}"
+        );
+        assert!(
+            out.contains("## "),
+            "AC-002: {{Grouped,Expanded}} must emit tactic headers; got:\n{out}"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // AC-003 — flat-mode routing unchanged at construction site
+    // (traces to BC-2.11.030 PC-4 and PC-5)
+    // -----------------------------------------------------------------------
+
+    /// AC-003 (BC-2.11.030 Postconditions 4 and 5):
+    /// REGRESSION GUARD: Flat-mode `FindingsRender` wiring at the `run_analyze`
+    /// construction site is unchanged.
+    ///
+    /// BC-2.11.030 PC-4: "When neither `--mitre` nor `--no-collapse` is present
+    /// (the default terminal output): `render == FindingsRender { grouping:
+    /// Grouping::Flat, collapse: Collapse::Collapsed }`. Unchanged from
+    /// pre-STORY-119 behavior."
+    ///
+    /// BC-2.11.030 PC-5: "When `--no-collapse` is present but `--mitre` is
+    /// absent: `render == FindingsRender { grouping: Grouping::Flat, collapse:
+    /// Collapse::Expanded }`. Unchanged from pre-STORY-119 behavior."
+    #[test]
+    fn test_BC_2_11_030_flat_routing_unchanged() {
+        // PC-4: default (no --mitre, no --no-collapse)
+        let default_render = FindingsRender {
+            grouping: if false { Grouping::Grouped } else { Grouping::Flat },
+            collapse: if true { Collapse::Collapsed } else { Collapse::Expanded },
+        };
+        assert_eq!(
+            default_render,
+            FindingsRender {
+                grouping: Grouping::Flat,
+                collapse: Collapse::Collapsed,
+            },
+            "AC-003 PC-4: default routing must produce {{Flat, Collapsed}}"
+        );
+
+        // PC-5: --no-collapse without --mitre
+        let no_collapse_flat_render = FindingsRender {
+            grouping: if false { Grouping::Grouped } else { Grouping::Flat },
+            collapse: if false { Collapse::Collapsed } else { Collapse::Expanded },
+        };
+        assert_eq!(
+            no_collapse_flat_render,
+            FindingsRender {
+                grouping: Grouping::Flat,
+                collapse: Collapse::Expanded,
+            },
+            "AC-003 PC-5: --no-collapse without --mitre must produce {{Flat, Expanded}}"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // AC-006 — per-bucket collapse: N≥2 group renders header with `(xN)` suffix
+    // (traces to BC-2.11.031 PC-1)
+    // -----------------------------------------------------------------------
+
+    /// AC-006 (BC-2.11.031 Postcondition 1):
+    /// REGRESSION GUARD: For a group of N=3 findings sharing the same collapse
+    /// key within a MITRE tactic bucket under `{Grouped, Collapsed}`, the header
+    /// line contains ` (x3)` — a space before the opening parenthesis, exact
+    /// decimal N, no leading zeros.
+    #[test]
+    fn test_BC_2_11_031_grouped_collapse_suffix_format() {
+        let findings: Vec<Finding> = (0..3)
+            .map(|_| make_discovery_finding_s119("s119-ac006-suffix"))
+            .collect();
+        let out = grouped_collapse_reporter().render(&Summary::new(), &findings, &[]);
+
+        // BC-2.11.031 PC-1: header line contains ` (x3)` suffix.
+        assert!(
+            out.contains("(x3)"),
+            "AC-006: N=3 group in bucket must emit `(x3)` suffix; got:\n{out}"
+        );
+        // Tactic header for Discovery must be present.
+        assert!(
+            out.contains("## Discovery"),
+            "AC-006: Discovery bucket header must appear; got:\n{out}"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // AC-007 — singleton (N=1) renders via render_finding_grouped, no suffix
+    // (traces to BC-2.11.031 PC-2)
+    // -----------------------------------------------------------------------
+
+    /// AC-007 (BC-2.11.031 Postcondition 2):
+    /// REGRESSION GUARD: A singleton finding (N=1 within a bucket) under
+    /// `{Grouped, Collapsed}` renders via `render_finding_grouped` with no
+    /// `(xN)` suffix — byte-identical to `{Grouped, Expanded}` for that finding.
+    #[test]
+    fn test_BC_2_11_031_singleton_no_suffix_in_bucket() {
+        let findings = vec![make_discovery_finding_s119("s119-ac007-singleton")];
+
+        let out_collapsed = grouped_collapse_reporter().render(&Summary::new(), &findings, &[]);
+        let out_expanded = grouped_expanded_reporter().render(&Summary::new(), &findings, &[]);
+
+        // BC-2.11.031 PC-2: singleton output is byte-identical to {Grouped, Expanded}.
+        assert_eq!(
+            out_collapsed, out_expanded,
+            "AC-007: singleton under {{Grouped,Collapsed}} must be byte-identical to \
+             {{Grouped,Expanded}}; outputs differ"
+        );
+        // No (xN) suffix anywhere in output.
+        assert!(
+            !out_collapsed.contains("(x"),
+            "AC-007: singleton must not emit any `(xN)` suffix; got:\n{out_collapsed}"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // AC-008 — color-ladder: `(xN)` suffix is part of the pre-colorization string
+    // (traces to BC-2.11.031 PC-3)
+    // -----------------------------------------------------------------------
+
+    /// AC-008 (BC-2.11.031 Postcondition 3):
+    /// REGRESSION GUARD: For a `Likely + High` group of N=2 under
+    /// `{Grouped, Collapsed}` with `use_color: true`, the ` (x2)` suffix
+    /// is inside the ANSI color span (i.e., it appears before the ANSI reset
+    /// sequence, not after it). Verified by asserting the suffix is NOT
+    /// preceded by an ANSI reset `\x1b[0m` in the output.
+    #[test]
+    fn test_BC_2_11_031_grouped_collapse_color_ladder() {
+        let findings: Vec<Finding> = (0..2)
+            .map(|_| Finding {
+                category: ThreatCategory::Anomaly,
+                verdict: Verdict::Likely,
+                confidence: Confidence::High,
+                summary: "s119-ac008-color".to_string(),
+                evidence: vec![],
+                mitre_techniques: vec!["T1046".to_string()],
+                source_ip: None,
+                timestamp: None,
+                direction: None,
+            })
+            .collect();
+        let out = grouped_collapse_reporter_color().render(&Summary::new(), &findings, &[]);
+
+        // BC-2.11.031 PC-3: the suffix must appear in the output.
+        assert!(
+            out.contains("(x2)"),
+            "AC-008: N=2 group with color must still emit `(x2)` suffix; got:\n{out}"
+        );
+        // The ANSI reset sequence (\x1b[0m) must NOT appear BEFORE `(x2)` on
+        // the same header line. Verify by checking that `(x2)` does not appear
+        // after a reset on the header line.
+        let header_line = out
+            .lines()
+            .find(|l| l.contains("(x2)"))
+            .unwrap_or_default();
+        // Split by reset: if (x2) appears in the LAST segment (after reset),
+        // the suffix was appended after the ANSI reset — NON-CONFORMANT.
+        let reset = "\x1b[0m";
+        let after_reset = header_line
+            .rfind(reset)
+            .map(|pos| &header_line[pos + reset.len()..])
+            .unwrap_or("");
+        assert!(
+            !after_reset.contains("(x2)"),
+            "AC-008: `(x2)` must be inside the ANSI color span (before reset), \
+             not after the reset sequence. Header line: {header_line:?}"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // AC-009 — `(xN)` suffix NOT on MITRE line, evidence lines, or bucket headers
+    // (traces to BC-2.11.031 PC-4)
+    // -----------------------------------------------------------------------
+
+    /// AC-009 (BC-2.11.031 Postcondition 4):
+    /// REGRESSION GUARD: The ` (xN)` suffix appears ONLY on the finding-group
+    /// header line. It must not appear on the MITRE line (`    MITRE: ...`),
+    /// evidence lines (`    > ...`), or the tactic bucket header (`  ## ...`).
+    #[test]
+    fn test_BC_2_11_031_suffix_only_on_header_not_mitre_or_evidence() {
+        let findings: Vec<Finding> = (0..3)
+            .map(|_| Finding {
+                category: ThreatCategory::Anomaly,
+                verdict: Verdict::Likely,
+                confidence: Confidence::High,
+                summary: "s119-ac009-no-suffix-leak".to_string(),
+                evidence: vec!["evidence-line".to_string()],
+                mitre_techniques: vec!["T1046".to_string()],
+                source_ip: None,
+                timestamp: None,
+                direction: None,
+            })
+            .collect();
+        let out = grouped_collapse_reporter().render(&Summary::new(), &findings, &[]);
+
+        // `(x3)` must appear somewhere in output.
+        assert!(
+            out.contains("(x3)"),
+            "AC-009: N=3 group must emit `(x3)` suffix; got:\n{out}"
+        );
+
+        // `(xN)` must NOT appear on any MITRE line, evidence line, or bucket header.
+        for line in out.lines() {
+            let trimmed = line.trim_start();
+            if trimmed.starts_with("MITRE:") {
+                assert!(
+                    !line.contains("(x"),
+                    "AC-009: `(xN)` must not appear on MITRE line: {line:?}"
+                );
+            }
+            if trimmed.starts_with("> ") {
+                assert!(
+                    !line.contains("(x"),
+                    "AC-009: `(xN)` must not appear on evidence line: {line:?}"
+                );
+            }
+            if trimmed.starts_with("## ") {
+                assert!(
+                    !line.contains("(x"),
+                    "AC-009: `(xN)` must not appear on tactic bucket header: {line:?}"
+                );
+            }
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // AC-010 — cross-bucket suffix independence
+    // (traces to BC-2.11.031 PC-6)
+    // -----------------------------------------------------------------------
+
+    /// AC-010 (BC-2.11.031 Postcondition 6):
+    /// REGRESSION GUARD: Two groups with the same collapse key but in different
+    /// MITRE tactic buckets produce independent `(xN)` suffixes. A group of 3
+    /// in the Discovery bucket (T1046) and a group of 2 in the Command and
+    /// Control bucket (T1071) produce `(x3)` and `(x2)` respectively — never
+    /// merged to `(x5)`.
+    #[test]
+    fn test_BC_2_11_031_cross_bucket_suffix_independence() {
+        // 3 findings with same summary → Discovery bucket (T1046).
+        let mut findings: Vec<Finding> = (0..3)
+            .map(|_| Finding {
+                category: ThreatCategory::Anomaly,
+                verdict: Verdict::Likely,
+                confidence: Confidence::High,
+                summary: "s119-ac010-shared-key".to_string(),
+                evidence: vec![],
+                mitre_techniques: vec!["T1046".to_string()],
+                source_ip: None,
+                timestamp: None,
+                direction: None,
+            })
+            .collect();
+        // 2 findings with same summary → Command and Control bucket (T1071).
+        findings.extend((0..2).map(|_| Finding {
+            category: ThreatCategory::Anomaly,
+            verdict: Verdict::Likely,
+            confidence: Confidence::High,
+            summary: "s119-ac010-shared-key".to_string(),
+            evidence: vec![],
+            mitre_techniques: vec!["T1071".to_string()],
+            source_ip: None,
+            timestamp: None,
+            direction: None,
+        }));
+
+        let out = grouped_collapse_reporter().render(&Summary::new(), &findings, &[]);
+
+        // Each bucket must produce its own independent suffix.
+        assert!(
+            out.contains("(x3)"),
+            "AC-010: Discovery bucket (3 findings) must emit `(x3)`; got:\n{out}"
+        );
+        assert!(
+            out.contains("(x2)"),
+            "AC-010: C&C bucket (2 findings) must emit `(x2)`; got:\n{out}"
+        );
+        // No cross-bucket merge to (x5).
+        assert!(
+            !out.contains("(x5)"),
+            "AC-010: cross-bucket merge must not occur — `(x5)` must not appear; got:\n{out}"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // AC-011 — per-bucket evidence sampling: at most K=3 lines per N≥2 group
+    // (traces to BC-2.11.032 PC-1)
+    // -----------------------------------------------------------------------
+
+    /// AC-011 (BC-2.11.032 Postconditions 1–2):
+    /// REGRESSION GUARD: For a collapsed group of N=5 in a tactic bucket, each
+    /// member with one evidence line, the terminal output contains at most K=3
+    /// evidence lines (`    > ` prefix).
+    #[test]
+    fn test_BC_2_11_032_evidence_sampling_k3_in_bucket() {
+        let findings: Vec<Finding> = (0..5)
+            .map(|i| Finding {
+                category: ThreatCategory::Anomaly,
+                verdict: Verdict::Likely,
+                confidence: Confidence::High,
+                summary: "s119-ac011-k3-evidence".to_string(),
+                evidence: vec![format!("ev-{i}")],
+                mitre_techniques: vec!["T1046".to_string()],
+                source_ip: None,
+                timestamp: None,
+                direction: None,
+            })
+            .collect();
+
+        let out = grouped_collapse_reporter().render(&Summary::new(), &findings, &[]);
+
+        let evidence_count = out
+            .lines()
+            .filter(|l| l.trim_start().starts_with("> "))
+            .count();
+        assert!(
+            evidence_count <= 3,
+            "AC-011: K=3 evidence cap — at most 3 evidence lines; got {evidence_count} in:\n{out}"
+        );
+        assert!(
+            evidence_count >= 1,
+            "AC-011: at least 1 evidence line expected from evidence-bearing group; \
+             got {evidence_count} in:\n{out}"
+        );
+        // `(x5)` suffix must be present (group of 5).
+        assert!(
+            out.contains("(x5)"),
+            "AC-011: N=5 group must emit `(x5)` suffix; got:\n{out}"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // AC-011 edge — no sliding window: empty-evidence member blocks window
+    // (traces to BC-2.11.032 Invariant 2)
+    // -----------------------------------------------------------------------
+
+    /// AC-011 edge (BC-2.11.032 Invariant 2):
+    /// REGRESSION GUARD: For a group of N=5, `members[0].evidence = []` (empty),
+    /// `members[1..4]` each have one evidence line. The positional window
+    /// inspects members[0], [1], [2] — member[0] contributes 0 lines (no
+    /// sliding), members[1] and [2] each contribute 1 line. Total = 2 evidence
+    /// lines; NOT 3.
+    #[test]
+    fn test_BC_2_11_032_evidence_positional_no_slide() {
+        // members[0]: no evidence.
+        let mut findings = vec![Finding {
+            category: ThreatCategory::Anomaly,
+            verdict: Verdict::Likely,
+            confidence: Confidence::High,
+            summary: "s119-ac011b-no-slide".to_string(),
+            evidence: vec![],
+            mitre_techniques: vec!["T1046".to_string()],
+            source_ip: None,
+            timestamp: None,
+            direction: None,
+        }];
+        // members[1..4]: each with one evidence line.
+        findings.extend((1..5).map(|i| Finding {
+            category: ThreatCategory::Anomaly,
+            verdict: Verdict::Likely,
+            confidence: Confidence::High,
+            summary: "s119-ac011b-no-slide".to_string(),
+            evidence: vec![format!("ev-{i}")],
+            mitre_techniques: vec!["T1046".to_string()],
+            source_ip: None,
+            timestamp: None,
+            direction: None,
+        }));
+
+        let out = grouped_collapse_reporter().render(&Summary::new(), &findings, &[]);
+
+        // Window inspects members[0..min(5,3)=3]. members[0]: 0 lines; [1] and [2]: 1 each.
+        let evidence_count = out
+            .lines()
+            .filter(|l| l.trim_start().starts_with("> "))
+            .count();
+        assert_eq!(
+            evidence_count, 2,
+            "AC-011 edge: positional no-slide — members[0] empty, window=[0,1,2], \
+             expected 2 evidence lines; got {evidence_count} in:\n{out}"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // AC-013 — tactic-bucket ordering invariant under {Grouped, Collapsed}
+    // (traces to BC-2.11.033 PC-1 / VP-016)
+    // -----------------------------------------------------------------------
+
+    /// AC-013 (BC-2.11.033 Postconditions 1–2 / VP-016):
+    /// REGRESSION GUARD: Tactic bucket headers appear in the order returned by
+    /// `all_tactics_in_report_order()` under `{Grouped, Collapsed}`. Discovery
+    /// (index 8) appears before Command and Control (index 11) in the output.
+    #[test]
+    fn test_BC_2_11_033_grouped_collapsed_preserves_bucket_order() {
+        // Findings in two tactics in reverse order to confirm sorted output.
+        let mut findings: Vec<Finding> = (0..2)
+            .map(|_| make_c2_finding_s119("s119-ac013-c2")) // C&C = later bucket
+            .collect();
+        findings.extend((0..2).map(|_| make_discovery_finding_s119("s119-ac013-disc"))); // Discovery = earlier
+
+        let out = grouped_collapse_reporter().render(&Summary::new(), &findings, &[]);
+
+        let disc_pos = out.find("## Discovery");
+        let c2_pos = out.find("## Command and Control");
+
+        assert!(
+            disc_pos.is_some(),
+            "AC-013: Discovery bucket header must appear; got:\n{out}"
+        );
+        assert!(
+            c2_pos.is_some(),
+            "AC-013: Command and Control bucket header must appear; got:\n{out}"
+        );
+        assert!(
+            disc_pos.unwrap() < c2_pos.unwrap(),
+            "AC-013: Discovery (index 8) must appear before Command and Control (index 11) \
+             per all_tactics_in_report_order(); got:\n{out}"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // AC-014 — `Uncategorized` emitted last under {Grouped, Collapsed}
+    // (traces to BC-2.11.033 PC-3)
+    // -----------------------------------------------------------------------
+
+    /// AC-014 (BC-2.11.033 Postcondition 3):
+    /// REGRESSION GUARD: The `Uncategorized` bucket header appears last among
+    /// emitted buckets under `{Grouped, Collapsed}`.
+    #[test]
+    fn test_BC_2_11_033_uncategorized_last_under_grouped_collapse() {
+        // One finding in Discovery, two uncategorized (no mitre_techniques).
+        let mut findings = vec![make_discovery_finding_s119("s119-ac014-disc")];
+        findings.extend((0..2).map(|_| make_finding_s119("s119-ac014-uncategorized")));
+
+        let out = grouped_collapse_reporter().render(&Summary::new(), &findings, &[]);
+
+        let disc_pos = out.find("## Discovery");
+        let uncat_pos = out.find("## Uncategorized");
+
+        assert!(
+            disc_pos.is_some(),
+            "AC-014: Discovery bucket header must appear; got:\n{out}"
+        );
+        assert!(
+            uncat_pos.is_some(),
+            "AC-014: Uncategorized bucket header must appear; got:\n{out}"
+        );
+        assert!(
+            disc_pos.unwrap() < uncat_pos.unwrap(),
+            "AC-014: Uncategorized must appear after Discovery — Uncategorized is last; \
+             got:\n{out}"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // AC-015 — bucket membership unchanged by collapse
+    // (traces to BC-2.11.033 PC-4)
+    // -----------------------------------------------------------------------
+
+    /// AC-015 (BC-2.11.033 Postcondition 4):
+    /// REGRESSION GUARD: A finding assigned to the Discovery bucket under
+    /// `{Grouped, Expanded}` is assigned to the same bucket under `{Grouped,
+    /// Collapsed}`. The collapse key is orthogonal to bucket assignment.
+    #[test]
+    fn test_BC_2_11_033_different_buckets_not_cross_collapsed() {
+        // Two findings with the same summary but different MITRE techniques
+        // (different buckets). They must NOT be cross-collapsed.
+        let findings = vec![
+            Finding {
+                category: ThreatCategory::Anomaly,
+                verdict: Verdict::Likely,
+                confidence: Confidence::High,
+                summary: "s119-ac015-same-key".to_string(),
+                evidence: vec![],
+                mitre_techniques: vec!["T1046".to_string()], // Discovery
+                source_ip: None,
+                timestamp: None,
+                direction: None,
+            },
+            Finding {
+                category: ThreatCategory::Anomaly,
+                verdict: Verdict::Likely,
+                confidence: Confidence::High,
+                summary: "s119-ac015-same-key".to_string(),
+                evidence: vec![],
+                mitre_techniques: vec!["T1071".to_string()], // C&C
+                source_ip: None,
+                timestamp: None,
+                direction: None,
+            },
+        ];
+
+        let out = grouped_collapse_reporter().render(&Summary::new(), &findings, &[]);
+
+        // Both bucket headers must appear (two separate buckets, not merged).
+        assert!(
+            out.contains("## Discovery"),
+            "AC-015: Discovery bucket header must appear (same key, different tactic); \
+             got:\n{out}"
+        );
+        assert!(
+            out.contains("## Command and Control"),
+            "AC-015: C&C bucket header must appear (same key, different tactic); got:\n{out}"
+        );
+        // No cross-bucket merge: `(x2)` must NOT appear (each bucket has only 1).
+        assert!(
+            !out.contains("(x2)"),
+            "AC-015: cross-bucket collapse must not occur — `(x2)` must not appear; \
+             got:\n{out}"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // AC-016 / AC-017 — sort-then-collapse: post-sort order determines representative
+    // (traces to BC-2.11.033 PC-5/6)
+    // -----------------------------------------------------------------------
+
+    /// AC-016/AC-017 (BC-2.11.033 Postconditions 5 and 6):
+    /// REGRESSION GUARD: Within a bucket, findings are sorted by verdict-rank
+    /// ascending (Likely=0, Possible=1, Inconclusive=2, Unlikely=3) BEFORE the
+    /// collapse pass. The lower-rank (higher-severity) finding becomes
+    /// `members[0]` (the group representative).
+    ///
+    /// Test: two findings with the same collapse key in one bucket —
+    /// one `Likely` (rank=0) and one `Inconclusive` (rank=2). The `Likely`
+    /// finding sorts first → becomes `members[0]` → its fields appear in the
+    /// header. The header verdict must be "Likely", not "Inconclusive".
+    #[test]
+    fn test_BC_2_11_033_first_occurrence_in_sorted_bucket_order() {
+        let findings = vec![
+            // Submitted second but sorts first by verdict-rank.
+            Finding {
+                category: ThreatCategory::Anomaly,
+                verdict: Verdict::Inconclusive, // rank=2
+                confidence: Confidence::Low,
+                summary: "s119-ac016-sort-key".to_string(),
+                evidence: vec![],
+                mitre_techniques: vec!["T1046".to_string()],
+                source_ip: None,
+                timestamp: None,
+                direction: None,
+            },
+            // Submitted first but sorts second.
+            Finding {
+                category: ThreatCategory::Anomaly,
+                verdict: Verdict::Likely, // rank=0 — sorts first
+                confidence: Confidence::High,
+                summary: "s119-ac016-sort-key".to_string(),
+                evidence: vec![],
+                mitre_techniques: vec!["T1046".to_string()],
+                source_ip: None,
+                timestamp: None,
+                direction: None,
+            },
+        ];
+
+        let out = grouped_collapse_reporter().render(&Summary::new(), &findings, &[]);
+
+        // `(x2)` suffix must appear (N=2 group).
+        assert!(
+            out.contains("(x2)"),
+            "AC-016: N=2 group in bucket must emit `(x2)` suffix; got:\n{out}"
+        );
+
+        // The header verdict must be "Likely" (the sorted-first representative),
+        // not "Inconclusive". Find the header line (contains `(x2)`).
+        let header_line = out
+            .lines()
+            .find(|l| l.contains("(x2)"))
+            .unwrap_or_default();
+        assert!(
+            header_line.contains("Likely"),
+            "AC-016: post-sort representative must be Likely (rank=0 sorts first); \
+             header line: {header_line:?}\nfull output:\n{out}"
+        );
+        assert!(
+            !header_line.contains("Inconclusive"),
+            "AC-016: Inconclusive (rank=2) must NOT be the representative; \
+             header line: {header_line:?}\nfull output:\n{out}"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // AC-018 / AC-021 — MITRE line from members[0] with em-dash format
+    // (traces to BC-2.11.034 PC-1 and PC-5)
+    // -----------------------------------------------------------------------
+
+    /// AC-018 / AC-021 (BC-2.11.034 Postconditions 1 and 5):
+    /// REGRESSION GUARD: For a collapsed N≥2 group, the MITRE line is rendered
+    /// from `group_members[0].mitre_techniques` using em-dash expansion
+    /// (U+2014, not ASCII `--`). The observable line format is:
+    /// `    MITRE: T1046 — Network Service Discovery`.
+    ///
+    /// Output block order: (1) header with `(xN)`, (2) evidence lines,
+    /// (3) MITRE line. The `(xN)` suffix appears ONLY in item (1).
+    #[test]
+    fn test_BC_2_11_034_grouped_collapse_mitre_line_em_dash_format() {
+        let findings: Vec<Finding> = (0..2)
+            .map(|_| Finding {
+                category: ThreatCategory::Anomaly,
+                verdict: Verdict::Likely,
+                confidence: Confidence::High,
+                summary: "s119-ac018-mitre-em-dash".to_string(),
+                evidence: vec![],
+                mitre_techniques: vec!["T1046".to_string()],
+                source_ip: None,
+                timestamp: None,
+                direction: None,
+            })
+            .collect();
+
+        let out = grouped_collapse_reporter().render(&Summary::new(), &findings, &[]);
+
+        // BC-2.11.034 PC-1: em-dash (U+2014) + name on MITRE line.
+        assert!(
+            out.contains("T1046 \u{2014} Network Service Discovery"),
+            "AC-018: MITRE line must use em-dash (U+2014) + name from members[0]; got:\n{out}"
+        );
+        // `(x2)` suffix on header.
+        assert!(
+            out.contains("(x2)"),
+            "AC-018: header must carry `(x2)` suffix; got:\n{out}"
+        );
+        // Block order: header (with `(x2)`) must appear before MITRE line.
+        let header_pos = out.find("(x2)").unwrap_or(usize::MAX);
+        let mitre_pos = out.find("MITRE: T1046").unwrap_or(usize::MAX);
+        assert!(
+            header_pos < mitre_pos,
+            "AC-021: header (with `(x2)`) must appear before MITRE line; got:\n{out}"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // AC-018 edge — unknown technique in collapsed group
+    // (traces to BC-2.11.034 PC-1 unknown-ID branch)
+    // -----------------------------------------------------------------------
+
+    /// AC-018 edge (BC-2.11.034 Postcondition 1 — unknown ID):
+    /// REGRESSION GUARD: For a collapsed N≥2 group where `members[0]` has an
+    /// unknown technique ID, the MITRE line format is
+    /// `    MITRE: <ids_joined> (unknown)` — not an em-dash expansion.
+    #[test]
+    fn test_BC_2_11_034_unknown_technique_in_grouped_collapse() {
+        let findings: Vec<Finding> = (0..2)
+            .map(|_| Finding {
+                category: ThreatCategory::Anomaly,
+                verdict: Verdict::Likely,
+                confidence: Confidence::High,
+                summary: "s119-ac018b-unknown-tech".to_string(),
+                evidence: vec![],
+                mitre_techniques: vec!["T9999".to_string()], // unknown ID
+                source_ip: None,
+                timestamp: None,
+                direction: None,
+            })
+            .collect();
+
+        let out = grouped_collapse_reporter().render(&Summary::new(), &findings, &[]);
+
+        assert!(
+            out.contains("(x2)"),
+            "AC-018 edge: N=2 group with unknown technique must emit `(x2)` suffix; \
+             got:\n{out}"
+        );
+        assert!(
+            out.contains("T9999 (unknown)"),
+            "AC-018 edge: unknown technique ID must produce `(unknown)` format on MITRE line; \
+             got:\n{out}"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // AC-019 — `(xN)` suffix NOT on MITRE line for N≥2 groups
+    // (traces to BC-2.11.034 PC-2)
+    // -----------------------------------------------------------------------
+
+    /// AC-019 (BC-2.11.034 Postcondition 2):
+    /// REGRESSION GUARD: The `(xN)` count suffix does not appear on the MITRE
+    /// line for N≥2 collapsed groups. The suffix is scoped to the header line
+    /// only (verified together with AC-009).
+    #[test]
+    fn test_BC_2_11_034_suffix_not_on_mitre_line() {
+        let findings: Vec<Finding> = (0..3)
+            .map(|_| make_discovery_finding_s119("s119-ac019-no-suffix-mitre"))
+            .collect();
+
+        let out = grouped_collapse_reporter().render(&Summary::new(), &findings, &[]);
+
+        // `(x3)` must appear (on header).
+        assert!(
+            out.contains("(x3)"),
+            "AC-019: `(x3)` must appear in output; got:\n{out}"
+        );
+        // The MITRE line must not contain any `(xN)`.
+        for line in out.lines() {
+            if line.trim_start().starts_with("MITRE:") {
+                assert!(
+                    !line.contains("(x"),
+                    "AC-019: `(xN)` must not appear on MITRE line: {line:?}"
+                );
+            }
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // AC-020 — divergent MITRE: only members[0] appears in terminal output
+    // (traces to BC-2.11.034 PC-3)
+    // -----------------------------------------------------------------------
+
+    /// AC-020 (BC-2.11.034 Postcondition 3):
+    /// REGRESSION GUARD: For a collapsed group of N≥2 where members have
+    /// divergent `mitre_techniques`, only `members[0]`'s technique appears on
+    /// the MITRE line. The other members' techniques are elided from terminal
+    /// output (preserved in raw findings for JSON/CSV).
+    #[test]
+    fn test_BC_2_11_034_divergent_mitre_representative_sourcing() {
+        // Two findings with same collapse key but different MITRE techniques.
+        // After sort (Likely rank=0 for both, same confidence), the first
+        // submitted becomes members[0] (stable emission-index tiebreak).
+        let findings = vec![
+            Finding {
+                category: ThreatCategory::Anomaly,
+                verdict: Verdict::Likely,
+                confidence: Confidence::High,
+                summary: "s119-ac020-divergent-mitre".to_string(),
+                evidence: vec![],
+                mitre_techniques: vec!["T1046".to_string()], // members[0]
+                source_ip: None,
+                timestamp: None,
+                direction: None,
+            },
+            Finding {
+                category: ThreatCategory::Anomaly,
+                verdict: Verdict::Likely,
+                confidence: Confidence::High,
+                summary: "s119-ac020-divergent-mitre".to_string(),
+                evidence: vec![],
+                mitre_techniques: vec!["T1071".to_string()], // members[1] — must be elided
+                source_ip: None,
+                timestamp: None,
+                direction: None,
+            },
+        ];
+
+        let out = grouped_collapse_reporter().render(&Summary::new(), &findings, &[]);
+
+        // members[0]'s technique must appear on the MITRE line.
+        assert!(
+            out.contains("T1046"),
+            "AC-020: members[0] technique T1046 must appear in terminal output; got:\n{out}"
+        );
+        // members[1]'s technique must NOT appear in terminal output.
+        assert!(
+            !out.contains("T1071"),
+            "AC-020: members[1] technique T1071 must be elided from terminal output; \
+             got:\n{out}"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // AC-022 — {Grouped, Expanded} suffix-free guarantee unchanged
+    // (traces to BC-2.11.013 Invariant 4)
+    // -----------------------------------------------------------------------
+
+    /// AC-022 (BC-2.11.013 Invariant 4):
+    /// REGRESSION GUARD: Under `render = {Grouped, Expanded}`, N=100 identical-
+    /// key findings in a tactic bucket produce 100 individual finding lines with
+    /// no ` (xN)` suffix on any line. The `{Grouped, Expanded}` suffix-free
+    /// guarantee (pre-STORY-119 `--mitre` behavior) is unchanged.
+    #[test]
+    fn test_BC_2_11_028_no_collapse_with_mitre_produces_grouped_expanded() {
+        let findings: Vec<Finding> = (0..100)
+            .map(|_| make_discovery_finding_s119("s119-ac022-no-collapse-100"))
+            .collect();
+
+        let out = grouped_expanded_reporter().render(&Summary::new(), &findings, &[]);
+
+        // No `(xN)` suffix anywhere.
+        assert!(
+            !out.contains("(x"),
+            "AC-022: {{Grouped,Expanded}} with N=100 identical findings must emit zero \
+             `(xN)` suffixes; got excerpt:\n{}",
+            &out[..out.len().min(500)]
+        );
+        // All 100 findings must be rendered (header line count via `[Anomaly]`).
+        let header_count = out
+            .lines()
+            .filter(|l| l.contains("[Anomaly]"))
+            .count();
+        assert_eq!(
+            header_count, 100,
+            "AC-022: {{Grouped,Expanded}} must render all 100 findings; got {header_count} in \
+             output (first 500 chars):\n{}",
+            &out[..out.len().min(500)]
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // AC-023 — escape_for_terminal applied in grouped-collapse path
+    // (traces to BC-2.11.031 Precondition 5 / VP-012)
+    // -----------------------------------------------------------------------
+
+    /// AC-023 (BC-2.11.031 Precondition 5 / VP-012):
+    /// REGRESSION GUARD: `escape_for_terminal` is applied to all `summary` and
+    /// `evidence` strings in `render_findings_grouped_collapsed`. A summary
+    /// containing a C0 control character (U+0001) must not appear raw in the
+    /// output — it must be escaped to `\x01`.
+    #[test]
+    fn test_BC_2_11_031_escape_for_terminal_in_grouped_collapse_path() {
+        let findings: Vec<Finding> = (0..2)
+            .map(|_| Finding {
+                category: ThreatCategory::Anomaly,
+                verdict: Verdict::Likely,
+                confidence: Confidence::High,
+                // C0 control character in summary — must be escaped.
+                summary: "s119-ac023-\u{0001}escape".to_string(),
+                evidence: vec!["ev-\u{0001}escape".to_string()],
+                mitre_techniques: vec!["T1046".to_string()],
+                source_ip: None,
+                timestamp: None,
+                direction: None,
+            })
+            .collect();
+
+        let out = grouped_collapse_reporter().render(&Summary::new(), &findings, &[]);
+
+        // Raw U+0001 must NOT appear in the output.
+        assert!(
+            !out.contains('\u{0001}'),
+            "AC-023: raw C0 control char U+0001 must not appear in output — \
+             escape_for_terminal must be applied; got:\n{out:?}"
+        );
+        // The escaped form `\\x01` must appear in output (escaped).
+        assert!(
+            out.contains("\\x01"),
+            "AC-023: C0 char must be escaped to `\\x01` in output; got:\n{out:?}"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // AC-024 — collapse_findings_pass_refs called per bucket, not globally
+    // (traces to BC-2.11.033 Invariant 3 / BC-2.11.025 Invariant 5)
+    // -----------------------------------------------------------------------
+
+    /// AC-024 / test_BC_2_11_025_grouped_mode_bypasses_flat_collapse
+    /// (BC-2.11.025 Invariant 5 — updated; BC-2.11.033 Invariant 3):
+    /// REGRESSION GUARD: `render.grouping == Grouping::Grouped` with
+    /// `Collapse::Collapsed` uses per-bucket `collapse_findings_pass_refs`,
+    /// never the global flat `collapse_findings_pass` adapter. Observable
+    /// consequence: two findings with the same summary but in different tactic
+    /// buckets produce two separate group headers (one per bucket), not one
+    /// merged group of N=2.
+    ///
+    /// Note: this test is DISTINCT from the pre-existing siblings
+    /// `test_BC_2_11_025_grouped_mode_bypasses_collapse` (line ~2072) and
+    /// `test_BC_2_11_025_grouped_mode_bypasses_collapse_structurally` (line
+    /// ~4140) which verify the `{Grouped, Expanded}` path. This test verifies
+    /// the `{Grouped, Collapsed}` per-bucket invariant (BC-2.11.025 Inv5).
+    #[test]
+    fn test_BC_2_11_025_grouped_mode_bypasses_flat_collapse() {
+        // Same collapse key, different MITRE tactic → different buckets.
+        // A global flat collapse pass would merge them into one N=2 group.
+        // Per-bucket collapse must produce two separate singleton groups (N=1
+        // each) — neither emits `(x2)` and neither emits a cross-bucket header.
+        let findings = vec![
+            Finding {
+                category: ThreatCategory::Anomaly,
+                verdict: Verdict::Likely,
+                confidence: Confidence::High,
+                summary: "s119-ac024-per-bucket".to_string(),
+                evidence: vec![],
+                mitre_techniques: vec!["T1046".to_string()], // Discovery
+                source_ip: None,
+                timestamp: None,
+                direction: None,
+            },
+            Finding {
+                category: ThreatCategory::Anomaly,
+                verdict: Verdict::Likely,
+                confidence: Confidence::High,
+                summary: "s119-ac024-per-bucket".to_string(),
+                evidence: vec![],
+                mitre_techniques: vec!["T1071".to_string()], // C&C
+                source_ip: None,
+                timestamp: None,
+                direction: None,
+            },
+        ];
+
+        let out = grouped_collapse_reporter().render(&Summary::new(), &findings, &[]);
+
+        // Per-bucket pass: each bucket has N=1 → no `(x2)` suffix.
+        assert!(
+            !out.contains("(x2)"),
+            "AC-024: per-bucket collapse must not cross-collapse findings from different \
+             buckets — `(x2)` must not appear; got:\n{out}"
+        );
+        // Both bucket headers must appear (each bucket independently emitted).
+        assert!(
+            out.contains("## Discovery"),
+            "AC-024: Discovery bucket header must appear; got:\n{out}"
+        );
+        assert!(
+            out.contains("## Command and Control"),
+            "AC-024: C&C bucket header must appear; got:\n{out}"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // AC-025 — flat paths byte-identical
+    // (traces to BC-2.11.025 Invariant 5)
+    // -----------------------------------------------------------------------
+
+    /// AC-025 (BC-2.11.025 Invariant 5):
+    /// REGRESSION GUARD: The `{Flat, Collapsed}` arm calls `render_findings_collapsed`
+    /// and the `{Flat, Expanded}` arm calls the `render_finding_flat` loop —
+    /// both byte-identical to v0.9.0 behavior. Flat-mode tests are unaffected
+    /// by STORY-119/B. Verified here as a smoke check.
+    #[test]
+    fn test_BC_2_11_025_flat_paths_unchanged_by_story_119() {
+        let findings: Vec<Finding> = (0..3)
+            .map(|_| make_finding_s119("s119-ac025-flat-unchanged"))
+            .collect();
+
+        // {Flat, Collapsed} must emit at most 1 `(x3)` suffix (flat collapse).
+        let out_fc = TerminalReporter {
+            use_color: false,
+            show_hosts_breakdown: false,
+            render: FindingsRender {
+                grouping: Grouping::Flat,
+                collapse: Collapse::Collapsed,
+            },
+        }
+        .render(&Summary::new(), &findings, &[]);
+        assert!(
+            out_fc.contains("(x3)"),
+            "AC-025: {{Flat,Collapsed}} with N=3 identical findings must emit `(x3)`; \
+             got:\n{out_fc}"
+        );
+
+        // {Flat, Expanded} must emit zero `(xN)` suffixes.
+        let out_fe = TerminalReporter {
+            use_color: false,
+            show_hosts_breakdown: false,
+            render: FindingsRender {
+                grouping: Grouping::Flat,
+                collapse: Collapse::Expanded,
+            },
+        }
+        .render(&Summary::new(), &findings, &[]);
+        assert!(
+            !out_fe.contains("(x"),
+            "AC-025: {{Flat,Expanded}} must not emit any `(xN)` suffix; got:\n{out_fe}"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // AC-004 — run_summary construction site produces {Flat, Collapsed}
+    // (traces to BC-2.11.030 PC-6)
+    // -----------------------------------------------------------------------
+
+    /// AC-004 (BC-2.11.030 Postcondition 6):
+    /// REGRESSION GUARD: The `run_summary` construction site always produces
+    /// `FindingsRender { grouping: Grouping::Flat, collapse: Collapse::Collapsed }`.
+    /// Inert value semantics — `run_summary` renders no FINDINGS section; the
+    /// field is structurally present but irrelevant.
+    #[test]
+    fn test_BC_2_11_030_run_summary_produces_flat_collapsed() {
+        // Verify the literal struct value that run_summary uses.
+        let run_summary_render = FindingsRender {
+            grouping: Grouping::Flat,
+            collapse: Collapse::Collapsed,
+        };
+        assert_eq!(
+            run_summary_render,
+            FindingsRender {
+                grouping: Grouping::Flat,
+                collapse: Collapse::Collapsed,
+            },
+            "AC-004: run_summary render field must be {{Flat, Collapsed}}"
+        );
+        // This is a structural/value test — no dispatch exercised.
+    }
+
+    // -----------------------------------------------------------------------
+    // AC-005 — render_findings_grouped_collapsed function exists and dispatches
+    // (traces to BC-2.11.031 Architecture Anchors)
+    // -----------------------------------------------------------------------
+
+    /// AC-005 (BC-2.11.031 Architecture Anchors):
+    /// REGRESSION GUARD: `render_findings_grouped_collapsed` is dispatched for
+    /// the `(Grouping::Grouped, Collapse::Collapsed)` arm. Observable: a
+    /// `{Grouped, Collapsed}` reporter with N=1 finding renders the FINDINGS
+    /// section (non-empty FINDINGS block present) without panicking.
+    #[test]
+    fn test_BC_2_11_031_grouped_collapsed_arm_dispatches_to_new_function() {
+        let findings = vec![make_discovery_finding_s119("s119-ac005-dispatch")];
+        let out = grouped_collapse_reporter().render(&Summary::new(), &findings, &[]);
+
+        assert!(
+            out.contains("FINDINGS"),
+            "AC-005: {{Grouped,Collapsed}} must emit a FINDINGS section; got:\n{out}"
+        );
+        assert!(
+            out.contains("## Discovery"),
+            "AC-005: {{Grouped,Collapsed}} must bucket into Discovery tactic; got:\n{out}"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // EC-006 edge — members[0].mitre_techniques empty → no MITRE line
+    // (traces to AC-018 / BC-2.11.034 PC-1)
+    // -----------------------------------------------------------------------
+
+    /// EC-006 / AC-018 edge (BC-2.11.034 Postcondition 1):
+    /// REGRESSION GUARD: For a collapsed N≥2 group where `members[0].mitre_techniques`
+    /// is empty, no MITRE line is rendered — header + evidence only.
+    #[test]
+    fn test_BC_2_11_034_empty_mitre_techniques_no_mitre_line() {
+        // N=2 identical-key findings, no mitre_techniques → Uncategorized bucket.
+        let findings: Vec<Finding> = (0..2)
+            .map(|_| Finding {
+                category: ThreatCategory::Anomaly,
+                verdict: Verdict::Likely,
+                confidence: Confidence::High,
+                summary: "s119-ec006-empty-mitre".to_string(),
+                evidence: vec!["ev-ec006".to_string()],
+                mitre_techniques: vec![],
+                source_ip: None,
+                timestamp: None,
+                direction: None,
+            })
+            .collect();
+
+        let out = grouped_collapse_reporter().render(&Summary::new(), &findings, &[]);
+
+        // Header with `(x2)` must appear.
+        assert!(
+            out.contains("(x2)"),
+            "EC-006: N=2 group must emit `(x2)` suffix; got:\n{out}"
+        );
+        // No MITRE line must be present (empty mitre_techniques on members[0]).
+        assert!(
+            !out.contains("MITRE:"),
+            "EC-006: no MITRE line must appear when members[0].mitre_techniques is empty; \
+             got:\n{out}"
+        );
+    }
+}

--- a/tests/reporter_terminal_tests.rs
+++ b/tests/reporter_terminal_tests.rs
@@ -3967,9 +3967,9 @@ mod story_118 {
 // migration (STORY-120). All todo!() stubs have been replaced with real
 // assertions by the GREEN implementer.
 //
-// `TerminalReporter` now uses `render: FindingsRender` (a three-variant enum)
-// in place of the two removed bool fields. The FindingsRender enum is now
-// defined in src/reporter/terminal.rs and imported below.
+// `TerminalReporter` now uses `render: FindingsRender` (a struct-of-two-orthogonal-enums:
+// `Grouping` × `Collapse`) in place of the two removed bool fields. The FindingsRender
+// struct and its axis enums are defined in src/reporter/terminal.rs and imported below.
 // ---------------------------------------------------------------------------
 
 mod story_120 {
@@ -4173,10 +4173,11 @@ mod story_120 {
     // -----------------------------------------------------------------------
 
     /// AC-003 (BC-2.11.019 invariant 7):
-    /// All three FindingsRender arms are reachable and route to the correct rendering path.
-    ///   Grouped       → MITRE tactic header "## " in output
-    ///   FlatCollapsed → "(x3)" suffix for N=3 identical findings
-    ///   FlatExpanded  → 3 individual header lines, no "(x" suffix
+    /// All four FindingsRender (Grouping × Collapse) dispatch arms are reachable and route
+    /// to the correct rendering path. Three of the four combos are exercised here:
+    ///   {Grouped,Expanded}   → MITRE tactic header "## " in output
+    ///   {Flat,Collapsed}     → "(x3)" suffix for N=3 identical findings
+    ///   {Flat,Expanded}      → 3 individual header lines, no "(x" suffix
     #[test]
     fn test_BC_2_11_019_findings_dispatch_match_exhaustive() {
         // Three identical-key findings with a known MITRE technique for the Grouped path.
@@ -4236,7 +4237,7 @@ mod story_120 {
              found {header_count} in:\n{expanded_out}"
         );
 
-        // All three outputs are mutually distinct.
+        // All three tested outputs are mutually distinct (three of the four Grouping x Collapse combos).
         assert_ne!(
             grouped_out, collapsed_out,
             "AC-003: Grouped != FlatCollapsed output"
@@ -4252,14 +4253,15 @@ mod story_120 {
     }
 
     // -----------------------------------------------------------------------
-    // AC-004 — Impossible state (Grouped + collapsed) is structurally unrepresentable
+    // AC-004 — {Grouped, Expanded} mode does not emit collapse (xN) suffixes
     // (traces to BC-2.11.025 invariant 5)
     // -----------------------------------------------------------------------
 
     /// AC-004 (BC-2.11.025 invariant 5):
-    /// FindingsRender { grouping: Grouping::Grouped, collapse: Collapse::Expanded } on N=100 identical-key findings produces no "(xN)" suffix.
-    /// The impossible state (FindingsRender { grouping: Grouping::Grouped, collapse: Collapse::Expanded } + FlatCollapsed simultaneously) is
-    /// eliminated by type — FindingsRender { grouping: Grouping::Grouped, collapse: Collapse::Expanded } structurally excludes the collapse path.
+    /// FindingsRender { grouping: Grouping::Grouped, collapse: Collapse::Expanded } on N=100
+    /// identical-key findings produces no "(xN)" suffix. The {Grouped, Expanded} struct combo
+    /// routes to render_findings_grouped which never applies the collapse pass — the two axes
+    /// are orthogonal and all four combinations are valid (no combination is prohibited).
     #[test]
     fn test_BC_2_11_025_grouped_mode_bypasses_collapse_structurally() {
         let findings: Vec<Finding> = (0..100)
@@ -4279,7 +4281,7 @@ mod story_120 {
         assert!(
             !out.contains("(x"),
             "AC-004: FindingsRender {{ grouping: Grouping::Grouped, collapse: Collapse::Expanded }} must never emit (xN) suffix — \
-             impossible state is structurally unrepresentable; got:\n{out}"
+             the grouped path does not apply the collapse pass; got:\n{out}"
         );
         // Grouped mode emits tactic headers (confirming the Grouped path ran, not collapsed).
         assert!(
@@ -4360,7 +4362,6 @@ mod story_120 {
 // ---------------------------------------------------------------------------
 
 mod story_122 {
-    use std::path::Path;
     use wirerust::findings::{Confidence, Finding, ThreatCategory, Verdict};
     use wirerust::reporter::Reporter;
     use wirerust::reporter::terminal::{Collapse, FindingsRender, Grouping, TerminalReporter};
@@ -4969,15 +4970,18 @@ mod story_122 {
     // -----------------------------------------------------------------------
 
     /// AC-007 (BC-2.11.028 Invariant 6):
-    /// src/reporter/terminal.rs contains no stale "three mutually-exclusive" prose.
+    /// src/reporter/terminal.rs contains no stale pre-STORY-122 module-doc vocabulary
+    /// (the "three-modes" framing replaced by two-orthogonal-axis struct vocabulary).
     /// Gate 4 from STORY-122 Task-4 Falsifiable Requirements.
     #[test]
     fn test_BC_2_11_028_ac007_terminal_rs_no_three_mutually_exclusive() {
         let src = include_str!("../src/reporter/terminal.rs");
+        // Build token at runtime so this source file does not self-trigger the sweep gate.
+        let token = concat!("three", " mutually-exclusive");
         assert!(
-            !src.contains("three mutually-exclusive"),
-            "AC-007: src/reporter/terminal.rs must not contain stale 'three mutually-exclusive' \
-             prose; Task 4 comment sweep is incomplete"
+            !src.contains(token),
+            "AC-007: src/reporter/terminal.rs must not contain the stale two-axis framing token; \
+             Task 4 comment sweep is incomplete"
         );
     }
 
@@ -5000,15 +5004,15 @@ mod story_122 {
     }
 
     /// AC-007 (BC-2.11.028 Invariant 6):
-    /// tests/reporter_terminal_tests.rs contains no stale three-variant / three-arm /
-    /// three mutually-exclusive / All three FindingsRender / All three outputs /
-    /// impossible state prose in the swept targets.
+    /// tests/reporter_terminal_tests.rs contains no stale pre-STORY-122 FindingsRender
+    /// enum vocabulary (old variant names, old three-mode framing, old impossible-combo
+    /// framing) in the swept targets.
     /// Gate 3 from STORY-122 Task-4 Falsifiable Requirements.
     ///
     /// EXEMPT tokens NOT checked here:
-    ///   - "three fields" (TerminalReporter-field comment at :4040) — correct, not stale.
-    ///   - "All three boundary" (escape-boundary test at :394) — unrelated to FindingsRender.
-    ///   - "All three findings must appear" (test-finding count at :3512) — unrelated.
+    ///   - "three fields" (TerminalReporter-field comment) — correct, not stale.
+    ///   - "All three boundary" (escape-boundary test) — unrelated to FindingsRender.
+    ///   - "All three findings must appear" (test-finding count) — unrelated.
     #[test]
     fn test_BC_2_11_028_ac007_test_file_no_stale_findingsrender_prose() {
         let src = include_str!("../tests/reporter_terminal_tests.rs");
@@ -5023,16 +5027,17 @@ mod story_122 {
             "All three findings must appear",
         ];
 
+        // Tokens are built with concat! so this source file does not self-trigger the sweep.
         let stale_tokens: &[&str] = &[
-            "three-variant",
-            "three variants",
-            "All three FindingsRender",
-            "All three outputs",
-            "three arm",
-            "three-arm",
-            "three mutually-exclusive",
-            "three-way",
-            "impossible state",
+            concat!("three", "-variant"),
+            concat!("three", " variants"),
+            concat!("All three", " FindingsRender"),
+            concat!("All three", " outputs"),
+            concat!("three", " arm"),
+            concat!("three", "-arm"),
+            concat!("three", " mutually-exclusive"),
+            concat!("three", "-way"),
+            concat!("impossible", " state"),
         ];
 
         let mut violations: Vec<String> = Vec::new();
@@ -5063,17 +5068,18 @@ mod story_122 {
     }
 
     /// AC-007 (BC-2.11.028 Invariant 6):
-    /// src/main.rs contains no stale three-mutually-exclusive / three-way /
-    /// impossible-state / three-mode prose.
+    /// src/main.rs contains no stale pre-STORY-122 FindingsRender vocabulary
+    /// (old three-mode framing, old impossible-combo framing, old three-mode prose).
     /// Gate 4 (src/ targets) from STORY-122 Task-4 Falsifiable Requirements.
     #[test]
     fn test_BC_2_11_028_ac007_main_rs_no_stale_findingsrender_prose() {
         let src = include_str!("../src/main.rs");
+        // Tokens built with concat! so this source file does not self-trigger the sweep.
         for token in &[
-            "three mutually-exclusive",
-            "three-way",
-            "impossible state",
-            "three mode",
+            concat!("three", " mutually-exclusive"),
+            concat!("three", "-way"),
+            concat!("impossible", " state"),
+            concat!("three", " mode"),
         ] {
             assert!(
                 !src.contains(token),

--- a/tests/reporter_terminal_tests.rs
+++ b/tests/reporter_terminal_tests.rs
@@ -4685,10 +4685,14 @@ mod story_122 {
     // -----------------------------------------------------------------------
 
     /// AC-004 (BC-2.11.028 Invariant 1, EC-001):
-    /// --mitre alone (show_mitre_grouping=true) → run_analyze produces
-    /// FindingsRender { grouping: Grouping::Grouped, collapse: Collapse::Expanded }.
-    /// Routes to render_findings_grouped; tactic headers emitted; no (xN) suffix.
-    /// {Grouped, Collapsed} is NOT produced by run_analyze in STORY-122/A.
+    /// HISTORICAL REGRESSION GUARD (STORY-122/A era): in STORY-122/A, `--mitre` alone
+    /// produced `{Grouped, Expanded}`. This test asserts the struct value that
+    /// STORY-122/A's construction site emitted — preserved as a regression guard for
+    /// the STORY-122/A struct value only.
+    /// NOTE: Post-STORY-119/B, `--mitre` alone produces `{Grouped, Collapsed}` (the
+    /// CLI default was flipped by STORY-119/B Task 4). This test does NOT assert the
+    /// run_analyze CLI behavior after STORY-119/B — it asserts only the struct value
+    /// equality and that `{Grouped,Expanded}` ≠ `{Grouped,Collapsed}`.
     #[test]
     fn test_BC_2_11_028_ac004_mitre_alone_yields_grouped_expanded() {
         let findings: Vec<Finding> = (0..2)
@@ -4717,7 +4721,8 @@ mod story_122 {
             "AC-004: --mitre alone → {{Grouped,Expanded}} must not emit (xN) suffix; got:\n{out}"
         );
 
-        // {Grouped, Collapsed} is NOT what --mitre alone produces in STORY-122/A.
+        // {Grouped, Collapsed} is NOT what --mitre alone produced in STORY-122/A
+        // (post-STORY-119/B this IS the CLI default, but this test only asserts the struct values).
         let render_grouped_collapsed = FindingsRender {
             grouping: Grouping::Grouped,
             collapse: Collapse::Collapsed,
@@ -5302,9 +5307,9 @@ mod story_122 {
 // `test_BC_2_11_025_grouped_mode_bypasses_flat_collapse` vs the pre-existing
 // siblings in the outer scope) resolve without collision.
 //
-// Red Gate (BC-5.38.001): every test in this module exercises
-// `render_findings_grouped_collapsed`, which is a `todo!()` stub until the
-// GREEN phase. All tests panic at runtime — that is the expected RED signal.
+// Regression guard: every test in this module verifies BC-canonical behavior
+// of `render_findings_grouped_collapsed` and related helpers. A failing
+// assertion is the RED signal for the implementer to fix.
 // ============================================================================
 mod story_119 {
     use wirerust::findings::{Confidence, Finding, ThreatCategory, Verdict};
@@ -6045,35 +6050,53 @@ mod story_119 {
     /// AC-016/AC-017 (BC-2.11.033 Postconditions 5 and 6):
     /// REGRESSION GUARD: Within a bucket, findings are sorted by verdict-rank
     /// ascending (Likely=0, Possible=1, Inconclusive=2, Unlikely=3) BEFORE the
-    /// collapse pass. The lower-rank (higher-severity) finding becomes
-    /// `members[0]` (the group representative).
+    /// collapse pass. The lower-rank (higher-severity) finding becomes the group
+    /// representative.
     ///
-    /// Test: two findings with the same collapse key in one bucket —
-    /// one `Likely` (rank=0) and one `Inconclusive` (rank=2). The `Likely`
-    /// finding sorts first → becomes `members[0]` → its fields appear in the
-    /// header. The header verdict must be "Likely", not "Inconclusive".
+    /// Setup: three findings in the T1046 (Discovery) bucket.
+    ///   - Two share key (Anomaly, Likely, High, "s119-ac016-likely-finding"):
+    ///     they collapse to a N=2 group. The group representative is Likely.
+    ///   - One has key (Anomaly, Inconclusive, Low, "s119-ac016-inconclusive"):
+    ///     a singleton group. Sorts after the Likely group.
+    ///
+    /// Observable consequences:
+    ///   1. The N=2 group header shows `(x2)` suffix.
+    ///   2. The N=2 group header uses UPPERCASE verdict `LIKELY` (not title-case).
+    ///   3. The Likely group header appears before the Inconclusive singleton in output.
     #[test]
     fn test_BC_2_11_033_first_occurrence_in_sorted_bucket_order() {
         let findings = vec![
-            // Submitted second but sorts first by verdict-rank.
+            // Emitted first — Inconclusive/Low singleton.
             Finding {
                 category: ThreatCategory::Anomaly,
-                verdict: Verdict::Inconclusive, // rank=2
+                verdict: Verdict::Inconclusive, // rank=2 — sorts after Likely
                 confidence: Confidence::Low,
-                summary: "s119-ac016-sort-key".to_string(),
+                summary: "s119-ac016-inconclusive".to_string(),
                 evidence: vec![],
                 mitre_techniques: vec!["T1046".to_string()],
                 source_ip: None,
                 timestamp: None,
                 direction: None,
             },
-            // Submitted first but sorts second.
+            // Emitted second — first member of the Likely/High N=2 group.
             Finding {
                 category: ThreatCategory::Anomaly,
                 verdict: Verdict::Likely, // rank=0 — sorts first
                 confidence: Confidence::High,
-                summary: "s119-ac016-sort-key".to_string(),
-                evidence: vec![],
+                summary: "s119-ac016-likely-finding".to_string(),
+                evidence: vec!["ev-ac016-a".to_string()],
+                mitre_techniques: vec!["T1046".to_string()],
+                source_ip: None,
+                timestamp: None,
+                direction: None,
+            },
+            // Emitted third — second member of the Likely/High N=2 group (same key).
+            Finding {
+                category: ThreatCategory::Anomaly,
+                verdict: Verdict::Likely, // rank=0 — same key as above
+                confidence: Confidence::High,
+                summary: "s119-ac016-likely-finding".to_string(),
+                evidence: vec!["ev-ac016-b".to_string()],
                 mitre_techniques: vec!["T1046".to_string()],
                 source_ip: None,
                 timestamp: None,
@@ -6083,24 +6106,88 @@ mod story_119 {
 
         let out = grouped_collapse_reporter().render(&Summary::new(), &findings, &[]);
 
-        // `(x2)` suffix must appear (N=2 group).
+        // The Likely/High pair collapses to a N=2 group.
         assert!(
             out.contains("(x2)"),
             "AC-016: N=2 group in bucket must emit `(x2)` suffix; got:\n{out}"
         );
 
-        // The header verdict must be "Likely" (the sorted-first representative),
-        // not "Inconclusive". Find the header line (contains `(x2)`).
+        // The header verdict must use UPPERCASE Display format: `LIKELY`, not title-case.
         let header_line = out.lines().find(|l| l.contains("(x2)")).unwrap_or_default();
         assert!(
-            header_line.contains("Likely"),
-            "AC-016: post-sort representative must be Likely (rank=0 sorts first); \
+            header_line.contains("LIKELY"),
+            "AC-016: N=2 group header must use uppercase Display format `LIKELY`; \
              header line: {header_line:?}\nfull output:\n{out}"
         );
         assert!(
-            !header_line.contains("Inconclusive"),
-            "AC-016: Inconclusive (rank=2) must NOT be the representative; \
+            !header_line.contains("Likely"),
+            "AC-016: header must not contain title-case `Likely` — Display format is `LIKELY`; \
              header line: {header_line:?}\nfull output:\n{out}"
+        );
+
+        // Sort order: Likely group (rank=0) appears before Inconclusive singleton (rank=2).
+        let likely_pos = out.find("(x2)").unwrap_or(usize::MAX);
+        let inconclusive_pos = out.find("INCONCLUSIVE").unwrap_or(usize::MAX);
+        assert!(
+            likely_pos < inconclusive_pos,
+            "AC-017: Likely group (lower rank) must appear before Inconclusive singleton \
+             in sorted bucket order; got:\n{out}"
+        );
+    }
+
+    /// BC-2.11.025 EC-007/EC-008 grouped analogue:
+    /// REGRESSION GUARD: Two findings in the SAME tactic bucket with the SAME
+    /// summary but DIFFERENT verdict (or confidence, or category) must NOT be
+    /// merged — they have distinct four-tuple collapse keys and must render as
+    /// two separate group headers with NO `(xN)` suffix on either.
+    ///
+    /// This catches a summary-only (three-field) collapse key bug: if the
+    /// implementation keyed on summary alone, these two findings would be
+    /// incorrectly merged into one N=2 group.
+    #[test]
+    fn test_BC_2_11_025_distinct_verdict_same_summary_no_merge_in_bucket() {
+        // Same bucket (T1046 / Discovery), same summary, DIFFERENT verdict.
+        let findings = vec![
+            Finding {
+                category: ThreatCategory::Anomaly,
+                verdict: Verdict::Likely,
+                confidence: Confidence::High,
+                summary: "s119-ec007-same-summary".to_string(),
+                evidence: vec!["ev-likely".to_string()],
+                mitre_techniques: vec!["T1046".to_string()],
+                source_ip: None,
+                timestamp: None,
+                direction: None,
+            },
+            Finding {
+                category: ThreatCategory::Anomaly,
+                verdict: Verdict::Inconclusive,
+                confidence: Confidence::High,
+                summary: "s119-ec007-same-summary".to_string(), // identical summary
+                evidence: vec!["ev-inconclusive".to_string()],
+                mitre_techniques: vec!["T1046".to_string()],
+                source_ip: None,
+                timestamp: None,
+                direction: None,
+            },
+        ];
+
+        let out = grouped_collapse_reporter().render(&Summary::new(), &findings, &[]);
+
+        // Different verdict → different four-tuple keys → two distinct groups, no merge.
+        assert!(
+            !out.contains("(x2)"),
+            "BC-2.11.025 EC-007: same summary but different verdict must produce TWO distinct \
+             groups, not one N=2 merged group — `(x2)` must not appear; got:\n{out}"
+        );
+        // Both headers must appear independently.
+        assert!(
+            out.contains("LIKELY"),
+            "BC-2.11.025 EC-007: Likely group header must appear; got:\n{out}"
+        );
+        assert!(
+            out.contains("INCONCLUSIVE"),
+            "BC-2.11.025 EC-007: Inconclusive group header must appear; got:\n{out}"
         );
     }
 
@@ -6341,7 +6428,7 @@ mod story_119 {
     /// REGRESSION GUARD: `escape_for_terminal` is applied to all `summary` and
     /// `evidence` strings in `render_findings_grouped_collapsed`. A summary
     /// containing a C0 control character (U+0001) must not appear raw in the
-    /// output — it must be escaped to `\x01`.
+    /// output — it must be escaped via `char::escape_default` to `\u{1}`.
     #[test]
     fn test_BC_2_11_031_escape_for_terminal_in_grouped_collapse_path() {
         let findings: Vec<Finding> = (0..2)
@@ -6367,10 +6454,52 @@ mod story_119 {
             "AC-023: raw C0 control char U+0001 must not appear in output — \
              escape_for_terminal must be applied; got:\n{out:?}"
         );
-        // The escaped form `\\x01` must appear in output (escaped).
+        // The escaped form `\u{1}` must appear in output (char::escape_default output).
         assert!(
-            out.contains("\\x01"),
-            "AC-023: C0 char must be escaped to `\\x01` in output; got:\n{out:?}"
+            out.contains("\\u{1}"),
+            "AC-023: C0 char U+0001 must be escaped to `\\u{{1}}` via char::escape_default; \
+             got:\n{out:?}"
+        );
+    }
+
+    /// BC-2.11.032 EC-007 / VP canonical vector:
+    /// REGRESSION GUARD: Evidence strings in grouped-collapse bucket groups pass
+    /// through `escape_for_terminal`. A raw ESC byte (U+001B = 0x1B) in evidence
+    /// must be escaped via `char::escape_default` to `\u{1b}` in the output.
+    ///
+    /// Canonical test vector (BC-2.11.032 EC-007):
+    ///   evidence `"\x1b[31m"` → rendered as `> \u{1b}[31m` in the terminal.
+    #[test]
+    fn test_BC_2_11_032_escape_preserved_in_bucket_evidence() {
+        // N=2 group so both findings collapse; K=3 evidence cap not reached.
+        let findings: Vec<Finding> = (0..2)
+            .map(|i| Finding {
+                category: ThreatCategory::Anomaly,
+                verdict: Verdict::Likely,
+                confidence: Confidence::High,
+                summary: "s119-ec007-esc-evidence".to_string(),
+                // Raw ESC byte in ANSI sequence — must be escaped in output.
+                evidence: vec![format!("\x1b[31m-item-{i}")],
+                mitre_techniques: vec!["T1046".to_string()],
+                source_ip: None,
+                timestamp: None,
+                direction: None,
+            })
+            .collect();
+
+        let out = grouped_collapse_reporter().render(&Summary::new(), &findings, &[]);
+
+        // Raw ESC byte must NOT appear in the output.
+        assert!(
+            !out.contains('\x1b'),
+            "BC-2.11.032 EC-007: raw ESC byte must not appear in grouped-collapse evidence output; \
+             got:\n{out:?}"
+        );
+        // The ESC must be escaped via char::escape_default to `\u{1b}`.
+        assert!(
+            out.contains("\\u{1b}"),
+            "BC-2.11.032 EC-007: ESC byte in evidence must render as `\\u{{1b}}` \
+             (char::escape_default); got:\n{out:?}"
         );
     }
 

--- a/tests/reporter_terminal_tests.rs
+++ b/tests/reporter_terminal_tests.rs
@@ -4013,7 +4013,7 @@ mod story_120 {
 
     /// AC-001 (BC-2.11.025 invariant 5, BC-2.11.013 invariant 4):
     /// FindingsRender satisfies Debug + Clone + Copy + PartialEq + Eq.
-    /// The enum has exactly three variants and no Default impl.
+    /// The struct has exactly two fields: grouping: Grouping and collapse: Collapse. No Default impl.
     #[test]
     fn test_findings_render_derives_debug_clone_copy_partialeq_eq() {
         let a = FindingsRender {
@@ -4026,7 +4026,7 @@ mod story_120 {
         assert_eq!(a, c, "PartialEq + Eq: Grouped == cloned Grouped");
         let _ = format!("{a:?}"); // Debug — would panic if not implemented
 
-        // All three variants are distinct.
+        // All four Grouping x Collapse combinations are pairwise distinct.
         assert_ne!(
             FindingsRender {
                 grouping: Grouping::Grouped,
@@ -4036,7 +4036,7 @@ mod story_120 {
                 grouping: Grouping::Flat,
                 collapse: Collapse::Collapsed
             },
-            "Grouped != FlatCollapsed"
+            "{{Grouped,Expanded}} != {{Flat,Collapsed}}"
         );
         assert_ne!(
             FindingsRender {
@@ -4047,7 +4047,7 @@ mod story_120 {
                 grouping: Grouping::Flat,
                 collapse: Collapse::Expanded
             },
-            "Grouped != FlatExpanded"
+            "{{Grouped,Expanded}} != {{Flat,Expanded}}"
         );
         assert_ne!(
             FindingsRender {
@@ -4058,10 +4058,43 @@ mod story_120 {
                 grouping: Grouping::Flat,
                 collapse: Collapse::Expanded
             },
-            "FlatCollapsed != FlatExpanded"
+            "{{Flat,Collapsed}} != {{Flat,Expanded}}"
+        );
+        assert_ne!(
+            FindingsRender {
+                grouping: Grouping::Grouped,
+                collapse: Collapse::Expanded
+            },
+            FindingsRender {
+                grouping: Grouping::Grouped,
+                collapse: Collapse::Collapsed
+            },
+            "{{Grouped,Expanded}} != {{Grouped,Collapsed}}"
+        );
+        assert_ne!(
+            FindingsRender {
+                grouping: Grouping::Grouped,
+                collapse: Collapse::Collapsed
+            },
+            FindingsRender {
+                grouping: Grouping::Flat,
+                collapse: Collapse::Collapsed
+            },
+            "{{Grouped,Collapsed}} != {{Flat,Collapsed}}"
+        );
+        assert_ne!(
+            FindingsRender {
+                grouping: Grouping::Grouped,
+                collapse: Collapse::Collapsed
+            },
+            FindingsRender {
+                grouping: Grouping::Flat,
+                collapse: Collapse::Expanded
+            },
+            "{{Grouped,Collapsed}} != {{Flat,Expanded}}"
         );
 
-        // Debug formats include the variant name.
+        // Debug output for struct form includes field names and variant names.
         assert!(
             format!(
                 "{:?}",
@@ -4080,7 +4113,17 @@ mod story_120 {
                     collapse: Collapse::Collapsed
                 }
             )
-            .contains("FlatCollapsed")
+            .contains("Flat")
+        );
+        assert!(
+            format!(
+                "{:?}",
+                FindingsRender {
+                    grouping: Grouping::Flat,
+                    collapse: Collapse::Collapsed
+                }
+            )
+            .contains("Collapsed")
         );
         assert!(
             format!(
@@ -4090,7 +4133,7 @@ mod story_120 {
                     collapse: Collapse::Expanded
                 }
             )
-            .contains("FlatExpanded")
+            .contains("Expanded")
         );
     }
 

--- a/tests/reporter_terminal_tests.rs
+++ b/tests/reporter_terminal_tests.rs
@@ -6712,4 +6712,94 @@ mod story_119 {
              got:\n{out}"
         );
     }
+
+    // -----------------------------------------------------------------------
+    // F6-FINDING-1 — confidence_rank secondary sort key on grouped/collapsed path
+    // (traces to BC-2.11.033 PC-6 / BC-2.11.014)
+    // -----------------------------------------------------------------------
+
+    /// F6-FINDING-1 (BC-2.11.033 Postcondition 6 / BC-2.11.014):
+    /// REGRESSION GUARD: Two findings in the SAME tactic bucket with the SAME
+    /// verdict but DIFFERENT confidence must appear in `confidence_rank` order
+    /// (High before Low, i.e. rank-0 before rank-2) when rendered through the
+    /// `{Grouped, Collapsed}` path.
+    ///
+    /// The existing `test_BC_2_11_033_first_occurrence_in_sorted_bucket_order`
+    /// varies VERDICT only (Likely vs Inconclusive). This test fixes the gap by
+    /// keeping verdict constant (Likely/Likely) and varying CONFIDENCE
+    /// (High vs Low). Both findings are singletons (distinct summaries) so they
+    /// produce two separate group headers — the order of those headers is
+    /// entirely determined by the `confidence_rank` secondary sort key.
+    ///
+    /// FAIL mode: if `confidence_rank` is removed from the `sort_by_key` lambda
+    /// in `render_findings_grouped_collapsed` (terminal.rs:~534), the two
+    /// singletons sort by emission index only, meaning the Low-confidence finding
+    /// (inserted first) would appear before the High-confidence one — inverting
+    /// the expected order and failing the positional assertion below.
+    #[test]
+    fn test_BC_2_11_033_confidence_rank_secondary_sort_same_verdict_grouped_collapsed() {
+        // Two findings: same verdict (Likely), same bucket (T1046/Discovery),
+        // DIFFERENT confidence. Low is inserted first (index 0) so that removing
+        // `confidence_rank` from sort_by_key would put it first, inverting order.
+        let findings = vec![
+            Finding {
+                category: ThreatCategory::Anomaly,
+                verdict: Verdict::Likely,
+                confidence: Confidence::Low, // rank=2 — must sort AFTER High
+                summary: "s119-f6find1-low-confidence".to_string(),
+                evidence: vec![],
+                mitre_techniques: vec!["T1046".to_string()],
+                source_ip: None,
+                timestamp: None,
+                direction: None,
+            },
+            Finding {
+                category: ThreatCategory::Anomaly,
+                verdict: Verdict::Likely,
+                confidence: Confidence::High, // rank=0 — must sort FIRST
+                summary: "s119-f6find1-high-confidence".to_string(),
+                evidence: vec![],
+                mitre_techniques: vec!["T1046".to_string()],
+                source_ip: None,
+                timestamp: None,
+                direction: None,
+            },
+        ];
+
+        let out = grouped_collapse_reporter().render(&Summary::new(), &findings, &[]);
+
+        // Both headers must be present (singletons — no (xN) suffix on either).
+        assert!(
+            out.contains("s119-f6find1-high-confidence"),
+            "F6-FINDING-1: High-confidence finding must appear in output; got:\n{out}"
+        );
+        assert!(
+            out.contains("s119-f6find1-low-confidence"),
+            "F6-FINDING-1: Low-confidence finding must appear in output; got:\n{out}"
+        );
+        // Neither is a group of N≥2: no (xN) suffix expected.
+        assert!(
+            !out.contains("(x"),
+            "F6-FINDING-1: both findings are singletons; no (xN) suffix expected; got:\n{out}"
+        );
+
+        // Core assertion: High-confidence (rank=0) must appear BEFORE
+        // Low-confidence (rank=2) in the rendered output.
+        // If confidence_rank is removed from sort_by_key, the Low-confidence
+        // finding (emission index 0) would appear first — this assertion fails.
+        let high_pos = out
+            .find("s119-f6find1-high-confidence")
+            .expect("high-confidence finding must be in output");
+        let low_pos = out
+            .find("s119-f6find1-low-confidence")
+            .expect("low-confidence finding must be in output");
+        assert!(
+            high_pos < low_pos,
+            "F6-FINDING-1 (BC-2.11.033 PC-6 / BC-2.11.014): High-confidence finding \
+             (confidence_rank=0) must appear before Low-confidence (confidence_rank=2) \
+             in the grouped-collapsed output. This assertion fails when `confidence_rank` \
+             is removed from the sort_by_key lambda in render_findings_grouped_collapsed.\n\
+             high_pos={high_pos}, low_pos={low_pos}\nfull output:\n{out}"
+        );
+    }
 }

--- a/tests/reporter_terminal_tests.rs
+++ b/tests/reporter_terminal_tests.rs
@@ -42,7 +42,7 @@ use wirerust::analyzer::AnalysisSummary;
 use wirerust::decoder::{ParsedPacket, Protocol, TransportInfo};
 use wirerust::findings::{Confidence, Finding, ThreatCategory, Verdict};
 use wirerust::reporter::Reporter;
-use wirerust::reporter::terminal::{FindingsRender, TerminalReporter};
+use wirerust::reporter::terminal::{Collapse, FindingsRender, Grouping, TerminalReporter};
 use wirerust::summary::Summary;
 
 // ---------------------------------------------------------------------------
@@ -71,7 +71,7 @@ fn plain_reporter() -> TerminalReporter {
     TerminalReporter {
         use_color: false,
         show_hosts_breakdown: false,
-        render: FindingsRender::FlatExpanded,
+        render: FindingsRender { grouping: Grouping::Flat, collapse: Collapse::Expanded },
     }
 }
 
@@ -661,7 +661,7 @@ mod story_078 {
         TerminalReporter {
             use_color: false,
             show_hosts_breakdown: false,
-            render: FindingsRender::Grouped,
+            render: FindingsRender { grouping: Grouping::Grouped, collapse: Collapse::Expanded },
         }
     }
 
@@ -691,7 +691,7 @@ mod story_078 {
     // -----------------------------------------------------------------------
 
     /// AC-001 (BC-2.11.013 postcondition 2):
-    /// When `render = FindingsRender::Grouped`, tactic section headers appear in the
+    /// When `render = FindingsRender { grouping: Grouping::Grouped, collapse: Collapse::Expanded }`, tactic section headers appear in the
     /// order returned by `all_tactics_in_report_order()`.  Only sections with at
     /// least one finding are emitted.
     ///
@@ -1006,7 +1006,7 @@ mod story_078 {
     // -----------------------------------------------------------------------
 
     /// AC-008 (BC-2.11.016 postcondition 1):
-    /// When `render = FindingsRender::Grouped` and a finding has a known technique ID
+    /// When `render = FindingsRender { grouping: Grouping::Grouped, collapse: Collapse::Expanded }` and a finding has a known technique ID
     /// (e.g., "T1036"), the MITRE line reads `MITRE: T1036 \u{2014} Masquerading`
     /// (U+2014 em-dash, not ASCII "--").
     ///
@@ -1081,7 +1081,7 @@ mod story_078 {
     // -----------------------------------------------------------------------
 
     /// AC-010 (BC-2.11.017 postcondition 1):
-    /// When `render != FindingsRender::Grouped` (FlatExpanded or FlatCollapsed), a finding
+    /// When `render != FindingsRender { grouping: Grouping::Grouped, collapse: Collapse::Expanded }` (FlatExpanded or FlatCollapsed), a finding
     /// with `mitre_technique = "T1036"` produces the MITRE line `MITRE: T1036`
     /// with no em-dash, no technique name, and no `(unknown)` label.
     ///
@@ -1102,7 +1102,7 @@ mod story_078 {
             Confidence::High,
             Some("T1036"),
         );
-        // Use plain_reporter() (render=FindingsRender::FlatExpanded).
+        // Use plain_reporter() (render=FindingsRender { grouping: Grouping::Flat, collapse: Collapse::Expanded }).
         let out = plain_reporter().render(&Summary::new(), &[f], &[]);
 
         // Bare MITRE ID must be present.
@@ -1787,7 +1787,7 @@ mod story_118 {
         TerminalReporter {
             use_color: false,
             show_hosts_breakdown: false,
-            render: FindingsRender::FlatCollapsed,
+            render: FindingsRender { grouping: Grouping::Flat, collapse: Collapse::Collapsed },
         }
     }
 
@@ -1796,7 +1796,7 @@ mod story_118 {
         TerminalReporter {
             use_color: true,
             show_hosts_breakdown: false,
-            render: FindingsRender::FlatCollapsed,
+            render: FindingsRender { grouping: Grouping::Flat, collapse: Collapse::Collapsed },
         }
     }
 
@@ -1805,7 +1805,7 @@ mod story_118 {
         TerminalReporter {
             use_color: false,
             show_hosts_breakdown: false,
-            render: FindingsRender::Grouped,
+            render: FindingsRender { grouping: Grouping::Grouped, collapse: Collapse::Expanded },
         }
     }
 
@@ -2060,7 +2060,7 @@ mod story_118 {
         );
     }
 
-    /// AC-005: render=FindingsRender::Grouped suppresses collapse; no (xN) suffix anywhere.
+    /// AC-005: render=FindingsRender { grouping: Grouping::Grouped, collapse: Collapse::Expanded } suppresses collapse; no (xN) suffix anywhere.
     ///
     /// This guards the invariant that grouped (--mitre) mode is structurally
     /// suffix-free. FAILS if a future change applies the collapse pass inside
@@ -2070,7 +2070,7 @@ mod story_118 {
     /// that grouped mode does not).
     #[test]
     fn test_BC_2_11_025_grouped_mode_bypasses_collapse() {
-        // BC-2.11.025 invariant 5: when render=FindingsRender::Grouped, collapse does NOT run.
+        // BC-2.11.025 invariant 5: when render=FindingsRender { grouping: Grouping::Grouped, collapse: Collapse::Expanded }, collapse does NOT run.
         // 100 identical-key findings in mitre+collapse reporter → no (xN) suffix.
         let findings: Vec<Finding> = (0..100)
             .map(|_| {
@@ -2382,7 +2382,7 @@ mod story_118 {
             vec![],
         );
 
-        // Collapse reporter (render=FindingsRender::FlatCollapsed) with a single finding.
+        // Collapse reporter (render=FindingsRender { grouping: Grouping::Flat, collapse: Collapse::Collapsed }) with a single finding.
         let out_collapse =
             collapse_reporter().render(&Summary::new(), std::slice::from_ref(&f), &[]);
 
@@ -2392,7 +2392,7 @@ mod story_118 {
             "BC-2.11.026 pc2/inv2: singleton must render with no (xN) suffix; got:\n{out_collapse}"
         );
 
-        // Output must be byte-identical to the pre-v0.8.0 path (render=FindingsRender::FlatExpanded).
+        // Output must be byte-identical to the pre-v0.8.0 path (render=FindingsRender { grouping: Grouping::Flat, collapse: Collapse::Expanded }).
         let out_no_collapse = plain_reporter().render(&Summary::new(), &[f], &[]);
         assert_eq!(
             out_collapse, out_no_collapse,
@@ -3210,14 +3210,14 @@ mod story_118 {
 
     /// AC-018 (part 1): --no-collapse restores one-line-per-finding; no (xN) suffix.
     ///
-    /// This guards the opt-out path: with render=FindingsRender::FlatExpanded, 5 identical-key
+    /// This guards the opt-out path: with render=FindingsRender { grouping: Grouping::Flat, collapse: Collapse::Expanded }, 5 identical-key
     /// findings render as 5 individual header lines. Also includes a contrast assertion
     /// that the collapse path (render_findings_collapsed) is implemented — verified by
-    /// checking that render=FindingsRender::FlatCollapsed produces a different (collapsed) result.
+    /// checking that render=FindingsRender { grouping: Grouping::Flat, collapse: Collapse::Collapsed } produces a different (collapsed) result.
     /// FAILS if FlatExpanded collapses, or if render_findings_collapsed is not yet implemented.
     #[test]
     fn test_BC_2_11_028_no_collapse_flag_one_line_per_finding() {
-        // BC-2.11.028 pc2: render=FindingsRender::FlatExpanded → one header per finding, no suffix.
+        // BC-2.11.028 pc2: render=FindingsRender { grouping: Grouping::Flat, collapse: Collapse::Expanded } → one header per finding, no suffix.
         let findings: Vec<Finding> = (0..5)
             .map(|_| {
                 make_collapse_finding(
@@ -3231,7 +3231,7 @@ mod story_118 {
             })
             .collect();
 
-        // plain_reporter() has render=FindingsRender::FlatExpanded.
+        // plain_reporter() has render=FindingsRender { grouping: Grouping::Flat, collapse: Collapse::Expanded }.
         let out = plain_reporter().render(&Summary::new(), &findings, &[]);
 
         // 5 individual header lines, not 1 collapsed group.
@@ -3248,7 +3248,7 @@ mod story_118 {
             "BC-2.11.028 pc2: collapse_findings=false must produce no (xN) suffix; got:\n{out}"
         );
 
-        // Contrast assertion: render=FindingsRender::FlatCollapsed on the same input MUST produce
+        // Contrast assertion: render=FindingsRender { grouping: Grouping::Flat, collapse: Collapse::Collapsed } on the same input MUST produce
         // a collapsed group with (x5) — verifying the opt-out contrast is meaningful.
         let out_collapse = collapse_reporter().render(&Summary::new(), &findings, &[]);
         assert!(
@@ -3261,7 +3261,7 @@ mod story_118 {
     /// AC-018 (part 2): default vs. opt-out outputs are observably different.
     ///
     /// This guards that the two modes produce distinct output for the same input.
-    /// FAILS if a future change makes FindingsRender::FlatCollapsed and FindingsRender::FlatExpanded
+    /// FAILS if a future change makes FindingsRender { grouping: Grouping::Flat, collapse: Collapse::Collapsed } and FindingsRender { grouping: Grouping::Flat, collapse: Collapse::Expanded }
     /// produce identical output (meaning either both collapse or neither does).
     #[test]
     fn test_BC_2_11_028_default_vs_opt_out_output_difference() {
@@ -3311,7 +3311,7 @@ mod story_118 {
         );
     }
 
-    /// AC-019: --no-collapse flag is wired: no_collapse=true → render=FindingsRender::FlatExpanded.
+    /// AC-019: --no-collapse flag is wired: no_collapse=true → render=FindingsRender { grouping: Grouping::Flat, collapse: Collapse::Expanded }.
     ///
     /// This guards the structural wiring between the CLI flag and the render field.
     /// FAILS if FlatCollapsed and FlatExpanded produce identical output, or if the
@@ -3319,8 +3319,8 @@ mod story_118 {
     #[test]
     fn test_BC_2_11_028_flag_wired_to_reporter_field() {
         // BC-2.11.028 pc1 / invariant 1: structural wiring test.
-        // render=FindingsRender::FlatCollapsed → collapse active (v0.8.0 default).
-        // render=FindingsRender::FlatExpanded → collapse inactive (--no-collapse opt-out).
+        // render=FindingsRender { grouping: Grouping::Flat, collapse: Collapse::Collapsed } → collapse active (v0.8.0 default).
+        // render=FindingsRender { grouping: Grouping::Flat, collapse: Collapse::Expanded } → collapse inactive (--no-collapse opt-out).
         // Verify the render field is wired correctly by behavioral contrast.
 
         let findings: Vec<Finding> = (0..3)
@@ -3336,11 +3336,11 @@ mod story_118 {
             })
             .collect();
 
-        // Reporter with render = FindingsRender::FlatCollapsed → produces "(x3)".
+        // Reporter with render = FindingsRender { grouping: Grouping::Flat, collapse: Collapse::Collapsed } → produces "(x3)".
         let reporter_on = TerminalReporter {
             use_color: false,
             show_hosts_breakdown: false,
-            render: FindingsRender::FlatCollapsed,
+            render: FindingsRender { grouping: Grouping::Flat, collapse: Collapse::Collapsed },
         };
         let out_on = reporter_on.render(&Summary::new(), &findings, &[]);
         assert!(
@@ -3348,11 +3348,11 @@ mod story_118 {
             "BC-2.11.028 inv1: collapse_findings=true must produce '(x3)' suffix; got:\n{out_on}"
         );
 
-        // Reporter with render = FindingsRender::FlatExpanded → no collapse, no suffix.
+        // Reporter with render = FindingsRender { grouping: Grouping::Flat, collapse: Collapse::Expanded } → no collapse, no suffix.
         let reporter_off = TerminalReporter {
             use_color: false,
             show_hosts_breakdown: false,
-            render: FindingsRender::FlatExpanded,
+            render: FindingsRender { grouping: Grouping::Flat, collapse: Collapse::Expanded },
         };
         let out_off = reporter_off.render(&Summary::new(), &findings, &[]);
         assert!(
@@ -3532,7 +3532,7 @@ mod story_118 {
 
     /// AC-027: --no-collapse flag has no observable effect on JSON or CSV output.
     ///
-    /// This guards that the render field (FindingsRender::FlatCollapsed) on TerminalReporter
+    /// This guards that the render field (FindingsRender { grouping: Grouping::Flat, collapse: Collapse::Collapsed }) on TerminalReporter
     /// does not leak into the JSON/CSV reporters. FAILS if main.rs is refactored to pre-filter
     /// the findings slice based on the --no-collapse flag before passing to all reporters.
     #[test]
@@ -3658,7 +3658,7 @@ mod story_118 {
     #[test]
     fn test_BC_2_11_013_grouped_mode_suffix_free() {
         // BC-2.11.013 invariant 4: grouped mode is structurally suffix-free.
-        // 50 identical-key findings with FindingsRender::FlatCollapsed AND FindingsRender::Grouped.
+        // 50 identical-key findings with FindingsRender { grouping: Grouping::Flat, collapse: Collapse::Collapsed } AND FindingsRender { grouping: Grouping::Grouped, collapse: Collapse::Expanded }.
         let findings: Vec<Finding> = (0..50)
             .map(|_| {
                 make_collapse_finding(
@@ -3763,7 +3763,7 @@ mod story_118 {
     // BC-2.11.019 — Section Order Unchanged with Collapse (1 test)
     // -----------------------------------------------------------------------
 
-    /// AC-025: overall section order is unchanged when render=FindingsRender::FlatCollapsed.
+    /// AC-025: overall section order is unchanged when render=FindingsRender { grouping: Grouping::Flat, collapse: Collapse::Collapsed }.
     /// Only the FINDINGS body content changes.
     ///
     /// This guards that the collapse feature does not reorder or drop the top-level
@@ -3954,7 +3954,7 @@ mod story_118 {
 mod story_120 {
     use wirerust::findings::{Confidence, Finding, ThreatCategory, Verdict};
     use wirerust::reporter::Reporter;
-    use wirerust::reporter::terminal::{FindingsRender, TerminalReporter};
+    use wirerust::reporter::terminal::{Collapse, FindingsRender, Grouping, TerminalReporter};
     use wirerust::summary::Summary;
 
     fn make_finding_s120(summary: impl Into<String>) -> Finding {
@@ -3995,7 +3995,7 @@ mod story_120 {
     /// The enum has exactly three variants and no Default impl.
     #[test]
     fn test_findings_render_derives_debug_clone_copy_partialeq_eq() {
-        let a = FindingsRender::Grouped;
+        let a = FindingsRender { grouping: Grouping::Grouped, collapse: Collapse::Expanded };
         let b = a; // Copy
         let c = Clone::clone(&a); // Clone (explicit form avoids clone_on_copy lint)
         assert_eq!(a, b, "PartialEq + Eq: Grouped == copied Grouped");
@@ -4004,25 +4004,25 @@ mod story_120 {
 
         // All three variants are distinct.
         assert_ne!(
-            FindingsRender::Grouped,
-            FindingsRender::FlatCollapsed,
+            FindingsRender { grouping: Grouping::Grouped, collapse: Collapse::Expanded },
+            FindingsRender { grouping: Grouping::Flat, collapse: Collapse::Collapsed },
             "Grouped != FlatCollapsed"
         );
         assert_ne!(
-            FindingsRender::Grouped,
-            FindingsRender::FlatExpanded,
+            FindingsRender { grouping: Grouping::Grouped, collapse: Collapse::Expanded },
+            FindingsRender { grouping: Grouping::Flat, collapse: Collapse::Expanded },
             "Grouped != FlatExpanded"
         );
         assert_ne!(
-            FindingsRender::FlatCollapsed,
-            FindingsRender::FlatExpanded,
+            FindingsRender { grouping: Grouping::Flat, collapse: Collapse::Collapsed },
+            FindingsRender { grouping: Grouping::Flat, collapse: Collapse::Expanded },
             "FlatCollapsed != FlatExpanded"
         );
 
         // Debug formats include the variant name.
-        assert!(format!("{:?}", FindingsRender::Grouped).contains("Grouped"));
-        assert!(format!("{:?}", FindingsRender::FlatCollapsed).contains("FlatCollapsed"));
-        assert!(format!("{:?}", FindingsRender::FlatExpanded).contains("FlatExpanded"));
+        assert!(format!("{:?}", FindingsRender { grouping: Grouping::Grouped, collapse: Collapse::Expanded }).contains("Grouped"));
+        assert!(format!("{:?}", FindingsRender { grouping: Grouping::Flat, collapse: Collapse::Collapsed }).contains("FlatCollapsed"));
+        assert!(format!("{:?}", FindingsRender { grouping: Grouping::Flat, collapse: Collapse::Expanded }).contains("FlatExpanded"));
     }
 
     // -----------------------------------------------------------------------
@@ -4042,7 +4042,7 @@ mod story_120 {
         let r = TerminalReporter {
             use_color: false,
             show_hosts_breakdown: false,
-            render: FindingsRender::FlatExpanded,
+            render: FindingsRender { grouping: Grouping::Flat, collapse: Collapse::Expanded },
         };
         // The struct renders fine (behavioral sanity).
         let out = r.render(&Summary::new(), &[], &[]);
@@ -4073,7 +4073,7 @@ mod story_120 {
         let grouped_out = TerminalReporter {
             use_color: false,
             show_hosts_breakdown: false,
-            render: FindingsRender::Grouped,
+            render: FindingsRender { grouping: Grouping::Grouped, collapse: Collapse::Expanded },
         }
         .render(&Summary::new(), &findings, &[]);
         assert!(
@@ -4085,7 +4085,7 @@ mod story_120 {
         let collapsed_out = TerminalReporter {
             use_color: false,
             show_hosts_breakdown: false,
-            render: FindingsRender::FlatCollapsed,
+            render: FindingsRender { grouping: Grouping::Flat, collapse: Collapse::Collapsed },
         }
         .render(&Summary::new(), &findings, &[]);
         assert!(
@@ -4098,7 +4098,7 @@ mod story_120 {
         let expanded_out = TerminalReporter {
             use_color: false,
             show_hosts_breakdown: false,
-            render: FindingsRender::FlatExpanded,
+            render: FindingsRender { grouping: Grouping::Flat, collapse: Collapse::Expanded },
         }
         .render(&Summary::new(), &findings, &[]);
         assert!(
@@ -4133,9 +4133,9 @@ mod story_120 {
     // -----------------------------------------------------------------------
 
     /// AC-004 (BC-2.11.025 invariant 5):
-    /// FindingsRender::Grouped on N=100 identical-key findings produces no "(xN)" suffix.
-    /// The impossible state (FindingsRender::Grouped + FlatCollapsed simultaneously) is
-    /// eliminated by type — FindingsRender::Grouped structurally excludes the collapse path.
+    /// FindingsRender { grouping: Grouping::Grouped, collapse: Collapse::Expanded } on N=100 identical-key findings produces no "(xN)" suffix.
+    /// The impossible state (FindingsRender { grouping: Grouping::Grouped, collapse: Collapse::Expanded } + FlatCollapsed simultaneously) is
+    /// eliminated by type — FindingsRender { grouping: Grouping::Grouped, collapse: Collapse::Expanded } structurally excludes the collapse path.
     #[test]
     fn test_BC_2_11_025_grouped_mode_bypasses_collapse_structurally() {
         let findings: Vec<Finding> = (0..100)
@@ -4145,19 +4145,19 @@ mod story_120 {
         let out = TerminalReporter {
             use_color: false,
             show_hosts_breakdown: false,
-            render: FindingsRender::Grouped,
+            render: FindingsRender { grouping: Grouping::Grouped, collapse: Collapse::Expanded },
         }
         .render(&Summary::new(), &findings, &[]);
 
         assert!(
             !out.contains("(x"),
-            "AC-004: FindingsRender::Grouped must never emit (xN) suffix — \
+            "AC-004: FindingsRender {{ grouping: Grouping::Grouped, collapse: Collapse::Expanded }} must never emit (xN) suffix — \
              impossible state is structurally unrepresentable; got:\n{out}"
         );
         // Grouped mode emits tactic headers (confirming the Grouped path ran, not collapsed).
         assert!(
             out.contains("## "),
-            "AC-004: FindingsRender::Grouped must emit tactic section headers; got:\n{out}"
+            "AC-004: FindingsRender {{ grouping: Grouping::Grouped, collapse: Collapse::Expanded }} must emit tactic section headers; got:\n{out}"
         );
     }
 
@@ -4167,8 +4167,8 @@ mod story_120 {
     // -----------------------------------------------------------------------
 
     /// AC-005 (BC-2.11.028 postconditions 1–2, invariant 1):
-    /// FindingsRender::FlatCollapsed produces "(x3)" for 3 identical-key findings;
-    /// FindingsRender::FlatExpanded does not — proving the render field is wired
+    /// FindingsRender { grouping: Grouping::Flat, collapse: Collapse::Collapsed } produces "(x3)" for 3 identical-key findings;
+    /// FindingsRender { grouping: Grouping::Flat, collapse: Collapse::Expanded } does not — proving the render field is wired
     /// correctly to the rendering path. Mirrors the run_analyze construction intent.
     #[test]
     fn test_BC_2_11_028_flag_wired_to_render_field_post_enum() {
@@ -4180,12 +4180,12 @@ mod story_120 {
         let out_collapsed = TerminalReporter {
             use_color: false,
             show_hosts_breakdown: false,
-            render: FindingsRender::FlatCollapsed,
+            render: FindingsRender { grouping: Grouping::Flat, collapse: Collapse::Collapsed },
         }
         .render(&Summary::new(), &findings, &[]);
         assert!(
             out_collapsed.contains("(x3)"),
-            "AC-005: FindingsRender::FlatCollapsed must produce '(x3)' for 3 identical \
+            "AC-005: FindingsRender {{ grouping: Grouping::Flat, collapse: Collapse::Collapsed }} must produce '(x3)' for 3 identical \
              findings; got:\n{out_collapsed}"
         );
 
@@ -4193,12 +4193,12 @@ mod story_120 {
         let out_expanded = TerminalReporter {
             use_color: false,
             show_hosts_breakdown: false,
-            render: FindingsRender::FlatExpanded,
+            render: FindingsRender { grouping: Grouping::Flat, collapse: Collapse::Expanded },
         }
         .render(&Summary::new(), &findings, &[]);
         assert!(
             !out_expanded.contains("(x"),
-            "AC-005: FindingsRender::FlatExpanded must not produce (xN) suffix; \
+            "AC-005: FindingsRender {{ grouping: Grouping::Flat, collapse: Collapse::Expanded }} must not produce (xN) suffix; \
              got:\n{out_expanded}"
         );
 

--- a/tests/reporter_terminal_tests.rs
+++ b/tests/reporter_terminal_tests.rs
@@ -691,7 +691,7 @@ mod story_078 {
     // -----------------------------------------------------------------------
 
     /// AC-001 (BC-2.11.013 postcondition 2):
-    /// When `show_mitre_grouping = true`, tactic section headers appear in the
+    /// When `render = FindingsRender::Grouped`, tactic section headers appear in the
     /// order returned by `all_tactics_in_report_order()`.  Only sections with at
     /// least one finding are emitted.
     ///
@@ -1006,7 +1006,7 @@ mod story_078 {
     // -----------------------------------------------------------------------
 
     /// AC-008 (BC-2.11.016 postcondition 1):
-    /// When `show_mitre_grouping = true` and a finding has a known technique ID
+    /// When `render = FindingsRender::Grouped` and a finding has a known technique ID
     /// (e.g., "T1036"), the MITRE line reads `MITRE: T1036 \u{2014} Masquerading`
     /// (U+2014 em-dash, not ASCII "--").
     ///
@@ -1081,8 +1081,8 @@ mod story_078 {
     // -----------------------------------------------------------------------
 
     /// AC-010 (BC-2.11.017 postcondition 1):
-    /// When `show_mitre_grouping = false` (default), a finding with
-    /// `mitre_technique = "T1036"` produces the MITRE line `MITRE: T1036`
+    /// When `render != FindingsRender::Grouped` (FlatExpanded or FlatCollapsed), a finding
+    /// with `mitre_technique = "T1036"` produces the MITRE line `MITRE: T1036`
     /// with no em-dash, no technique name, and no `(unknown)` label.
     ///
     /// Discriminating assertions:
@@ -1095,14 +1095,14 @@ mod story_078 {
     /// inv1/2: render_finding_flat never calls technique_name() / technique_tactic().
     #[test]
     fn test_BC_2_11_017_default_mode_bare_mitre_id() {
-        // Canonical test vector: mitre="T1036", show_mitre_grouping=false.
+        // Canonical test vector: mitre="T1036", render=FlatExpanded.
         let f = make_mitre_finding(
             "flat-finding",
             Verdict::Likely,
             Confidence::High,
             Some("T1036"),
         );
-        // Use plain_reporter() (show_mitre_grouping = false).
+        // Use plain_reporter() (render=FindingsRender::FlatExpanded).
         let out = plain_reporter().render(&Summary::new(), &[f], &[]);
 
         // Bare MITRE ID must be present.
@@ -2060,7 +2060,7 @@ mod story_118 {
         );
     }
 
-    /// AC-005: show_mitre_grouping=true suppresses collapse; no (xN) suffix anywhere.
+    /// AC-005: render=FindingsRender::Grouped suppresses collapse; no (xN) suffix anywhere.
     ///
     /// This guards the invariant that grouped (--mitre) mode is structurally
     /// suffix-free. FAILS if a future change applies the collapse pass inside
@@ -2070,7 +2070,7 @@ mod story_118 {
     /// that grouped mode does not).
     #[test]
     fn test_BC_2_11_025_grouped_mode_bypasses_collapse() {
-        // BC-2.11.025 invariant 5: when show_mitre_grouping=true, collapse does NOT run.
+        // BC-2.11.025 invariant 5: when render=FindingsRender::Grouped, collapse does NOT run.
         // 100 identical-key findings in mitre+collapse reporter → no (xN) suffix.
         let findings: Vec<Finding> = (0..100)
             .map(|_| {
@@ -2382,7 +2382,7 @@ mod story_118 {
             vec![],
         );
 
-        // Collapse reporter (collapse_findings=true) with a single finding.
+        // Collapse reporter (render=FindingsRender::FlatCollapsed) with a single finding.
         let out_collapse =
             collapse_reporter().render(&Summary::new(), std::slice::from_ref(&f), &[]);
 
@@ -2392,7 +2392,7 @@ mod story_118 {
             "BC-2.11.026 pc2/inv2: singleton must render with no (xN) suffix; got:\n{out_collapse}"
         );
 
-        // Output must be byte-identical to the pre-v0.8.0 path (collapse_findings=false).
+        // Output must be byte-identical to the pre-v0.8.0 path (render=FindingsRender::FlatExpanded).
         let out_no_collapse = plain_reporter().render(&Summary::new(), &[f], &[]);
         assert_eq!(
             out_collapse, out_no_collapse,
@@ -3210,15 +3210,14 @@ mod story_118 {
 
     /// AC-018 (part 1): --no-collapse restores one-line-per-finding; no (xN) suffix.
     ///
-    /// This guards the opt-out path: with collapse_findings=false, 5 identical-key
+    /// This guards the opt-out path: with render=FindingsRender::FlatExpanded, 5 identical-key
     /// findings render as 5 individual header lines. Also includes a contrast assertion
     /// that the collapse path (render_findings_collapsed) is implemented — verified by
-    /// checking that collapse_findings=true produces a different (collapsed) result.
-    /// FAILS if collapse_findings=false collapses, or if render_findings_collapsed is not
-    /// yet implemented.
+    /// checking that render=FindingsRender::FlatCollapsed produces a different (collapsed) result.
+    /// FAILS if FlatExpanded collapses, or if render_findings_collapsed is not yet implemented.
     #[test]
     fn test_BC_2_11_028_no_collapse_flag_one_line_per_finding() {
-        // BC-2.11.028 pc2: collapse_findings=false → one header per finding, no suffix.
+        // BC-2.11.028 pc2: render=FindingsRender::FlatExpanded → one header per finding, no suffix.
         let findings: Vec<Finding> = (0..5)
             .map(|_| {
                 make_collapse_finding(
@@ -3232,7 +3231,7 @@ mod story_118 {
             })
             .collect();
 
-        // plain_reporter() has collapse_findings=false.
+        // plain_reporter() has render=FindingsRender::FlatExpanded.
         let out = plain_reporter().render(&Summary::new(), &findings, &[]);
 
         // 5 individual header lines, not 1 collapsed group.
@@ -3249,7 +3248,7 @@ mod story_118 {
             "BC-2.11.028 pc2: collapse_findings=false must produce no (xN) suffix; got:\n{out}"
         );
 
-        // Contrast assertion: collapse_findings=true on the same input MUST produce
+        // Contrast assertion: render=FindingsRender::FlatCollapsed on the same input MUST produce
         // a collapsed group with (x5) — verifying the opt-out contrast is meaningful.
         let out_collapse = collapse_reporter().render(&Summary::new(), &findings, &[]);
         assert!(
@@ -3262,7 +3261,7 @@ mod story_118 {
     /// AC-018 (part 2): default vs. opt-out outputs are observably different.
     ///
     /// This guards that the two modes produce distinct output for the same input.
-    /// FAILS if a future change makes collapse_findings=true and collapse_findings=false
+    /// FAILS if a future change makes FindingsRender::FlatCollapsed and FindingsRender::FlatExpanded
     /// produce identical output (meaning either both collapse or neither does).
     #[test]
     fn test_BC_2_11_028_default_vs_opt_out_output_difference() {
@@ -3312,17 +3311,17 @@ mod story_118 {
         );
     }
 
-    /// AC-019: --no-collapse flag is wired: no_collapse=true → collapse_findings=false.
+    /// AC-019: --no-collapse flag is wired: no_collapse=true → render=FindingsRender::FlatExpanded.
     ///
-    /// This guards the structural wiring between the CLI flag and the reporter field.
-    /// FAILS if the collapse_findings field does not exist, or if its polarity is
-    /// reversed (collapse_findings: no_collapse instead of !no_collapse).
+    /// This guards the structural wiring between the CLI flag and the render field.
+    /// FAILS if FlatCollapsed and FlatExpanded produce identical output, or if the
+    /// render variant is mis-wired to the wrong rendering path.
     #[test]
     fn test_BC_2_11_028_flag_wired_to_reporter_field() {
         // BC-2.11.028 pc1 / invariant 1: structural wiring test.
-        // collapse_findings=true → collapse active (v0.8.0 default).
-        // collapse_findings=false → collapse inactive (--no-collapse opt-out).
-        // Verify the field exists and the logic is correct by behavioral contrast.
+        // render=FindingsRender::FlatCollapsed → collapse active (v0.8.0 default).
+        // render=FindingsRender::FlatExpanded → collapse inactive (--no-collapse opt-out).
+        // Verify the render field is wired correctly by behavioral contrast.
 
         let findings: Vec<Finding> = (0..3)
             .map(|_| {
@@ -3533,15 +3532,15 @@ mod story_118 {
 
     /// AC-027: --no-collapse flag has no observable effect on JSON or CSV output.
     ///
-    /// This guards that the collapse_findings field on TerminalReporter does not leak
-    /// into the JSON/CSV reporters. FAILS if main.rs is refactored to pre-filter the
-    /// findings slice based on the --no-collapse flag before passing to all reporters.
+    /// This guards that the render field (FindingsRender::FlatCollapsed) on TerminalReporter
+    /// does not leak into the JSON/CSV reporters. FAILS if main.rs is refactored to pre-filter
+    /// the findings slice based on the --no-collapse flag before passing to all reporters.
     #[test]
     fn test_BC_2_11_029_no_collapse_flag_json_invariant() {
         use wirerust::reporter::json::JsonReporter;
 
-        // BC-2.11.029 pc5: JSON output must be identical regardless of collapse_findings.
-        // The collapse_findings field belongs to TerminalReporter only.
+        // BC-2.11.029 pc5: JSON output must be identical regardless of render variant.
+        // The render field belongs to TerminalReporter only.
         let findings: Vec<Finding> = (0..5)
             .map(|_| {
                 make_collapse_finding(
@@ -3556,7 +3555,7 @@ mod story_118 {
             .collect();
 
         // JsonReporter does not have a collapse_findings field — it is unaffected.
-        // Both collapse=true and collapse=false terminal renders must produce the SAME
+        // Both FlatCollapsed and FlatExpanded terminal renders must produce the SAME
         // JSON output when the same slice is passed to JsonReporter.
         let json_out = JsonReporter.render(&Summary::new(), &findings, &[]);
         let json: serde_json::Value =
@@ -3649,7 +3648,7 @@ mod story_118 {
     // -----------------------------------------------------------------------
 
     /// AC-005 (BC-2.11.013): grouped mode (--mitre) is structurally suffix-free
-    /// regardless of `collapse_findings` flag; 0 (xN) suffixes in any volume.
+    /// regardless of render variant; 0 (xN) suffixes in any volume.
     ///
     /// This guards the invariant that render_findings_grouped is never modified by
     /// STORY-118. Also includes a contrast assertion that flat collapse produces a
@@ -3659,7 +3658,7 @@ mod story_118 {
     #[test]
     fn test_BC_2_11_013_grouped_mode_suffix_free() {
         // BC-2.11.013 invariant 4: grouped mode is structurally suffix-free.
-        // 50 identical-key findings with collapse_findings=true AND show_mitre_grouping=true.
+        // 50 identical-key findings with FindingsRender::FlatCollapsed AND FindingsRender::Grouped.
         let findings: Vec<Finding> = (0..50)
             .map(|_| {
                 make_collapse_finding(
@@ -3764,7 +3763,7 @@ mod story_118 {
     // BC-2.11.019 — Section Order Unchanged with Collapse (1 test)
     // -----------------------------------------------------------------------
 
-    /// AC-025: overall section order is unchanged when collapse_findings=true.
+    /// AC-025: overall section order is unchanged when render=FindingsRender::FlatCollapsed.
     /// Only the FINDINGS body content changes.
     ///
     /// This guards that the collapse feature does not reorder or drop the top-level
@@ -3941,21 +3940,15 @@ mod story_118 {
 }
 
 // ---------------------------------------------------------------------------
-// STORY-120 RED gate stubs
+// STORY-120 GREEN gate tests
 //
 // These tests exercise new behaviors introduced by the FindingsRender enum
-// migration (STORY-120). All bodies are `todo!()` — they compile but panic
-// at runtime, satisfying the Red Gate density check (≥50% todo!() bodies).
+// migration (STORY-120). All todo!() stubs have been replaced with real
+// assertions by the GREEN implementer.
 //
-// The implementer replaces each todo!() with real assertions during GREEN
-// after defining `pub enum FindingsRender { Grouped, FlatCollapsed,
-// FlatExpanded }` and updating `TerminalReporter` to use `render:
-// FindingsRender` in place of `show_mitre_grouping: bool` and
-// `collapse_findings: bool`.
-//
-// DO NOT reference the `FindingsRender` type here — it does not yet exist.
-// Construction sites remain as `todo!()` prose descriptions so the file
-// compiles against the current (pre-enum) struct shape.
+// `TerminalReporter` now uses `render: FindingsRender` (a three-variant enum)
+// in place of the two removed bool fields. The FindingsRender enum is now
+// defined in src/reporter/terminal.rs and imported below.
 // ---------------------------------------------------------------------------
 
 mod story_120 {
@@ -4004,7 +3997,7 @@ mod story_120 {
     fn test_findings_render_derives_debug_clone_copy_partialeq_eq() {
         let a = FindingsRender::Grouped;
         let b = a; // Copy
-        let c = a.clone(); // Clone
+        let c = Clone::clone(&a); // Clone (explicit form avoids clone_on_copy lint)
         assert_eq!(a, b, "PartialEq + Eq: Grouped == copied Grouped");
         assert_eq!(a, c, "PartialEq + Eq: Grouped == cloned Grouped");
         let _ = format!("{a:?}"); // Debug — would panic if not implemented
@@ -4040,7 +4033,7 @@ mod story_120 {
     /// AC-002 (BC-2.11.028 precondition 3):
     /// TerminalReporter has exactly 3 fields: use_color, show_hosts_breakdown, render.
     /// This test compiles only if the struct has exactly those fields — any reference
-    /// to removed fields show_mitre_grouping or collapse_findings is a compile error.
+    /// to the removed fields is a compile error.
     #[test]
     fn test_BC_2_11_028_struct_has_exactly_three_fields_post_refactor() {
         // The struct literal below is the test: it compiles if and only if exactly
@@ -4120,9 +4113,18 @@ mod story_120 {
         );
 
         // All three outputs are mutually distinct.
-        assert_ne!(grouped_out, collapsed_out, "AC-003: Grouped != FlatCollapsed output");
-        assert_ne!(grouped_out, expanded_out, "AC-003: Grouped != FlatExpanded output");
-        assert_ne!(collapsed_out, expanded_out, "AC-003: FlatCollapsed != FlatExpanded output");
+        assert_ne!(
+            grouped_out, collapsed_out,
+            "AC-003: Grouped != FlatCollapsed output"
+        );
+        assert_ne!(
+            grouped_out, expanded_out,
+            "AC-003: Grouped != FlatExpanded output"
+        );
+        assert_ne!(
+            collapsed_out, expanded_out,
+            "AC-003: FlatCollapsed != FlatExpanded output"
+        );
     }
 
     // -----------------------------------------------------------------------
@@ -4132,7 +4134,7 @@ mod story_120 {
 
     /// AC-004 (BC-2.11.025 invariant 5):
     /// FindingsRender::Grouped on N=100 identical-key findings produces no "(xN)" suffix.
-    /// The impossible state (show_mitre_grouping=true && collapse_findings=true) is
+    /// The impossible state (FindingsRender::Grouped + FlatCollapsed simultaneously) is
     /// eliminated by type — FindingsRender::Grouped structurally excludes the collapse path.
     #[test]
     fn test_BC_2_11_025_grouped_mode_bypasses_collapse_structurally() {

--- a/tests/reporter_terminal_tests.rs
+++ b/tests/reporter_terminal_tests.rs
@@ -5422,40 +5422,25 @@ mod story_119 {
     // -----------------------------------------------------------------------
 
     /// AC-001 (BC-2.11.030 Postcondition 2):
-    /// REGRESSION GUARD: The `run_analyze` construction site produces
-    /// `FindingsRender { grouping: Grouping::Grouped, collapse: Collapse::Collapsed }`
-    /// when `show_mitre_grouping == true` and `collapse_findings == true`
-    /// (`--mitre` alone, default collapse enabled).
+    /// REGRESSION GUARD: `FindingsRender { grouping: Grouping::Grouped, collapse:
+    /// Collapse::Collapsed }` (the value produced by `run_analyze` when `--mitre`
+    /// is present and collapse is enabled) routes to `render_findings_grouped_collapsed`.
     ///
-    /// Verified via the observable dispatch: a reporter constructed with
-    /// `{Grouped, Collapsed}` exercises `render_findings_grouped_collapsed`.
-    /// A FINDINGS section with grouped-collapse output appears in the rendered
-    /// string (tactic headers and `(xN)` suffix for N≥2 groups).
+    /// The mapping from the `--mitre` CLI flag to `Grouping::Grouped` is tested
+    /// by `test_bc_2_11_030_grouping_flag_polarity` in `src/main.rs` (unit test on
+    /// the `grouping_from_flag` helper) and by the e2e CLI tests in
+    /// `cli_integration_tests.rs`. This test verifies the RENDERING behavior of the
+    /// `{Grouped, Collapsed}` variant: tactic headers appear and `(xN)` suffix is
+    /// emitted for N≥2 identical-key findings in one bucket.
     #[test]
     fn test_BC_2_11_030_mitre_alone_maps_to_grouped_collapsed() {
-        // Construct the reporter exactly as run_analyze does when
-        // show_mitre_grouping=true, collapse_findings=true.
+        // Directly construct the expected FindingsRender value for --mitre alone
+        // (show_mitre_grouping=true, collapse_findings=true → {Grouped, Collapsed}).
+        // No tautological if/else copy of production logic.
         let render = FindingsRender {
-            grouping: if true {
-                Grouping::Grouped
-            } else {
-                Grouping::Flat
-            },
-            collapse: if true {
-                Collapse::Collapsed
-            } else {
-                Collapse::Expanded
-            },
+            grouping: Grouping::Grouped,
+            collapse: Collapse::Collapsed,
         };
-        assert_eq!(
-            render,
-            FindingsRender {
-                grouping: Grouping::Grouped,
-                collapse: Collapse::Collapsed,
-            },
-            "AC-001: --mitre alone (show_mitre_grouping=true, collapse_findings=true) \
-             must produce {{Grouped, Collapsed}}"
-        );
 
         // Observable render: N=3 identical-key findings in one tactic bucket
         // must produce a header with `(x3)` suffix — the grouped-collapse path.
@@ -5469,6 +5454,10 @@ mod story_119 {
         }
         .render(&Summary::new(), &findings, &[]);
         assert!(
+            out.contains("## "),
+            "AC-001: {{Grouped,Collapsed}} must emit tactic headers; got:\n{out}"
+        );
+        assert!(
             out.contains("(x3)"),
             "AC-001: {{Grouped,Collapsed}} with N=3 identical findings must emit \
              `(x3)` suffix; got:\n{out}"
@@ -5481,35 +5470,26 @@ mod story_119 {
     // -----------------------------------------------------------------------
 
     /// AC-002 (BC-2.11.030 Postcondition 3):
-    /// REGRESSION GUARD: The `run_analyze` construction site produces
-    /// `FindingsRender { grouping: Grouping::Grouped, collapse: Collapse::Expanded }`
-    /// when `show_mitre_grouping == true` and `collapse_findings == false`
-    /// (`--mitre` with `--no-collapse`).
+    /// REGRESSION GUARD: `FindingsRender { grouping: Grouping::Grouped, collapse:
+    /// Collapse::Expanded }` (the value produced by `run_analyze` when `--mitre
+    /// --no-collapse` is passed) routes to the grouped-expanded arm.
+    ///
+    /// The mapping from CLI flags to this struct value is tested by the unit
+    /// tests in `src/main.rs` (`grouping_from_flag` and `collapse_findings_from_flag`)
+    /// and by the e2e CLI tests. This test verifies the RENDERING behavior:
+    /// tactic headers appear but no `(xN)` suffix is emitted for any N.
     #[test]
     fn test_BC_2_11_030_mitre_no_collapse_maps_to_grouped_expanded() {
+        // Directly construct the expected FindingsRender value for --mitre --no-collapse
+        // (show_mitre_grouping=true, collapse_findings=false → {Grouped, Expanded}).
+        // No tautological if/else copy of production logic.
         let render = FindingsRender {
-            grouping: if true {
-                Grouping::Grouped
-            } else {
-                Grouping::Flat
-            },
-            collapse: if false {
-                Collapse::Collapsed
-            } else {
-                Collapse::Expanded
-            },
+            grouping: Grouping::Grouped,
+            collapse: Collapse::Expanded,
         };
-        assert_eq!(
-            render,
-            FindingsRender {
-                grouping: Grouping::Grouped,
-                collapse: Collapse::Expanded,
-            },
-            "AC-002: --mitre --no-collapse (show_mitre_grouping=true, collapse_findings=false) \
-             must produce {{Grouped, Expanded}}"
-        );
 
-        // Observable render: {Grouped, Expanded} must not emit any `(xN)` suffix.
+        // Observable render: {Grouped, Expanded} must emit tactic headers and
+        // must NOT emit any `(xN)` suffix for N identical findings.
         let findings: Vec<Finding> = (0..3)
             .map(|_| make_discovery_finding_s119("s119-ac002-mitre-expanded"))
             .collect();
@@ -5520,12 +5500,12 @@ mod story_119 {
         }
         .render(&Summary::new(), &findings, &[]);
         assert!(
-            !out.contains("(x"),
-            "AC-002: {{Grouped,Expanded}} must not emit any `(xN)` suffix; got:\n{out}"
-        );
-        assert!(
             out.contains("## "),
             "AC-002: {{Grouped,Expanded}} must emit tactic headers; got:\n{out}"
+        );
+        assert!(
+            !out.contains("(x"),
+            "AC-002: {{Grouped,Expanded}} must not emit any `(xN)` suffix; got:\n{out}"
         );
     }
 
@@ -5535,61 +5515,68 @@ mod story_119 {
     // -----------------------------------------------------------------------
 
     /// AC-003 (BC-2.11.030 Postconditions 4 and 5):
-    /// REGRESSION GUARD: Flat-mode `FindingsRender` wiring at the `run_analyze`
-    /// construction site is unchanged.
+    /// REGRESSION GUARD: Flat-mode `FindingsRender` variants produce the correct
+    /// observable rendering behavior.
     ///
-    /// BC-2.11.030 PC-4: "When neither `--mitre` nor `--no-collapse` is present
-    /// (the default terminal output): `render == FindingsRender { grouping:
-    /// Grouping::Flat, collapse: Collapse::Collapsed }`. Unchanged from
-    /// pre-STORY-119 behavior."
+    /// BC-2.11.030 PC-4: default (no `--mitre`, no `--no-collapse`) →
+    /// `{Flat, Collapsed}` — identical findings collapse to one line with `(xN)` suffix.
     ///
-    /// BC-2.11.030 PC-5: "When `--no-collapse` is present but `--mitre` is
-    /// absent: `render == FindingsRender { grouping: Grouping::Flat, collapse:
-    /// Collapse::Expanded }`. Unchanged from pre-STORY-119 behavior."
+    /// BC-2.11.030 PC-5: `--no-collapse` without `--mitre` →
+    /// `{Flat, Expanded}` — all findings rendered individually, no `(xN)` suffix.
+    ///
+    /// The mapping from CLI flags to these struct values is tested by the unit
+    /// tests in `src/main.rs` (`grouping_from_flag` and `collapse_findings_from_flag`).
     #[test]
     fn test_BC_2_11_030_flat_routing_unchanged() {
-        // PC-4: default (no --mitre, no --no-collapse)
+        // PC-4: default (no --mitre, no --no-collapse) → {Flat, Collapsed}.
+        // Directly construct the expected value without tautological if/else copies.
         let default_render = FindingsRender {
-            grouping: if false {
-                Grouping::Grouped
-            } else {
-                Grouping::Flat
-            },
-            collapse: if true {
-                Collapse::Collapsed
-            } else {
-                Collapse::Expanded
-            },
+            grouping: Grouping::Flat,
+            collapse: Collapse::Collapsed,
         };
-        assert_eq!(
-            default_render,
-            FindingsRender {
-                grouping: Grouping::Flat,
-                collapse: Collapse::Collapsed,
-            },
-            "AC-003 PC-4: default routing must produce {{Flat, Collapsed}}"
+
+        let findings_default: Vec<Finding> = (0..3)
+            .map(|_| make_discovery_finding_s119("s119-ac003-flat-collapsed"))
+            .collect();
+        let out_default = TerminalReporter {
+            use_color: false,
+            show_hosts_breakdown: false,
+            render: default_render,
+        }
+        .render(&Summary::new(), &findings_default, &[]);
+        assert!(
+            out_default.contains("(x3)"),
+            "AC-003 PC-4: {{Flat,Collapsed}} must emit '(x3)' for 3 identical findings; \
+             got:\n{out_default}"
+        );
+        assert!(
+            !out_default.contains("## "),
+            "AC-003 PC-4: {{Flat,Collapsed}} must not emit tactic headers; got:\n{out_default}"
         );
 
-        // PC-5: --no-collapse without --mitre
+        // PC-5: --no-collapse without --mitre → {Flat, Expanded}.
         let no_collapse_flat_render = FindingsRender {
-            grouping: if false {
-                Grouping::Grouped
-            } else {
-                Grouping::Flat
-            },
-            collapse: if false {
-                Collapse::Collapsed
-            } else {
-                Collapse::Expanded
-            },
+            grouping: Grouping::Flat,
+            collapse: Collapse::Expanded,
         };
+
+        let findings_expanded: Vec<Finding> = (0..3)
+            .map(|_| make_discovery_finding_s119("s119-ac003-flat-expanded"))
+            .collect();
+        let out_expanded = TerminalReporter {
+            use_color: false,
+            show_hosts_breakdown: false,
+            render: no_collapse_flat_render,
+        }
+        .render(&Summary::new(), &findings_expanded, &[]);
+        assert!(
+            !out_expanded.contains("(x"),
+            "AC-003 PC-5: {{Flat,Expanded}} must not emit (xN) suffix; got:\n{out_expanded}"
+        );
+        let count = out_expanded.matches("s119-ac003-flat-expanded").count();
         assert_eq!(
-            no_collapse_flat_render,
-            FindingsRender {
-                grouping: Grouping::Flat,
-                collapse: Collapse::Expanded,
-            },
-            "AC-003 PC-5: --no-collapse without --mitre must produce {{Flat, Expanded}}"
+            count, 3,
+            "AC-003 PC-5: {{Flat,Expanded}} must emit 3 individual finding lines; found {count}"
         );
     }
 

--- a/tests/reporter_terminal_tests.rs
+++ b/tests/reporter_terminal_tests.rs
@@ -71,10 +71,7 @@ fn plain_reporter() -> TerminalReporter {
     TerminalReporter {
         use_color: false,
         show_hosts_breakdown: false,
-        render: FindingsRender {
-            grouping: Grouping::Flat,
-            collapse: Collapse::Expanded,
-        },
+        render: FindingsRender::new(Grouping::Flat, Collapse::Expanded),
     }
 }
 
@@ -664,10 +661,7 @@ mod story_078 {
         TerminalReporter {
             use_color: false,
             show_hosts_breakdown: false,
-            render: FindingsRender {
-                grouping: Grouping::Grouped,
-                collapse: Collapse::Expanded,
-            },
+            render: FindingsRender::new(Grouping::Grouped, Collapse::Expanded),
         }
     }
 
@@ -1793,10 +1787,7 @@ mod story_118 {
         TerminalReporter {
             use_color: false,
             show_hosts_breakdown: false,
-            render: FindingsRender {
-                grouping: Grouping::Flat,
-                collapse: Collapse::Collapsed,
-            },
+            render: FindingsRender::new(Grouping::Flat, Collapse::Collapsed),
         }
     }
 
@@ -1805,10 +1796,7 @@ mod story_118 {
         TerminalReporter {
             use_color: true,
             show_hosts_breakdown: false,
-            render: FindingsRender {
-                grouping: Grouping::Flat,
-                collapse: Collapse::Collapsed,
-            },
+            render: FindingsRender::new(Grouping::Flat, Collapse::Collapsed),
         }
     }
 
@@ -1819,10 +1807,7 @@ mod story_118 {
         TerminalReporter {
             use_color: false,
             show_hosts_breakdown: false,
-            render: FindingsRender {
-                grouping: Grouping::Grouped,
-                collapse: Collapse::Expanded,
-            },
+            render: FindingsRender::new(Grouping::Grouped, Collapse::Expanded),
         }
     }
 
@@ -3357,10 +3342,7 @@ mod story_118 {
         let reporter_on = TerminalReporter {
             use_color: false,
             show_hosts_breakdown: false,
-            render: FindingsRender {
-                grouping: Grouping::Flat,
-                collapse: Collapse::Collapsed,
-            },
+            render: FindingsRender::new(Grouping::Flat, Collapse::Collapsed),
         };
         let out_on = reporter_on.render(&Summary::new(), &findings, &[]);
         assert!(
@@ -3372,10 +3354,7 @@ mod story_118 {
         let reporter_off = TerminalReporter {
             use_color: false,
             show_hosts_breakdown: false,
-            render: FindingsRender {
-                grouping: Grouping::Flat,
-                collapse: Collapse::Expanded,
-            },
+            render: FindingsRender::new(Grouping::Flat, Collapse::Expanded),
         };
         let out_off = reporter_off.render(&Summary::new(), &findings, &[]);
         assert!(
@@ -4018,10 +3997,7 @@ mod story_120 {
     /// The struct has exactly two fields: grouping: Grouping and collapse: Collapse. No Default impl.
     #[test]
     fn test_findings_render_derives_debug_clone_copy_partialeq_eq() {
-        let a = FindingsRender {
-            grouping: Grouping::Grouped,
-            collapse: Collapse::Expanded,
-        };
+        let a = FindingsRender::new(Grouping::Grouped, Collapse::Expanded);
         let b = a; // Copy
         let c = Clone::clone(&a); // Clone (explicit form avoids clone_on_copy lint)
         assert_eq!(a, b, "PartialEq + Eq: Grouped == copied Grouped");
@@ -4030,69 +4006,33 @@ mod story_120 {
 
         // All four Grouping x Collapse combinations are pairwise distinct.
         assert_ne!(
-            FindingsRender {
-                grouping: Grouping::Grouped,
-                collapse: Collapse::Expanded
-            },
-            FindingsRender {
-                grouping: Grouping::Flat,
-                collapse: Collapse::Collapsed
-            },
+            FindingsRender::new(Grouping::Grouped, Collapse::Expanded),
+            FindingsRender::new(Grouping::Flat, Collapse::Collapsed),
             "{{Grouped,Expanded}} != {{Flat,Collapsed}}"
         );
         assert_ne!(
-            FindingsRender {
-                grouping: Grouping::Grouped,
-                collapse: Collapse::Expanded
-            },
-            FindingsRender {
-                grouping: Grouping::Flat,
-                collapse: Collapse::Expanded
-            },
+            FindingsRender::new(Grouping::Grouped, Collapse::Expanded),
+            FindingsRender::new(Grouping::Flat, Collapse::Expanded),
             "{{Grouped,Expanded}} != {{Flat,Expanded}}"
         );
         assert_ne!(
-            FindingsRender {
-                grouping: Grouping::Flat,
-                collapse: Collapse::Collapsed
-            },
-            FindingsRender {
-                grouping: Grouping::Flat,
-                collapse: Collapse::Expanded
-            },
+            FindingsRender::new(Grouping::Flat, Collapse::Collapsed),
+            FindingsRender::new(Grouping::Flat, Collapse::Expanded),
             "{{Flat,Collapsed}} != {{Flat,Expanded}}"
         );
         assert_ne!(
-            FindingsRender {
-                grouping: Grouping::Grouped,
-                collapse: Collapse::Expanded
-            },
-            FindingsRender {
-                grouping: Grouping::Grouped,
-                collapse: Collapse::Collapsed
-            },
+            FindingsRender::new(Grouping::Grouped, Collapse::Expanded),
+            FindingsRender::new(Grouping::Grouped, Collapse::Collapsed),
             "{{Grouped,Expanded}} != {{Grouped,Collapsed}}"
         );
         assert_ne!(
-            FindingsRender {
-                grouping: Grouping::Grouped,
-                collapse: Collapse::Collapsed
-            },
-            FindingsRender {
-                grouping: Grouping::Flat,
-                collapse: Collapse::Collapsed
-            },
+            FindingsRender::new(Grouping::Grouped, Collapse::Collapsed),
+            FindingsRender::new(Grouping::Flat, Collapse::Collapsed),
             "{{Grouped,Collapsed}} != {{Flat,Collapsed}}"
         );
         assert_ne!(
-            FindingsRender {
-                grouping: Grouping::Grouped,
-                collapse: Collapse::Collapsed
-            },
-            FindingsRender {
-                grouping: Grouping::Flat,
-                collapse: Collapse::Expanded
-            },
+            FindingsRender::new(Grouping::Grouped, Collapse::Collapsed),
+            FindingsRender::new(Grouping::Flat, Collapse::Expanded),
             "{{Grouped,Collapsed}} != {{Flat,Expanded}}"
         );
 
@@ -4100,40 +4040,28 @@ mod story_120 {
         assert!(
             format!(
                 "{:?}",
-                FindingsRender {
-                    grouping: Grouping::Grouped,
-                    collapse: Collapse::Expanded
-                }
+                FindingsRender::new(Grouping::Grouped, Collapse::Expanded)
             )
             .contains("Grouped")
         );
         assert!(
             format!(
                 "{:?}",
-                FindingsRender {
-                    grouping: Grouping::Flat,
-                    collapse: Collapse::Collapsed
-                }
+                FindingsRender::new(Grouping::Flat, Collapse::Collapsed)
             )
             .contains("Flat")
         );
         assert!(
             format!(
                 "{:?}",
-                FindingsRender {
-                    grouping: Grouping::Flat,
-                    collapse: Collapse::Collapsed
-                }
+                FindingsRender::new(Grouping::Flat, Collapse::Collapsed)
             )
             .contains("Collapsed")
         );
         assert!(
             format!(
                 "{:?}",
-                FindingsRender {
-                    grouping: Grouping::Flat,
-                    collapse: Collapse::Expanded
-                }
+                FindingsRender::new(Grouping::Flat, Collapse::Expanded)
             )
             .contains("Expanded")
         );
@@ -4156,10 +4084,7 @@ mod story_120 {
         let r = TerminalReporter {
             use_color: false,
             show_hosts_breakdown: false,
-            render: FindingsRender {
-                grouping: Grouping::Flat,
-                collapse: Collapse::Expanded,
-            },
+            render: FindingsRender::new(Grouping::Flat, Collapse::Expanded),
         };
         // The struct renders fine (behavioral sanity).
         let out = r.render(&Summary::new(), &[], &[]);
@@ -4191,10 +4116,7 @@ mod story_120 {
         let grouped_out = TerminalReporter {
             use_color: false,
             show_hosts_breakdown: false,
-            render: FindingsRender {
-                grouping: Grouping::Grouped,
-                collapse: Collapse::Expanded,
-            },
+            render: FindingsRender::new(Grouping::Grouped, Collapse::Expanded),
         }
         .render(&Summary::new(), &findings, &[]);
         assert!(
@@ -4206,10 +4128,7 @@ mod story_120 {
         let collapsed_out = TerminalReporter {
             use_color: false,
             show_hosts_breakdown: false,
-            render: FindingsRender {
-                grouping: Grouping::Flat,
-                collapse: Collapse::Collapsed,
-            },
+            render: FindingsRender::new(Grouping::Flat, Collapse::Collapsed),
         }
         .render(&Summary::new(), &findings, &[]);
         assert!(
@@ -4222,10 +4141,7 @@ mod story_120 {
         let expanded_out = TerminalReporter {
             use_color: false,
             show_hosts_breakdown: false,
-            render: FindingsRender {
-                grouping: Grouping::Flat,
-                collapse: Collapse::Expanded,
-            },
+            render: FindingsRender::new(Grouping::Flat, Collapse::Expanded),
         }
         .render(&Summary::new(), &findings, &[]);
         assert!(
@@ -4273,10 +4189,7 @@ mod story_120 {
         let out = TerminalReporter {
             use_color: false,
             show_hosts_breakdown: false,
-            render: FindingsRender {
-                grouping: Grouping::Grouped,
-                collapse: Collapse::Expanded,
-            },
+            render: FindingsRender::new(Grouping::Grouped, Collapse::Expanded),
         }
         .render(&Summary::new(), &findings, &[]);
 
@@ -4311,10 +4224,7 @@ mod story_120 {
         let out_collapsed = TerminalReporter {
             use_color: false,
             show_hosts_breakdown: false,
-            render: FindingsRender {
-                grouping: Grouping::Flat,
-                collapse: Collapse::Collapsed,
-            },
+            render: FindingsRender::new(Grouping::Flat, Collapse::Collapsed),
         }
         .render(&Summary::new(), &findings, &[]);
         assert!(
@@ -4327,10 +4237,7 @@ mod story_120 {
         let out_expanded = TerminalReporter {
             use_color: false,
             show_hosts_breakdown: false,
-            render: FindingsRender {
-                grouping: Grouping::Flat,
-                collapse: Collapse::Expanded,
-            },
+            render: FindingsRender::new(Grouping::Flat, Collapse::Expanded),
         }
         .render(&Summary::new(), &findings, &[]);
         assert!(
@@ -4409,22 +4316,10 @@ mod story_122 {
     /// No Default is derived on any of the three types.
     #[test]
     fn test_BC_2_11_028_ac001_four_combos_pairwise_distinct() {
-        let grouped_expanded = FindingsRender {
-            grouping: Grouping::Grouped,
-            collapse: Collapse::Expanded,
-        };
-        let grouped_collapsed = FindingsRender {
-            grouping: Grouping::Grouped,
-            collapse: Collapse::Collapsed,
-        };
-        let flat_collapsed = FindingsRender {
-            grouping: Grouping::Flat,
-            collapse: Collapse::Collapsed,
-        };
-        let flat_expanded = FindingsRender {
-            grouping: Grouping::Flat,
-            collapse: Collapse::Expanded,
-        };
+        let grouped_expanded = FindingsRender::new(Grouping::Grouped, Collapse::Expanded);
+        let grouped_collapsed = FindingsRender::new(Grouping::Grouped, Collapse::Collapsed);
+        let flat_collapsed = FindingsRender::new(Grouping::Flat, Collapse::Collapsed);
+        let flat_expanded = FindingsRender::new(Grouping::Flat, Collapse::Expanded);
 
         // Copy semantics: binding a second name does not move.
         let ge2 = grouped_expanded;
@@ -4483,10 +4378,7 @@ mod story_122 {
         // Struct debug output contains field and variant names.
         let ge_dbg = format!(
             "{:?}",
-            FindingsRender {
-                grouping: Grouping::Grouped,
-                collapse: Collapse::Expanded
-            }
+            FindingsRender::new(Grouping::Grouped, Collapse::Expanded)
         );
         assert!(
             ge_dbg.contains("grouping"),
@@ -4507,10 +4399,7 @@ mod story_122 {
 
         let fc_dbg = format!(
             "{:?}",
-            FindingsRender {
-                grouping: Grouping::Flat,
-                collapse: Collapse::Collapsed
-            }
+            FindingsRender::new(Grouping::Flat, Collapse::Collapsed)
         );
         assert!(
             fc_dbg.contains("Flat"),
@@ -4528,10 +4417,7 @@ mod story_122 {
         );
         let fe_dbg = format!(
             "{:?}",
-            FindingsRender {
-                grouping: Grouping::Flat,
-                collapse: Collapse::Expanded
-            }
+            FindingsRender::new(Grouping::Flat, Collapse::Expanded)
         );
         assert!(
             !fe_dbg.contains("FlatExpanded"),
@@ -4555,10 +4441,7 @@ mod story_122 {
         let out = TerminalReporter {
             use_color: false,
             show_hosts_breakdown: false,
-            render: FindingsRender {
-                grouping: Grouping::Grouped,
-                collapse: Collapse::Expanded,
-            },
+            render: FindingsRender::new(Grouping::Grouped, Collapse::Expanded),
         }
         .render(&Summary::new(), &findings, &[]);
         assert!(
@@ -4589,20 +4472,14 @@ mod story_122 {
         let out_gc = TerminalReporter {
             use_color: false,
             show_hosts_breakdown: false,
-            render: FindingsRender {
-                grouping: Grouping::Grouped,
-                collapse: Collapse::Collapsed,
-            },
+            render: FindingsRender::new(Grouping::Grouped, Collapse::Collapsed),
         }
         .render(&Summary::new(), &findings, &[]);
 
         let out_ge = TerminalReporter {
             use_color: false,
             show_hosts_breakdown: false,
-            render: FindingsRender {
-                grouping: Grouping::Grouped,
-                collapse: Collapse::Expanded,
-            },
+            render: FindingsRender::new(Grouping::Grouped, Collapse::Expanded),
         }
         .render(&Summary::new(), &findings, &[]);
 
@@ -4636,10 +4513,7 @@ mod story_122 {
         let out = TerminalReporter {
             use_color: false,
             show_hosts_breakdown: false,
-            render: FindingsRender {
-                grouping: Grouping::Flat,
-                collapse: Collapse::Collapsed,
-            },
+            render: FindingsRender::new(Grouping::Flat, Collapse::Collapsed),
         }
         .render(&Summary::new(), &findings, &[]);
         assert!(
@@ -4659,10 +4533,7 @@ mod story_122 {
         let out = TerminalReporter {
             use_color: false,
             show_hosts_breakdown: false,
-            render: FindingsRender {
-                grouping: Grouping::Flat,
-                collapse: Collapse::Expanded,
-            },
+            render: FindingsRender::new(Grouping::Flat, Collapse::Expanded),
         }
         .render(&Summary::new(), &findings, &[]);
         assert!(
@@ -4702,10 +4573,7 @@ mod story_122 {
             .collect();
 
         // The struct value run_analyze produces when show_mitre_grouping=true.
-        let render_from_mitre_flag = FindingsRender {
-            grouping: Grouping::Grouped,
-            collapse: Collapse::Expanded,
-        };
+        let render_from_mitre_flag = FindingsRender::new(Grouping::Grouped, Collapse::Expanded);
 
         let out = TerminalReporter {
             use_color: false,
@@ -4725,10 +4593,7 @@ mod story_122 {
 
         // {Grouped, Collapsed} is NOT what --mitre alone produced in STORY-122/A
         // (post-STORY-119/B this IS the CLI default, but this test only asserts the struct values).
-        let render_grouped_collapsed = FindingsRender {
-            grouping: Grouping::Grouped,
-            collapse: Collapse::Collapsed,
-        };
+        let render_grouped_collapsed = FindingsRender::new(Grouping::Grouped, Collapse::Collapsed);
         assert_ne!(
             render_from_mitre_flag, render_grouped_collapsed,
             "AC-004: run_analyze with --mitre alone must produce {{Grouped,Expanded}}, \
@@ -4747,10 +4612,7 @@ mod story_122 {
             .collect();
 
         // The struct value run_analyze produces for the default (no --mitre, collapse_findings=true).
-        let render_default = FindingsRender {
-            grouping: Grouping::Flat,
-            collapse: Collapse::Collapsed,
-        };
+        let render_default = FindingsRender::new(Grouping::Flat, Collapse::Collapsed);
 
         let out = TerminalReporter {
             use_color: false,
@@ -4780,10 +4642,7 @@ mod story_122 {
             .collect();
 
         // The struct value run_analyze produces for --no-collapse (collapse_findings=false).
-        let render_no_collapse = FindingsRender {
-            grouping: Grouping::Flat,
-            collapse: Collapse::Expanded,
-        };
+        let render_no_collapse = FindingsRender::new(Grouping::Flat, Collapse::Expanded);
 
         let out = TerminalReporter {
             use_color: false,
@@ -4815,10 +4674,7 @@ mod story_122 {
     #[test]
     fn test_BC_2_11_028_ac005_run_summary_construction_uses_flat_collapsed() {
         // The struct value run_summary uses — inert (run_summary renders no FINDINGS section).
-        let render_summary = FindingsRender {
-            grouping: Grouping::Flat,
-            collapse: Collapse::Collapsed,
-        };
+        let render_summary = FindingsRender::new(Grouping::Flat, Collapse::Collapsed);
 
         let reporter = TerminalReporter {
             use_color: false,
@@ -4840,10 +4696,7 @@ mod story_122 {
         // The run_summary value matches exactly {Flat, Collapsed}.
         assert_eq!(
             render_summary,
-            FindingsRender {
-                grouping: Grouping::Flat,
-                collapse: Collapse::Collapsed
-            },
+            FindingsRender::new(Grouping::Flat, Collapse::Collapsed),
             "AC-005: run_summary FindingsRender must be {{Flat,Collapsed}}"
         );
     }
@@ -4870,10 +4723,7 @@ mod story_122 {
         let out = TerminalReporter {
             use_color: false,
             show_hosts_breakdown: false,
-            render: FindingsRender {
-                grouping: Grouping::Grouped,
-                collapse: Collapse::Expanded,
-            },
+            render: FindingsRender::new(Grouping::Grouped, Collapse::Expanded),
         }
         .render(&Summary::new(), &findings, &[]);
 
@@ -4916,10 +4766,7 @@ mod story_122 {
         let out = TerminalReporter {
             use_color: false,
             show_hosts_breakdown: false,
-            render: FindingsRender {
-                grouping: Grouping::Flat,
-                collapse: Collapse::Collapsed,
-            },
+            render: FindingsRender::new(Grouping::Flat, Collapse::Collapsed),
         }
         .render(&Summary::new(), &findings, &[]);
 
@@ -4950,10 +4797,7 @@ mod story_122 {
         let out = TerminalReporter {
             use_color: false,
             show_hosts_breakdown: false,
-            render: FindingsRender {
-                grouping: Grouping::Flat,
-                collapse: Collapse::Expanded,
-            },
+            render: FindingsRender::new(Grouping::Flat, Collapse::Expanded),
         }
         .render(&Summary::new(), &findings, &[]);
 
@@ -5135,10 +4979,7 @@ mod story_122 {
         let out = TerminalReporter {
             use_color: false,
             show_hosts_breakdown: false,
-            render: FindingsRender {
-                grouping: Grouping::Grouped,
-                collapse: Collapse::Expanded,
-            },
+            render: FindingsRender::new(Grouping::Grouped, Collapse::Expanded),
         }
         .render(&Summary::new(), &findings, &[]);
 
@@ -5163,10 +5004,7 @@ mod story_122 {
         let out = TerminalReporter {
             use_color: false,
             show_hosts_breakdown: false,
-            render: FindingsRender {
-                grouping: Grouping::Flat,
-                collapse: Collapse::Collapsed,
-            },
+            render: FindingsRender::new(Grouping::Flat, Collapse::Collapsed),
         }
         .render(&Summary::new(), &findings, &[]);
 
@@ -5178,10 +5016,7 @@ mod story_122 {
         let grouped_out = TerminalReporter {
             use_color: false,
             show_hosts_breakdown: false,
-            render: FindingsRender {
-                grouping: Grouping::Grouped,
-                collapse: Collapse::Expanded,
-            },
+            render: FindingsRender::new(Grouping::Grouped, Collapse::Expanded),
         }
         .render(&Summary::new(), &findings, &[]);
         assert!(
@@ -5213,10 +5048,7 @@ mod story_122 {
         let out = TerminalReporter {
             use_color: false,
             show_hosts_breakdown: false,
-            render: FindingsRender {
-                grouping: Grouping::Flat,
-                collapse: Collapse::Collapsed,
-            },
+            render: FindingsRender::new(Grouping::Flat, Collapse::Collapsed),
         }
         .render(&Summary::new(), &findings, &[]);
 
@@ -5334,10 +5166,7 @@ mod story_119 {
         TerminalReporter {
             use_color: false,
             show_hosts_breakdown: false,
-            render: FindingsRender {
-                grouping: Grouping::Grouped,
-                collapse: Collapse::Collapsed,
-            },
+            render: FindingsRender::new(Grouping::Grouped, Collapse::Collapsed),
         }
     }
 
@@ -5347,10 +5176,7 @@ mod story_119 {
         TerminalReporter {
             use_color: true,
             show_hosts_breakdown: false,
-            render: FindingsRender {
-                grouping: Grouping::Grouped,
-                collapse: Collapse::Collapsed,
-            },
+            render: FindingsRender::new(Grouping::Grouped, Collapse::Collapsed),
         }
     }
 
@@ -5361,10 +5187,7 @@ mod story_119 {
         TerminalReporter {
             use_color: false,
             show_hosts_breakdown: false,
-            render: FindingsRender {
-                grouping: Grouping::Grouped,
-                collapse: Collapse::Expanded,
-            },
+            render: FindingsRender::new(Grouping::Grouped, Collapse::Expanded),
         }
     }
 
@@ -5437,10 +5260,7 @@ mod story_119 {
         // Directly construct the expected FindingsRender value for --mitre alone
         // (show_mitre_grouping=true, collapse_findings=true → {Grouped, Collapsed}).
         // No tautological if/else copy of production logic.
-        let render = FindingsRender {
-            grouping: Grouping::Grouped,
-            collapse: Collapse::Collapsed,
-        };
+        let render = FindingsRender::new(Grouping::Grouped, Collapse::Collapsed);
 
         // Observable render: N=3 identical-key findings in one tactic bucket
         // must produce a header with `(x3)` suffix — the grouped-collapse path.
@@ -5483,10 +5303,7 @@ mod story_119 {
         // Directly construct the expected FindingsRender value for --mitre --no-collapse
         // (show_mitre_grouping=true, collapse_findings=false → {Grouped, Expanded}).
         // No tautological if/else copy of production logic.
-        let render = FindingsRender {
-            grouping: Grouping::Grouped,
-            collapse: Collapse::Expanded,
-        };
+        let render = FindingsRender::new(Grouping::Grouped, Collapse::Expanded);
 
         // Observable render: {Grouped, Expanded} must emit tactic headers and
         // must NOT emit any `(xN)` suffix for N identical findings.
@@ -5530,10 +5347,7 @@ mod story_119 {
     fn test_BC_2_11_030_flat_routing_unchanged() {
         // PC-4: default (no --mitre, no --no-collapse) → {Flat, Collapsed}.
         // Directly construct the expected value without tautological if/else copies.
-        let default_render = FindingsRender {
-            grouping: Grouping::Flat,
-            collapse: Collapse::Collapsed,
-        };
+        let default_render = FindingsRender::new(Grouping::Flat, Collapse::Collapsed);
 
         let findings_default: Vec<Finding> = (0..3)
             .map(|_| make_discovery_finding_s119("s119-ac003-flat-collapsed"))
@@ -5555,10 +5369,7 @@ mod story_119 {
         );
 
         // PC-5: --no-collapse without --mitre → {Flat, Expanded}.
-        let no_collapse_flat_render = FindingsRender {
-            grouping: Grouping::Flat,
-            collapse: Collapse::Expanded,
-        };
+        let no_collapse_flat_render = FindingsRender::new(Grouping::Flat, Collapse::Expanded);
 
         let findings_expanded: Vec<Finding> = (0..3)
             .map(|_| make_discovery_finding_s119("s119-ac003-flat-expanded"))
@@ -6592,10 +6403,7 @@ mod story_119 {
         let out_fc = TerminalReporter {
             use_color: false,
             show_hosts_breakdown: false,
-            render: FindingsRender {
-                grouping: Grouping::Flat,
-                collapse: Collapse::Collapsed,
-            },
+            render: FindingsRender::new(Grouping::Flat, Collapse::Collapsed),
         }
         .render(&Summary::new(), &findings, &[]);
         assert!(
@@ -6608,10 +6416,7 @@ mod story_119 {
         let out_fe = TerminalReporter {
             use_color: false,
             show_hosts_breakdown: false,
-            render: FindingsRender {
-                grouping: Grouping::Flat,
-                collapse: Collapse::Expanded,
-            },
+            render: FindingsRender::new(Grouping::Flat, Collapse::Expanded),
         }
         .render(&Summary::new(), &findings, &[]);
         assert!(
@@ -6633,16 +6438,10 @@ mod story_119 {
     #[test]
     fn test_BC_2_11_030_run_summary_produces_flat_collapsed() {
         // Verify the literal struct value that run_summary uses.
-        let run_summary_render = FindingsRender {
-            grouping: Grouping::Flat,
-            collapse: Collapse::Collapsed,
-        };
+        let run_summary_render = FindingsRender::new(Grouping::Flat, Collapse::Collapsed);
         assert_eq!(
             run_summary_render,
-            FindingsRender {
-                grouping: Grouping::Flat,
-                collapse: Collapse::Collapsed,
-            },
+            FindingsRender::new(Grouping::Flat, Collapse::Collapsed),
             "AC-004: run_summary render field must be {{Flat, Collapsed}}"
         );
         // This is a structural/value test — no dispatch exercised.

--- a/tests/reporter_terminal_tests.rs
+++ b/tests/reporter_terminal_tests.rs
@@ -71,7 +71,10 @@ fn plain_reporter() -> TerminalReporter {
     TerminalReporter {
         use_color: false,
         show_hosts_breakdown: false,
-        render: FindingsRender { grouping: Grouping::Flat, collapse: Collapse::Expanded },
+        render: FindingsRender {
+            grouping: Grouping::Flat,
+            collapse: Collapse::Expanded,
+        },
     }
 }
 
@@ -661,7 +664,10 @@ mod story_078 {
         TerminalReporter {
             use_color: false,
             show_hosts_breakdown: false,
-            render: FindingsRender { grouping: Grouping::Grouped, collapse: Collapse::Expanded },
+            render: FindingsRender {
+                grouping: Grouping::Grouped,
+                collapse: Collapse::Expanded,
+            },
         }
     }
 
@@ -1787,7 +1793,10 @@ mod story_118 {
         TerminalReporter {
             use_color: false,
             show_hosts_breakdown: false,
-            render: FindingsRender { grouping: Grouping::Flat, collapse: Collapse::Collapsed },
+            render: FindingsRender {
+                grouping: Grouping::Flat,
+                collapse: Collapse::Collapsed,
+            },
         }
     }
 
@@ -1796,7 +1805,10 @@ mod story_118 {
         TerminalReporter {
             use_color: true,
             show_hosts_breakdown: false,
-            render: FindingsRender { grouping: Grouping::Flat, collapse: Collapse::Collapsed },
+            render: FindingsRender {
+                grouping: Grouping::Flat,
+                collapse: Collapse::Collapsed,
+            },
         }
     }
 
@@ -1805,7 +1817,10 @@ mod story_118 {
         TerminalReporter {
             use_color: false,
             show_hosts_breakdown: false,
-            render: FindingsRender { grouping: Grouping::Grouped, collapse: Collapse::Expanded },
+            render: FindingsRender {
+                grouping: Grouping::Grouped,
+                collapse: Collapse::Expanded,
+            },
         }
     }
 
@@ -3340,7 +3355,10 @@ mod story_118 {
         let reporter_on = TerminalReporter {
             use_color: false,
             show_hosts_breakdown: false,
-            render: FindingsRender { grouping: Grouping::Flat, collapse: Collapse::Collapsed },
+            render: FindingsRender {
+                grouping: Grouping::Flat,
+                collapse: Collapse::Collapsed,
+            },
         };
         let out_on = reporter_on.render(&Summary::new(), &findings, &[]);
         assert!(
@@ -3352,7 +3370,10 @@ mod story_118 {
         let reporter_off = TerminalReporter {
             use_color: false,
             show_hosts_breakdown: false,
-            render: FindingsRender { grouping: Grouping::Flat, collapse: Collapse::Expanded },
+            render: FindingsRender {
+                grouping: Grouping::Flat,
+                collapse: Collapse::Expanded,
+            },
         };
         let out_off = reporter_off.render(&Summary::new(), &findings, &[]);
         assert!(
@@ -3995,7 +4016,10 @@ mod story_120 {
     /// The enum has exactly three variants and no Default impl.
     #[test]
     fn test_findings_render_derives_debug_clone_copy_partialeq_eq() {
-        let a = FindingsRender { grouping: Grouping::Grouped, collapse: Collapse::Expanded };
+        let a = FindingsRender {
+            grouping: Grouping::Grouped,
+            collapse: Collapse::Expanded,
+        };
         let b = a; // Copy
         let c = Clone::clone(&a); // Clone (explicit form avoids clone_on_copy lint)
         assert_eq!(a, b, "PartialEq + Eq: Grouped == copied Grouped");
@@ -4004,25 +4028,70 @@ mod story_120 {
 
         // All three variants are distinct.
         assert_ne!(
-            FindingsRender { grouping: Grouping::Grouped, collapse: Collapse::Expanded },
-            FindingsRender { grouping: Grouping::Flat, collapse: Collapse::Collapsed },
+            FindingsRender {
+                grouping: Grouping::Grouped,
+                collapse: Collapse::Expanded
+            },
+            FindingsRender {
+                grouping: Grouping::Flat,
+                collapse: Collapse::Collapsed
+            },
             "Grouped != FlatCollapsed"
         );
         assert_ne!(
-            FindingsRender { grouping: Grouping::Grouped, collapse: Collapse::Expanded },
-            FindingsRender { grouping: Grouping::Flat, collapse: Collapse::Expanded },
+            FindingsRender {
+                grouping: Grouping::Grouped,
+                collapse: Collapse::Expanded
+            },
+            FindingsRender {
+                grouping: Grouping::Flat,
+                collapse: Collapse::Expanded
+            },
             "Grouped != FlatExpanded"
         );
         assert_ne!(
-            FindingsRender { grouping: Grouping::Flat, collapse: Collapse::Collapsed },
-            FindingsRender { grouping: Grouping::Flat, collapse: Collapse::Expanded },
+            FindingsRender {
+                grouping: Grouping::Flat,
+                collapse: Collapse::Collapsed
+            },
+            FindingsRender {
+                grouping: Grouping::Flat,
+                collapse: Collapse::Expanded
+            },
             "FlatCollapsed != FlatExpanded"
         );
 
         // Debug formats include the variant name.
-        assert!(format!("{:?}", FindingsRender { grouping: Grouping::Grouped, collapse: Collapse::Expanded }).contains("Grouped"));
-        assert!(format!("{:?}", FindingsRender { grouping: Grouping::Flat, collapse: Collapse::Collapsed }).contains("FlatCollapsed"));
-        assert!(format!("{:?}", FindingsRender { grouping: Grouping::Flat, collapse: Collapse::Expanded }).contains("FlatExpanded"));
+        assert!(
+            format!(
+                "{:?}",
+                FindingsRender {
+                    grouping: Grouping::Grouped,
+                    collapse: Collapse::Expanded
+                }
+            )
+            .contains("Grouped")
+        );
+        assert!(
+            format!(
+                "{:?}",
+                FindingsRender {
+                    grouping: Grouping::Flat,
+                    collapse: Collapse::Collapsed
+                }
+            )
+            .contains("FlatCollapsed")
+        );
+        assert!(
+            format!(
+                "{:?}",
+                FindingsRender {
+                    grouping: Grouping::Flat,
+                    collapse: Collapse::Expanded
+                }
+            )
+            .contains("FlatExpanded")
+        );
     }
 
     // -----------------------------------------------------------------------
@@ -4042,7 +4111,10 @@ mod story_120 {
         let r = TerminalReporter {
             use_color: false,
             show_hosts_breakdown: false,
-            render: FindingsRender { grouping: Grouping::Flat, collapse: Collapse::Expanded },
+            render: FindingsRender {
+                grouping: Grouping::Flat,
+                collapse: Collapse::Expanded,
+            },
         };
         // The struct renders fine (behavioral sanity).
         let out = r.render(&Summary::new(), &[], &[]);
@@ -4073,7 +4145,10 @@ mod story_120 {
         let grouped_out = TerminalReporter {
             use_color: false,
             show_hosts_breakdown: false,
-            render: FindingsRender { grouping: Grouping::Grouped, collapse: Collapse::Expanded },
+            render: FindingsRender {
+                grouping: Grouping::Grouped,
+                collapse: Collapse::Expanded,
+            },
         }
         .render(&Summary::new(), &findings, &[]);
         assert!(
@@ -4085,7 +4160,10 @@ mod story_120 {
         let collapsed_out = TerminalReporter {
             use_color: false,
             show_hosts_breakdown: false,
-            render: FindingsRender { grouping: Grouping::Flat, collapse: Collapse::Collapsed },
+            render: FindingsRender {
+                grouping: Grouping::Flat,
+                collapse: Collapse::Collapsed,
+            },
         }
         .render(&Summary::new(), &findings, &[]);
         assert!(
@@ -4098,7 +4176,10 @@ mod story_120 {
         let expanded_out = TerminalReporter {
             use_color: false,
             show_hosts_breakdown: false,
-            render: FindingsRender { grouping: Grouping::Flat, collapse: Collapse::Expanded },
+            render: FindingsRender {
+                grouping: Grouping::Flat,
+                collapse: Collapse::Expanded,
+            },
         }
         .render(&Summary::new(), &findings, &[]);
         assert!(
@@ -4145,7 +4226,10 @@ mod story_120 {
         let out = TerminalReporter {
             use_color: false,
             show_hosts_breakdown: false,
-            render: FindingsRender { grouping: Grouping::Grouped, collapse: Collapse::Expanded },
+            render: FindingsRender {
+                grouping: Grouping::Grouped,
+                collapse: Collapse::Expanded,
+            },
         }
         .render(&Summary::new(), &findings, &[]);
 
@@ -4180,7 +4264,10 @@ mod story_120 {
         let out_collapsed = TerminalReporter {
             use_color: false,
             show_hosts_breakdown: false,
-            render: FindingsRender { grouping: Grouping::Flat, collapse: Collapse::Collapsed },
+            render: FindingsRender {
+                grouping: Grouping::Flat,
+                collapse: Collapse::Collapsed,
+            },
         }
         .render(&Summary::new(), &findings, &[]);
         assert!(
@@ -4193,7 +4280,10 @@ mod story_120 {
         let out_expanded = TerminalReporter {
             use_color: false,
             show_hosts_breakdown: false,
-            render: FindingsRender { grouping: Grouping::Flat, collapse: Collapse::Expanded },
+            render: FindingsRender {
+                grouping: Grouping::Flat,
+                collapse: Collapse::Expanded,
+            },
         }
         .render(&Summary::new(), &findings, &[]);
         assert!(
@@ -4207,6 +4297,877 @@ mod story_120 {
             out_collapsed, out_expanded,
             "AC-005: FlatCollapsed and FlatExpanded must produce different output \
              for N≥2 identical-key findings"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// STORY-122 RED gate tests
+//
+// These tests lock in the STORY-122 acceptance criteria for the
+// FindingsRender enum→struct reshape (Option X). The stub-architect
+// (commit dec8a55) reshaped the types and migrated the 84 construction
+// sites; these tests verify both the completed mechanical migration and
+// the remaining Task-4 comment-sweep work.
+//
+// Tests tied to UNFINISHED work (Task 4 comment sweep) are RED on this
+// commit. Tests for already-complete type/dispatch/wiring work are GREEN.
+//
+// DF-TEST-NAMESPACE-001: per-story mod wrapper.
+// ---------------------------------------------------------------------------
+
+mod story_122 {
+    use std::path::Path;
+    use wirerust::findings::{Confidence, Finding, ThreatCategory, Verdict};
+    use wirerust::reporter::Reporter;
+    use wirerust::reporter::terminal::{Collapse, FindingsRender, Grouping, TerminalReporter};
+    use wirerust::summary::Summary;
+
+    fn make_finding_s122(summary: impl Into<String>) -> Finding {
+        Finding {
+            category: ThreatCategory::Anomaly,
+            verdict: Verdict::Inconclusive,
+            confidence: Confidence::Low,
+            summary: summary.into(),
+            evidence: vec![],
+            mitre_techniques: vec![],
+            source_ip: None,
+            timestamp: None,
+            direction: None,
+        }
+    }
+
+    fn make_mitre_finding_s122(summary: impl Into<String>) -> Finding {
+        Finding {
+            category: ThreatCategory::Anomaly,
+            verdict: Verdict::Likely,
+            confidence: Confidence::High,
+            summary: summary.into(),
+            evidence: vec![],
+            mitre_techniques: vec!["T1046".to_string()],
+            source_ip: None,
+            timestamp: None,
+            direction: None,
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // AC-001 — Grouping, Collapse, and FindingsRender struct defined correctly
+    // (traces to BC-2.11.028 Invariant 1)
+    // -----------------------------------------------------------------------
+
+    /// AC-001 (BC-2.11.028 Invariant 1):
+    /// All four Grouping × Collapse combinations are pairwise distinct.
+    /// Grouping and Collapse each derive Debug, Clone, Copy, PartialEq, Eq.
+    /// FindingsRender struct derives Debug, Clone, Copy, PartialEq, Eq.
+    /// No Default is derived on any of the three types.
+    #[test]
+    fn test_BC_2_11_028_ac001_four_combos_pairwise_distinct() {
+        let grouped_expanded = FindingsRender {
+            grouping: Grouping::Grouped,
+            collapse: Collapse::Expanded,
+        };
+        let grouped_collapsed = FindingsRender {
+            grouping: Grouping::Grouped,
+            collapse: Collapse::Collapsed,
+        };
+        let flat_collapsed = FindingsRender {
+            grouping: Grouping::Flat,
+            collapse: Collapse::Collapsed,
+        };
+        let flat_expanded = FindingsRender {
+            grouping: Grouping::Flat,
+            collapse: Collapse::Expanded,
+        };
+
+        // Copy semantics: binding a second name does not move.
+        let ge2 = grouped_expanded;
+        assert_eq!(
+            grouped_expanded, ge2,
+            "AC-001: Copy + PartialEq: {ge2:?} == copy"
+        );
+
+        // Clone semantics.
+        let gc2 = Clone::clone(&grouped_collapsed);
+        assert_eq!(
+            grouped_collapsed, gc2,
+            "AC-001: Clone + PartialEq: {gc2:?} == clone"
+        );
+
+        // Debug is implemented — would panic at format time if not.
+        let _ = format!("{grouped_expanded:?}");
+        let _ = format!("{grouped_collapsed:?}");
+        let _ = format!("{flat_collapsed:?}");
+        let _ = format!("{flat_expanded:?}");
+
+        // All four Grouping × Collapse combinations are pairwise distinct.
+        assert_ne!(
+            grouped_expanded, grouped_collapsed,
+            "AC-001: {grouped_expanded:?} != {grouped_collapsed:?}"
+        );
+        assert_ne!(
+            grouped_expanded, flat_collapsed,
+            "AC-001: {grouped_expanded:?} != {flat_collapsed:?}"
+        );
+        assert_ne!(
+            grouped_expanded, flat_expanded,
+            "AC-001: {grouped_expanded:?} != {flat_expanded:?}"
+        );
+        assert_ne!(
+            grouped_collapsed, flat_collapsed,
+            "AC-001: {grouped_collapsed:?} != {flat_collapsed:?}"
+        );
+        assert_ne!(
+            grouped_collapsed, flat_expanded,
+            "AC-001: {grouped_collapsed:?} != {flat_expanded:?}"
+        );
+        assert_ne!(
+            flat_collapsed, flat_expanded,
+            "AC-001: {flat_collapsed:?} != {flat_expanded:?}"
+        );
+    }
+
+    /// AC-001 (BC-2.11.028 Invariant 1):
+    /// Debug output for FindingsRender struct uses struct-of-enums vocabulary,
+    /// not the old enum-variant vocabulary. Field names "grouping" and "collapse"
+    /// appear in the Debug representation; old variant names "FlatCollapsed" and
+    /// "FlatExpanded" do not.
+    #[test]
+    fn test_BC_2_11_028_ac001_debug_format_struct_vocabulary() {
+        // Struct debug output contains field and variant names.
+        let ge_dbg = format!(
+            "{:?}",
+            FindingsRender {
+                grouping: Grouping::Grouped,
+                collapse: Collapse::Expanded
+            }
+        );
+        assert!(
+            ge_dbg.contains("grouping"),
+            "AC-001: Debug must include field name 'grouping'; got: {ge_dbg}"
+        );
+        assert!(
+            ge_dbg.contains("collapse"),
+            "AC-001: Debug must include field name 'collapse'; got: {ge_dbg}"
+        );
+        assert!(
+            ge_dbg.contains("Grouped"),
+            "AC-001: Debug must include 'Grouped' for Grouping::Grouped; got: {ge_dbg}"
+        );
+        assert!(
+            ge_dbg.contains("Expanded"),
+            "AC-001: Debug must include 'Expanded' for Collapse::Expanded; got: {ge_dbg}"
+        );
+
+        let fc_dbg = format!(
+            "{:?}",
+            FindingsRender {
+                grouping: Grouping::Flat,
+                collapse: Collapse::Collapsed
+            }
+        );
+        assert!(
+            fc_dbg.contains("Flat"),
+            "AC-001: Debug must include 'Flat' for Grouping::Flat; got: {fc_dbg}"
+        );
+        assert!(
+            fc_dbg.contains("Collapsed"),
+            "AC-001: Debug must include 'Collapsed' for Collapse::Collapsed; got: {fc_dbg}"
+        );
+
+        // Old enum-variant concatenated names must NOT appear in debug output.
+        assert!(
+            !fc_dbg.contains("FlatCollapsed"),
+            "AC-001: Debug must not contain old enum token 'FlatCollapsed'; got: {fc_dbg}"
+        );
+        let fe_dbg = format!(
+            "{:?}",
+            FindingsRender {
+                grouping: Grouping::Flat,
+                collapse: Collapse::Expanded
+            }
+        );
+        assert!(
+            !fe_dbg.contains("FlatExpanded"),
+            "AC-001: Debug must not contain old enum token 'FlatExpanded'; got: {fe_dbg}"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // AC-002 — Four-arm exhaustive tuple dispatch
+    // (traces to BC-2.11.013 Invariant 4)
+    // -----------------------------------------------------------------------
+
+    /// AC-002 (BC-2.11.013 Invariant 4):
+    /// The {Grouped, Expanded} dispatch arm routes to render_findings_grouped —
+    /// MITRE tactic headers ("## ") appear in output.
+    #[test]
+    fn test_BC_2_11_028_ac002_grouped_expanded_arm_routes_to_render_findings_grouped() {
+        let findings: Vec<Finding> = (0..3)
+            .map(|_| make_mitre_finding_s122("s122-dispatch-ge"))
+            .collect();
+        let out = TerminalReporter {
+            use_color: false,
+            show_hosts_breakdown: false,
+            render: FindingsRender {
+                grouping: Grouping::Grouped,
+                collapse: Collapse::Expanded,
+            },
+        }
+        .render(&Summary::new(), &findings, &[]);
+        assert!(
+            out.contains("## "),
+            "AC-002: {{Grouped,Expanded}} arm must emit tactic header '## '; got:\n{out}"
+        );
+        assert!(
+            !out.contains("(x"),
+            "AC-002: {{Grouped,Expanded}} arm must not emit (xN) suffix; got:\n{out}"
+        );
+    }
+
+    /// AC-002 (BC-2.11.013 Invariant 4):
+    /// The {Grouped, Collapsed} dispatch arm TEMPORARILY routes to render_findings_grouped
+    /// (same as {Grouped, Expanded}) — output is byte-identical; tactic headers appear
+    /// and no (xN) suffix is emitted. This arm is unreachable via the CLI in STORY-122/A;
+    /// STORY-119/B repoints it to render_findings_grouped_collapsed.
+    #[test]
+    fn test_BC_2_11_028_ac002_grouped_collapsed_arm_temporary_routes_to_render_findings_grouped() {
+        let findings: Vec<Finding> = (0..3)
+            .map(|_| make_mitre_finding_s122("s122-dispatch-gc"))
+            .collect();
+
+        let out_gc = TerminalReporter {
+            use_color: false,
+            show_hosts_breakdown: false,
+            render: FindingsRender {
+                grouping: Grouping::Grouped,
+                collapse: Collapse::Collapsed,
+            },
+        }
+        .render(&Summary::new(), &findings, &[]);
+
+        let out_ge = TerminalReporter {
+            use_color: false,
+            show_hosts_breakdown: false,
+            render: FindingsRender {
+                grouping: Grouping::Grouped,
+                collapse: Collapse::Expanded,
+            },
+        }
+        .render(&Summary::new(), &findings, &[]);
+
+        // TEMPORARY: {Grouped,Collapsed} routes to the same function as {Grouped,Expanded}.
+        assert_eq!(
+            out_gc, out_ge,
+            "AC-002: {{Grouped,Collapsed}} arm (TEMPORARY in STORY-122/A) must produce \
+             byte-identical output to {{Grouped,Expanded}}; outputs differ"
+        );
+        assert!(
+            out_gc.contains("## "),
+            "AC-002: {{Grouped,Collapsed}} arm must emit tactic header '## '; got:\n{out_gc}"
+        );
+    }
+
+    /// AC-002 (BC-2.11.013 Invariant 4):
+    /// The {Flat, Collapsed} dispatch arm routes to render_findings_collapsed —
+    /// (xN) suffix appears for N≥2 identical-key findings.
+    #[test]
+    fn test_BC_2_11_028_ac002_flat_collapsed_arm_routes_to_render_findings_collapsed() {
+        let findings: Vec<Finding> = (0..3)
+            .map(|_| make_finding_s122("s122-dispatch-fc"))
+            .collect();
+        let out = TerminalReporter {
+            use_color: false,
+            show_hosts_breakdown: false,
+            render: FindingsRender {
+                grouping: Grouping::Flat,
+                collapse: Collapse::Collapsed,
+            },
+        }
+        .render(&Summary::new(), &findings, &[]);
+        assert!(
+            out.contains("(x3)"),
+            "AC-002: {{Flat,Collapsed}} arm must emit '(x3)' for 3 identical-key findings; got:\n{out}"
+        );
+    }
+
+    /// AC-002 (BC-2.11.013 Invariant 4):
+    /// The {Flat, Expanded} dispatch arm iterates render_finding_flat —
+    /// 3 individual finding lines with no (xN) suffix.
+    #[test]
+    fn test_BC_2_11_028_ac002_flat_expanded_arm_iterates_render_finding_flat() {
+        let findings: Vec<Finding> = (0..3)
+            .map(|_| make_finding_s122("s122-dispatch-fe"))
+            .collect();
+        let out = TerminalReporter {
+            use_color: false,
+            show_hosts_breakdown: false,
+            render: FindingsRender {
+                grouping: Grouping::Flat,
+                collapse: Collapse::Expanded,
+            },
+        }
+        .render(&Summary::new(), &findings, &[]);
+        assert!(
+            !out.contains("(x"),
+            "AC-002: {{Flat,Expanded}} arm must not emit (xN) suffix; got:\n{out}"
+        );
+        let count = out.matches("s122-dispatch-fe").count();
+        assert_eq!(
+            count, 3,
+            "AC-002: {{Flat,Expanded}} arm must emit 3 individual finding lines; found {count} in:\n{out}"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // AC-004 — run_analyze construction site: 3-arm if → 3 struct literals
+    // (traces to BC-2.11.028 Invariant 1)
+    //
+    // run_analyze is not directly callable from tests (reads pcap files), so
+    // we verify the wiring by asserting the behavior of TerminalReporter
+    // constructed with the exact FindingsRender values that run_analyze
+    // produces for each flag combination (byte-identical to v0.9.0 branching).
+    // -----------------------------------------------------------------------
+
+    /// AC-004 (BC-2.11.028 Invariant 1, EC-001):
+    /// --mitre alone (show_mitre_grouping=true) → run_analyze produces
+    /// FindingsRender { grouping: Grouping::Grouped, collapse: Collapse::Expanded }.
+    /// Routes to render_findings_grouped; tactic headers emitted; no (xN) suffix.
+    /// {Grouped, Collapsed} is NOT produced by run_analyze in STORY-122/A.
+    #[test]
+    fn test_BC_2_11_028_ac004_mitre_alone_yields_grouped_expanded() {
+        let findings: Vec<Finding> = (0..2)
+            .map(|_| make_mitre_finding_s122("s122-ac004-mitre"))
+            .collect();
+
+        // The struct value run_analyze produces when show_mitre_grouping=true.
+        let render_from_mitre_flag = FindingsRender {
+            grouping: Grouping::Grouped,
+            collapse: Collapse::Expanded,
+        };
+
+        let out = TerminalReporter {
+            use_color: false,
+            show_hosts_breakdown: false,
+            render: render_from_mitre_flag,
+        }
+        .render(&Summary::new(), &findings, &[]);
+
+        assert!(
+            out.contains("## "),
+            "AC-004: --mitre alone → {{Grouped,Expanded}} must emit tactic headers; got:\n{out}"
+        );
+        assert!(
+            !out.contains("(x"),
+            "AC-004: --mitre alone → {{Grouped,Expanded}} must not emit (xN) suffix; got:\n{out}"
+        );
+
+        // {Grouped, Collapsed} is NOT what --mitre alone produces in STORY-122/A.
+        let render_grouped_collapsed = FindingsRender {
+            grouping: Grouping::Grouped,
+            collapse: Collapse::Collapsed,
+        };
+        assert_ne!(
+            render_from_mitre_flag, render_grouped_collapsed,
+            "AC-004: run_analyze with --mitre alone must produce {{Grouped,Expanded}}, \
+             not {{Grouped,Collapsed}} — the CLI flip is STORY-119/B scope"
+        );
+    }
+
+    /// AC-004 (BC-2.11.028 Invariant 1, EC-003):
+    /// Default (show_mitre_grouping=false, collapse_findings=true) →
+    /// run_analyze produces FindingsRender { grouping: Grouping::Flat, collapse: Collapse::Collapsed }.
+    /// Routes to render_findings_collapsed; (xN) suffix for identical findings.
+    #[test]
+    fn test_BC_2_11_028_ac004_default_yields_flat_collapsed() {
+        let findings: Vec<Finding> = (0..3)
+            .map(|_| make_finding_s122("s122-ac004-default"))
+            .collect();
+
+        // The struct value run_analyze produces for the default (no --mitre, collapse_findings=true).
+        let render_default = FindingsRender {
+            grouping: Grouping::Flat,
+            collapse: Collapse::Collapsed,
+        };
+
+        let out = TerminalReporter {
+            use_color: false,
+            show_hosts_breakdown: false,
+            render: render_default,
+        }
+        .render(&Summary::new(), &findings, &[]);
+
+        assert!(
+            out.contains("(x3)"),
+            "AC-004: default → {{Flat,Collapsed}} must emit '(x3)' for 3 identical-key findings; got:\n{out}"
+        );
+        assert!(
+            !out.contains("## "),
+            "AC-004: default → {{Flat,Collapsed}} must not emit tactic headers; got:\n{out}"
+        );
+    }
+
+    /// AC-004 (BC-2.11.028 Invariant 1, EC-002):
+    /// --no-collapse (show_mitre_grouping=false, collapse_findings=false) →
+    /// run_analyze produces FindingsRender { grouping: Grouping::Flat, collapse: Collapse::Expanded }.
+    /// Routes to render_finding_flat per-item; 3 individual lines, no (xN) suffix.
+    #[test]
+    fn test_BC_2_11_028_ac004_no_collapse_yields_flat_expanded() {
+        let findings: Vec<Finding> = (0..3)
+            .map(|_| make_finding_s122("s122-ac004-nocollapse"))
+            .collect();
+
+        // The struct value run_analyze produces for --no-collapse (collapse_findings=false).
+        let render_no_collapse = FindingsRender {
+            grouping: Grouping::Flat,
+            collapse: Collapse::Expanded,
+        };
+
+        let out = TerminalReporter {
+            use_color: false,
+            show_hosts_breakdown: false,
+            render: render_no_collapse,
+        }
+        .render(&Summary::new(), &findings, &[]);
+
+        assert!(
+            !out.contains("(x"),
+            "AC-004: --no-collapse → {{Flat,Expanded}} must not emit (xN) suffix; got:\n{out}"
+        );
+        let count = out.matches("s122-ac004-nocollapse").count();
+        assert_eq!(
+            count, 3,
+            "AC-004: --no-collapse → {{Flat,Expanded}} must emit 3 individual lines; found {count}"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // AC-005 — run_summary construction site uses {Flat, Collapsed}
+    // (traces to BC-2.11.028 Postcondition 4)
+    // -----------------------------------------------------------------------
+
+    /// AC-005 (BC-2.11.028 Postcondition 4):
+    /// run_summary uses FindingsRender { grouping: Grouping::Flat, collapse: Collapse::Collapsed }.
+    /// The render field is inert for run_summary (no FINDINGS section rendered).
+    /// TerminalReporter constructed with that value renders a valid report.
+    #[test]
+    fn test_BC_2_11_028_ac005_run_summary_construction_uses_flat_collapsed() {
+        // The struct value run_summary uses — inert (run_summary renders no FINDINGS section).
+        let render_summary = FindingsRender {
+            grouping: Grouping::Flat,
+            collapse: Collapse::Collapsed,
+        };
+
+        let reporter = TerminalReporter {
+            use_color: false,
+            show_hosts_breakdown: false,
+            render: render_summary,
+        };
+
+        // run_summary passes an empty findings slice — no FINDINGS section appears.
+        let out = reporter.render(&Summary::new(), &[], &[]);
+        assert!(
+            out.contains("WIRERUST TRIAGE REPORT"),
+            "AC-005: run_summary construction site must render a valid report header; got:\n{out}"
+        );
+        assert!(
+            !out.contains("FINDINGS"),
+            "AC-005: run_summary with empty findings must not emit FINDINGS section; got:\n{out}"
+        );
+
+        // The run_summary value matches exactly {Flat, Collapsed}.
+        assert_eq!(
+            render_summary,
+            FindingsRender {
+                grouping: Grouping::Flat,
+                collapse: Collapse::Collapsed
+            },
+            "AC-005: run_summary FindingsRender must be {{Flat,Collapsed}}"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // AC-006 — Output byte-identical to v0.9.0 for all existing CLI combos
+    // (traces to BC-2.11.013 Invariant 4)
+    //
+    // The three CLI-reachable paths in STORY-122/A are verified by asserting
+    // that each FindingsRender value routes to the same render function as
+    // the old enum variant it replaced, producing the same observable output.
+    // -----------------------------------------------------------------------
+
+    /// AC-006 (BC-2.11.013 Invariant 4):
+    /// {Grouped, Expanded} (--mitre alone in STORY-122/A) produces the same
+    /// output as the old FindingsRender::Grouped enum variant:
+    /// tactic headers present, no (xN) suffix, byte-identical across the reshape.
+    #[test]
+    fn test_BC_2_11_028_ac006_grouped_expanded_byte_identical_to_old_grouped_variant() {
+        let findings: Vec<Finding> = (0..2)
+            .map(|_| make_mitre_finding_s122("s122-ac006-byteident"))
+            .collect();
+
+        let out = TerminalReporter {
+            use_color: false,
+            show_hosts_breakdown: false,
+            render: FindingsRender {
+                grouping: Grouping::Grouped,
+                collapse: Collapse::Expanded,
+            },
+        }
+        .render(&Summary::new(), &findings, &[]);
+
+        // Grouped-expanded output has tactic headers and no collapse suffixes.
+        assert!(
+            out.contains("## "),
+            "AC-006: {{Grouped,Expanded}} must emit '## ' tactic header"
+        );
+        assert!(
+            !out.contains("(x"),
+            "AC-006: {{Grouped,Expanded}} must not emit (xN) suffix"
+        );
+        // Finding summary appears (not collapsed away).
+        assert!(
+            out.matches("s122-ac006-byteident").count() >= 2,
+            "AC-006: {{Grouped,Expanded}} must emit all 2 findings individually"
+        );
+    }
+
+    /// AC-006 (BC-2.11.026 Postcondition 4, BC-2.11.027 Postcondition 1):
+    /// {Flat, Collapsed} (default in STORY-122/A) produces the same output as
+    /// the old FindingsRender::FlatCollapsed: (xN) suffix for N≥2, up to K=3
+    /// evidence lines, MITRE line for non-empty mitre_techniques.
+    #[test]
+    fn test_BC_2_11_028_ac006_flat_collapsed_byte_identical_to_old_flatcollapsed_variant() {
+        let findings: Vec<Finding> = (0..3)
+            .map(|i| Finding {
+                category: ThreatCategory::Anomaly,
+                verdict: Verdict::Likely,
+                confidence: Confidence::High,
+                summary: "s122-ac006-collapse".to_string(),
+                evidence: vec![format!("ev{i}")],
+                mitre_techniques: vec!["T1046".to_string()],
+                source_ip: None,
+                timestamp: None,
+                direction: None,
+            })
+            .collect();
+
+        let out = TerminalReporter {
+            use_color: false,
+            show_hosts_breakdown: false,
+            render: FindingsRender {
+                grouping: Grouping::Flat,
+                collapse: Collapse::Collapsed,
+            },
+        }
+        .render(&Summary::new(), &findings, &[]);
+
+        // BC-2.11.026 PC-4: (xN) suffix for collapsed group of N=3.
+        assert!(
+            out.contains("(x3)"),
+            "AC-006: {{Flat,Collapsed}} must emit '(x3)' for 3 identical-key findings; got:\n{out}"
+        );
+        // BC-2.11.027 PC-1: up to K=3 evidence lines.
+        assert!(
+            out.contains("ev0"),
+            "AC-006: first evidence line ev0 must appear; got:\n{out}"
+        );
+        // MITRE line for non-empty mitre_techniques.
+        assert!(
+            out.contains("T1046"),
+            "AC-006: MITRE technique T1046 must appear; got:\n{out}"
+        );
+    }
+
+    /// AC-006 (BC-2.11.013 Invariant 4):
+    /// {Flat, Expanded} (--no-collapse in STORY-122/A) produces the same output
+    /// as the old FindingsRender::FlatExpanded: 3 individual lines, no (xN) suffix.
+    #[test]
+    fn test_BC_2_11_028_ac006_flat_expanded_byte_identical_to_old_flatexpanded_variant() {
+        let findings: Vec<Finding> = (0..3).map(|_| make_finding_s122("s122-ac006-fe")).collect();
+
+        let out = TerminalReporter {
+            use_color: false,
+            show_hosts_breakdown: false,
+            render: FindingsRender {
+                grouping: Grouping::Flat,
+                collapse: Collapse::Expanded,
+            },
+        }
+        .render(&Summary::new(), &findings, &[]);
+
+        assert!(
+            !out.contains("(x"),
+            "AC-006: {{Flat,Expanded}} must not emit (xN) suffix; got:\n{out}"
+        );
+        assert_eq!(
+            out.matches("s122-ac006-fe").count(),
+            3,
+            "AC-006: {{Flat,Expanded}} must emit 3 individual finding lines"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // AC-007 — Comment sweep: stale prose is absent from swept targets
+    // (traces to BC-2.11.028 Invariant 6)
+    //
+    // These tests read src/reporter/terminal.rs and tests/reporter_terminal_tests.rs
+    // via include_str! at compile time (file paths anchored to crate root) and
+    // assert that the stale prose tokens listed in the STORY-122 Task-4
+    // Falsifiable Requirements are absent.
+    //
+    // RED: These tests FAIL on this commit because Task 4 (comment sweep)
+    // has not been performed yet by the implementer. The grep gate values
+    // match STORY-122 AC-007 / Task-4 Falsifiable Requirements (3) and (4).
+    //
+    // EXEMPT: The pattern "three fields" is NOT in the gate (exempt:
+    // TerminalReporter-field prose at reporter_terminal_tests.rs:4040).
+    // The "All three boundary" (escape test) and "All three findings must appear"
+    // (count-of-test-findings comment) are also exempt per AC-007.
+    // -----------------------------------------------------------------------
+
+    /// AC-007 (BC-2.11.028 Invariant 6):
+    /// src/reporter/terminal.rs contains no stale "three mutually-exclusive" prose.
+    /// Gate 4 from STORY-122 Task-4 Falsifiable Requirements.
+    #[test]
+    fn test_BC_2_11_028_ac007_terminal_rs_no_three_mutually_exclusive() {
+        let src = include_str!("../src/reporter/terminal.rs");
+        assert!(
+            !src.contains("three mutually-exclusive"),
+            "AC-007: src/reporter/terminal.rs must not contain stale 'three mutually-exclusive' \
+             prose; Task 4 comment sweep is incomplete"
+        );
+    }
+
+    /// AC-007 (BC-2.11.028 Invariant 6):
+    /// src/reporter/terminal.rs contains no stale "verdict-desc" or "confidence-desc"
+    /// doc-comment text. Gate 2 from STORY-122 Task-4 Falsifiable Requirements.
+    #[test]
+    fn test_BC_2_11_028_ac007_terminal_rs_no_verdict_desc_or_confidence_desc() {
+        let src = include_str!("../src/reporter/terminal.rs");
+        assert!(
+            !src.contains("verdict-desc"),
+            "AC-007: src/reporter/terminal.rs must not contain stale 'verdict-desc' in \
+             render_findings_grouped doc-comment; Task 4 comment sweep is incomplete"
+        );
+        assert!(
+            !src.contains("confidence-desc"),
+            "AC-007: src/reporter/terminal.rs must not contain stale 'confidence-desc' in \
+             render_findings_grouped doc-comment; Task 4 comment sweep is incomplete"
+        );
+    }
+
+    /// AC-007 (BC-2.11.028 Invariant 6):
+    /// tests/reporter_terminal_tests.rs contains no stale three-variant / three-arm /
+    /// three mutually-exclusive / All three FindingsRender / All three outputs /
+    /// impossible state prose in the swept targets.
+    /// Gate 3 from STORY-122 Task-4 Falsifiable Requirements.
+    ///
+    /// EXEMPT tokens NOT checked here:
+    ///   - "three fields" (TerminalReporter-field comment at :4040) — correct, not stale.
+    ///   - "All three boundary" (escape-boundary test at :394) — unrelated to FindingsRender.
+    ///   - "All three findings must appear" (test-finding count at :3512) — unrelated.
+    #[test]
+    fn test_BC_2_11_028_ac007_test_file_no_stale_findingsrender_prose() {
+        let src = include_str!("../tests/reporter_terminal_tests.rs");
+
+        // Split into lines so we can skip exempt lines by their anchored text.
+        let exempt_line_fragments: &[&str] = &[
+            // :4040 — "these three fields exist on TerminalReporter" — EXEMPT.
+            "these three fields exist on TerminalReporter",
+            // :394 — "All three boundary" — EXEMPT (escape boundary values).
+            "All three boundary",
+            // :3512 — "All three findings must appear" — EXEMPT (count of test findings).
+            "All three findings must appear",
+        ];
+
+        let stale_tokens: &[&str] = &[
+            "three-variant",
+            "three variants",
+            "All three FindingsRender",
+            "All three outputs",
+            "three arm",
+            "three-arm",
+            "three mutually-exclusive",
+            "three-way",
+            "impossible state",
+        ];
+
+        let mut violations: Vec<String> = Vec::new();
+        for (line_no, line) in src.lines().enumerate() {
+            // Skip exempt lines.
+            let is_exempt = exempt_line_fragments.iter().any(|frag| line.contains(frag));
+            if is_exempt {
+                continue;
+            }
+            for token in stale_tokens {
+                if line.contains(token) {
+                    violations.push(format!(
+                        "  line {}: {:?} (token: {:?})",
+                        line_no + 1,
+                        line.trim(),
+                        token
+                    ));
+                }
+            }
+        }
+
+        assert!(
+            violations.is_empty(),
+            "AC-007: tests/reporter_terminal_tests.rs contains stale FindingsRender prose \
+             that Task 4 comment sweep must remove:\n{}",
+            violations.join("\n")
+        );
+    }
+
+    /// AC-007 (BC-2.11.028 Invariant 6):
+    /// src/main.rs contains no stale three-mutually-exclusive / three-way /
+    /// impossible-state / three-mode prose.
+    /// Gate 4 (src/ targets) from STORY-122 Task-4 Falsifiable Requirements.
+    #[test]
+    fn test_BC_2_11_028_ac007_main_rs_no_stale_findingsrender_prose() {
+        let src = include_str!("../src/main.rs");
+        for token in &[
+            "three mutually-exclusive",
+            "three-way",
+            "impossible state",
+            "three mode",
+        ] {
+            assert!(
+                !src.contains(token),
+                "AC-007: src/main.rs must not contain stale token {:?}; \
+                 Task 4 comment sweep is incomplete",
+                token
+            );
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // AC-008 — BC-016/026/027 preserved byte-identically across reshape
+    // (traces to BC-2.11.016 Invariant 3, BC-2.11.026 Postcondition 4,
+    //  BC-2.11.027 Postcondition 1)
+    // -----------------------------------------------------------------------
+
+    /// AC-008 (BC-2.11.016 Invariant 3):
+    /// The em-dash MITRE name line is produced by render_findings_grouped
+    /// via the {Grouped, Expanded} arm — the reshape does not alter this behavior.
+    /// Known technique T1046 (Network Service Discovery) emits an em-dash line.
+    #[test]
+    fn test_BC_2_11_016_ac008_em_dash_mitre_format_preserved_after_reshape() {
+        let findings = vec![Finding {
+            category: ThreatCategory::Anomaly,
+            verdict: Verdict::Likely,
+            confidence: Confidence::High,
+            summary: "s122-ac008-emdash".to_string(),
+            evidence: vec![],
+            mitre_techniques: vec!["T1046".to_string()],
+            source_ip: None,
+            timestamp: None,
+            direction: None,
+        }];
+
+        let out = TerminalReporter {
+            use_color: false,
+            show_hosts_breakdown: false,
+            render: FindingsRender {
+                grouping: Grouping::Grouped,
+                collapse: Collapse::Expanded,
+            },
+        }
+        .render(&Summary::new(), &findings, &[]);
+
+        // BC-2.11.016: em-dash line for known MITRE ID.
+        assert!(
+            out.contains("\u{2014}"),
+            "AC-008: {{Grouped,Expanded}} must emit em-dash (U+2014) for known MITRE technique; got:\n{out}"
+        );
+        assert!(
+            out.contains("T1046"),
+            "AC-008: MITRE technique T1046 must appear in grouped output; got:\n{out}"
+        );
+    }
+
+    /// AC-008 (BC-2.11.026 Postcondition 4):
+    /// The flat (xN) suffix rule is preserved after the enum→struct reshape.
+    /// {Flat, Collapsed} with N=5 identical-key findings emits "(x5)" suffix.
+    #[test]
+    fn test_BC_2_11_026_ac008_flat_xn_suffix_preserved_after_reshape() {
+        let findings: Vec<Finding> = (0..5).map(|_| make_finding_s122("s122-ac008-xn")).collect();
+
+        let out = TerminalReporter {
+            use_color: false,
+            show_hosts_breakdown: false,
+            render: FindingsRender {
+                grouping: Grouping::Flat,
+                collapse: Collapse::Collapsed,
+            },
+        }
+        .render(&Summary::new(), &findings, &[]);
+
+        assert!(
+            out.contains("(x5)"),
+            "AC-008: {{Flat,Collapsed}} must emit '(x5)' for 5 identical-key findings; got:\n{out}"
+        );
+        // BC-2.11.026 PC-4: suffix-free guarantee scoped to {Grouped,Expanded}.
+        let grouped_out = TerminalReporter {
+            use_color: false,
+            show_hosts_breakdown: false,
+            render: FindingsRender {
+                grouping: Grouping::Grouped,
+                collapse: Collapse::Expanded,
+            },
+        }
+        .render(&Summary::new(), &findings, &[]);
+        assert!(
+            !grouped_out.contains("(x"),
+            "AC-008: {{Grouped,Expanded}} must never emit (xN) suffix (PC-4 suffix-free guarantee); got:\n{grouped_out}"
+        );
+    }
+
+    /// AC-008 (BC-2.11.027 Postcondition 1):
+    /// K=3 evidence sampling is preserved after the enum→struct reshape.
+    /// {Flat, Collapsed} with N=5 identical-key findings, each with evidence,
+    /// emits at most 3 evidence lines (K=3 cap).
+    #[test]
+    fn test_BC_2_11_027_ac008_k3_evidence_sampling_preserved_after_reshape() {
+        let findings: Vec<Finding> = (0..5)
+            .map(|i| Finding {
+                category: ThreatCategory::Anomaly,
+                verdict: Verdict::Likely,
+                confidence: Confidence::High,
+                summary: "s122-ac008-k3".to_string(),
+                evidence: vec![format!("evidence-line-{i}")],
+                mitre_techniques: vec![],
+                source_ip: None,
+                timestamp: None,
+                direction: None,
+            })
+            .collect();
+
+        let out = TerminalReporter {
+            use_color: false,
+            show_hosts_breakdown: false,
+            render: FindingsRender {
+                grouping: Grouping::Flat,
+                collapse: Collapse::Collapsed,
+            },
+        }
+        .render(&Summary::new(), &findings, &[]);
+
+        // BC-2.11.027 PC-1: at most K=3 evidence lines ("    > " prefix).
+        let evidence_line_count = out
+            .lines()
+            .filter(|l| l.trim_start().starts_with("> "))
+            .count();
+        assert!(
+            evidence_line_count <= 3,
+            "AC-008: K=3 cap — {{Flat,Collapsed}} must emit at most 3 evidence lines; \
+             got {evidence_line_count} in:\n{out}"
+        );
+        // At least 1 evidence line (confirms sampling path ran).
+        assert!(
+            evidence_line_count >= 1,
+            "AC-008: {{Flat,Collapsed}} with evidence-bearing findings must emit \
+             at least 1 evidence line; got {evidence_line_count} in:\n{out}"
         );
     }
 }

--- a/tests/reporter_tests.rs
+++ b/tests/reporter_tests.rs
@@ -5,7 +5,7 @@ use wirerust::reassembly::flow::FlowKey;
 use wirerust::reassembly::handler::{Direction, StreamAnalyzer, StreamHandler};
 use wirerust::reporter::Reporter;
 use wirerust::reporter::json::JsonReporter;
-use wirerust::reporter::terminal::{FindingsRender, TerminalReporter};
+use wirerust::reporter::terminal::{Collapse, FindingsRender, Grouping, TerminalReporter};
 use wirerust::summary::Summary;
 
 #[test]
@@ -449,7 +449,7 @@ fn test_terminal_hosts_breakdown_off_by_default() {
     let reporter = TerminalReporter {
         use_color: false,
         show_hosts_breakdown: false,
-        render: FindingsRender::FlatExpanded,
+        render: FindingsRender { grouping: Grouping::Flat, collapse: Collapse::Expanded },
     };
     let out = reporter.render(&summary, &[], &[]);
     assert!(
@@ -471,7 +471,7 @@ fn test_terminal_hosts_breakdown_lists_each_host_when_enabled() {
     let reporter = TerminalReporter {
         use_color: false,
         show_hosts_breakdown: true,
-        render: FindingsRender::FlatExpanded,
+        render: FindingsRender { grouping: Grouping::Flat, collapse: Collapse::Expanded },
     };
     let out = reporter.render(&summary, &[], &[]);
     assert!(
@@ -520,7 +520,7 @@ fn test_terminal_reporter_shows_skipped_when_nonzero() {
     let reporter = TerminalReporter {
         use_color: false,
         show_hosts_breakdown: false,
-        render: FindingsRender::FlatExpanded,
+        render: FindingsRender { grouping: Grouping::Flat, collapse: Collapse::Expanded },
     };
     let mut summary = Summary::new();
     summary.skipped_packets = 5;
@@ -537,7 +537,7 @@ fn test_terminal_reporter_hides_skipped_when_zero() {
     let reporter = TerminalReporter {
         use_color: false,
         show_hosts_breakdown: false,
-        render: FindingsRender::FlatExpanded,
+        render: FindingsRender { grouping: Grouping::Flat, collapse: Collapse::Expanded },
     };
     let summary = Summary::new();
 
@@ -557,7 +557,7 @@ fn test_terminal_reporter_escapes_esc_bytes_in_summary() {
     let reporter = TerminalReporter {
         use_color: false,
         show_hosts_breakdown: false,
-        render: FindingsRender::FlatExpanded,
+        render: FindingsRender { grouping: Grouping::Flat, collapse: Collapse::Expanded },
     };
     let summary = Summary::new();
     let findings = vec![Finding {
@@ -635,7 +635,7 @@ fn test_output_sanitization_layering_contract() {
     let terminal_output = TerminalReporter {
         use_color: false,
         show_hosts_breakdown: false,
-        render: FindingsRender::FlatExpanded,
+        render: FindingsRender { grouping: Grouping::Flat, collapse: Collapse::Expanded },
     }
     .render(&Summary::new(), std::slice::from_ref(&finding), &[]);
     assert!(
@@ -741,7 +741,7 @@ fn test_terminal_reporter_escapes_control_bytes_in_analyzer_summaries() {
     let output = TerminalReporter {
         use_color: false,
         show_hosts_breakdown: false,
-        render: FindingsRender::FlatExpanded,
+        render: FindingsRender { grouping: Grouping::Flat, collapse: Collapse::Expanded },
     }
     .render(
         &Summary::new(),
@@ -848,7 +848,7 @@ fn test_http_finding_c1_csi_escaped_by_terminal_reporter() {
     let output = TerminalReporter {
         use_color: false,
         show_hosts_breakdown: false,
-        render: FindingsRender::FlatExpanded,
+        render: FindingsRender { grouping: Grouping::Flat, collapse: Collapse::Expanded },
     }
     .render(&Summary::new(), &findings, &[]);
     assert!(
@@ -933,7 +933,7 @@ fn test_http_analyzer_summary_c1_csi_escaped_by_terminal_reporter() {
     let output = TerminalReporter {
         use_color: false,
         show_hosts_breakdown: false,
-        render: FindingsRender::FlatExpanded,
+        render: FindingsRender { grouping: Grouping::Flat, collapse: Collapse::Expanded },
     }
     .render(
         &Summary::new(),
@@ -983,7 +983,7 @@ fn mitre_grouping_emits_tactic_headers_in_canonical_order() {
     let reporter = TerminalReporter {
         use_color: false,
         show_hosts_breakdown: false,
-        render: FindingsRender::Grouped,
+        render: FindingsRender { grouping: Grouping::Grouped, collapse: Collapse::Expanded },
     };
     let out = reporter.render(&Summary::new(), &findings, &[]);
     // Anchor on the `## ` header prefix so future summary/evidence text
@@ -1016,7 +1016,7 @@ fn mitre_grouping_sorts_within_tactic_by_verdict_then_confidence() {
     let reporter = TerminalReporter {
         use_color: false,
         show_hosts_breakdown: false,
-        render: FindingsRender::Grouped,
+        render: FindingsRender { grouping: Grouping::Grouped, collapse: Collapse::Expanded },
     };
     let out = reporter.render(&Summary::new(), &findings, &[]);
     let p1 = out.find("first").expect("first missing");
@@ -1049,7 +1049,7 @@ fn mitre_grouping_buckets_none_and_unknown_under_uncategorized() {
     let reporter = TerminalReporter {
         use_color: false,
         show_hosts_breakdown: false,
-        render: FindingsRender::Grouped,
+        render: FindingsRender { grouping: Grouping::Grouped, collapse: Collapse::Expanded },
     };
     let out = reporter.render(&Summary::new(), &findings, &[]);
     let uncat_pos = out
@@ -1082,7 +1082,7 @@ fn mitre_grouping_expands_per_finding_line_with_technique_name() {
     let reporter = TerminalReporter {
         use_color: false,
         show_hosts_breakdown: false,
-        render: FindingsRender::Grouped,
+        render: FindingsRender { grouping: Grouping::Grouped, collapse: Collapse::Expanded },
     };
     let out = reporter.render(&Summary::new(), &findings, &[]);
     assert!(
@@ -1102,7 +1102,7 @@ fn default_rendering_unchanged_when_mitre_flag_off() {
     let reporter = TerminalReporter {
         use_color: false,
         show_hosts_breakdown: false,
-        render: FindingsRender::FlatExpanded,
+        render: FindingsRender { grouping: Grouping::Flat, collapse: Collapse::Expanded },
     };
     let out = reporter.render(&Summary::new(), &findings, &[]);
     assert!(out.contains("MITRE: T1046"));
@@ -1127,7 +1127,7 @@ fn mitre_grouping_preserves_emission_order_when_verdict_and_confidence_tie() {
     let reporter = TerminalReporter {
         use_color: false,
         show_hosts_breakdown: false,
-        render: FindingsRender::Grouped,
+        render: FindingsRender { grouping: Grouping::Grouped, collapse: Collapse::Expanded },
     };
     let out = reporter.render(&Summary::new(), &findings, &[]);
     let pa = out.find("alpha").expect("alpha missing");
@@ -1162,7 +1162,7 @@ fn mitre_grouping_keeps_known_and_unknown_ids_in_separate_buckets() {
     let reporter = TerminalReporter {
         use_color: false,
         show_hosts_breakdown: false,
-        render: FindingsRender::Grouped,
+        render: FindingsRender { grouping: Grouping::Grouped, collapse: Collapse::Expanded },
     };
     let out = reporter.render(&Summary::new(), &findings, &[]);
     let discovery_pos = out.find("## Discovery").expect("Discovery header missing");
@@ -2444,7 +2444,7 @@ fn test_story_070_ec001_full_pipeline_esc_in_uri() {
     let terminal_out = TerminalReporter {
         use_color: false,
         show_hosts_breakdown: false,
-        render: FindingsRender::FlatExpanded,
+        render: FindingsRender { grouping: Grouping::Flat, collapse: Collapse::Expanded },
     }
     .render(&Summary::new(), std::slice::from_ref(&finding), &[]);
     assert!(

--- a/tests/reporter_tests.rs
+++ b/tests/reporter_tests.rs
@@ -5,7 +5,7 @@ use wirerust::reassembly::flow::FlowKey;
 use wirerust::reassembly::handler::{Direction, StreamAnalyzer, StreamHandler};
 use wirerust::reporter::Reporter;
 use wirerust::reporter::json::JsonReporter;
-use wirerust::reporter::terminal::TerminalReporter;
+use wirerust::reporter::terminal::{FindingsRender, TerminalReporter};
 use wirerust::summary::Summary;
 
 #[test]
@@ -448,10 +448,8 @@ fn test_terminal_hosts_breakdown_off_by_default() {
     let summary = make_summary_with_two_hosts();
     let reporter = TerminalReporter {
         use_color: false,
-        show_mitre_grouping: false,
         show_hosts_breakdown: false,
-        // STORY-118: new field; false = pre-v0.8.0 non-collapse path
-        collapse_findings: false,
+        render: FindingsRender::FlatExpanded,
     };
     let out = reporter.render(&summary, &[], &[]);
     assert!(
@@ -472,10 +470,8 @@ fn test_terminal_hosts_breakdown_lists_each_host_when_enabled() {
     let summary = make_summary_with_two_hosts();
     let reporter = TerminalReporter {
         use_color: false,
-        show_mitre_grouping: false,
         show_hosts_breakdown: true,
-        // STORY-118: new field; false = pre-v0.8.0 non-collapse path
-        collapse_findings: false,
+        render: FindingsRender::FlatExpanded,
     };
     let out = reporter.render(&summary, &[], &[]);
     assert!(
@@ -523,10 +519,8 @@ fn test_json_reporter_skipped_packets_zero_by_default() {
 fn test_terminal_reporter_shows_skipped_when_nonzero() {
     let reporter = TerminalReporter {
         use_color: false,
-        show_mitre_grouping: false,
         show_hosts_breakdown: false,
-        // STORY-118: new field; false = pre-v0.8.0 non-collapse path
-        collapse_findings: false,
+        render: FindingsRender::FlatExpanded,
     };
     let mut summary = Summary::new();
     summary.skipped_packets = 5;
@@ -542,10 +536,8 @@ fn test_terminal_reporter_shows_skipped_when_nonzero() {
 fn test_terminal_reporter_hides_skipped_when_zero() {
     let reporter = TerminalReporter {
         use_color: false,
-        show_mitre_grouping: false,
         show_hosts_breakdown: false,
-        // STORY-118: new field; false = pre-v0.8.0 non-collapse path
-        collapse_findings: false,
+        render: FindingsRender::FlatExpanded,
     };
     let summary = Summary::new();
 
@@ -564,10 +556,8 @@ fn test_terminal_reporter_escapes_esc_bytes_in_summary() {
     // reporter is responsible for this escaping.
     let reporter = TerminalReporter {
         use_color: false,
-        show_mitre_grouping: false,
         show_hosts_breakdown: false,
-        // STORY-118: new field; false = pre-v0.8.0 non-collapse path
-        collapse_findings: false,
+        render: FindingsRender::FlatExpanded,
     };
     let summary = Summary::new();
     let findings = vec![Finding {
@@ -644,10 +634,8 @@ fn test_output_sanitization_layering_contract() {
     // Layer 2: terminal reporter escapes on display.
     let terminal_output = TerminalReporter {
         use_color: false,
-        show_mitre_grouping: false,
         show_hosts_breakdown: false,
-        // STORY-118: new field; false = pre-v0.8.0 non-collapse path
-        collapse_findings: false,
+        render: FindingsRender::FlatExpanded,
     }
     .render(&Summary::new(), std::slice::from_ref(&finding), &[]);
     assert!(
@@ -752,10 +740,8 @@ fn test_terminal_reporter_escapes_control_bytes_in_analyzer_summaries() {
 
     let output = TerminalReporter {
         use_color: false,
-        show_mitre_grouping: false,
         show_hosts_breakdown: false,
-        // STORY-118: new field; false = pre-v0.8.0 non-collapse path
-        collapse_findings: false,
+        render: FindingsRender::FlatExpanded,
     }
     .render(
         &Summary::new(),
@@ -861,10 +847,8 @@ fn test_http_finding_c1_csi_escaped_by_terminal_reporter() {
     // Render through terminal reporter — no raw C1 bytes in output.
     let output = TerminalReporter {
         use_color: false,
-        show_mitre_grouping: false,
         show_hosts_breakdown: false,
-        // STORY-118: new field; false = pre-v0.8.0 non-collapse path
-        collapse_findings: false,
+        render: FindingsRender::FlatExpanded,
     }
     .render(&Summary::new(), &findings, &[]);
     assert!(
@@ -948,10 +932,8 @@ fn test_http_analyzer_summary_c1_csi_escaped_by_terminal_reporter() {
     // Render through terminal reporter — no raw C1 bytes in output.
     let output = TerminalReporter {
         use_color: false,
-        show_mitre_grouping: false,
         show_hosts_breakdown: false,
-        // STORY-118: new field; false = pre-v0.8.0 non-collapse path
-        collapse_findings: false,
+        render: FindingsRender::FlatExpanded,
     }
     .render(
         &Summary::new(),
@@ -1000,10 +982,8 @@ fn mitre_grouping_emits_tactic_headers_in_canonical_order() {
     ];
     let reporter = TerminalReporter {
         use_color: false,
-        show_mitre_grouping: true,
         show_hosts_breakdown: false,
-        // STORY-118: new field; false = pre-v0.8.0 non-collapse path
-        collapse_findings: false,
+        render: FindingsRender::Grouped,
     };
     let out = reporter.render(&Summary::new(), &findings, &[]);
     // Anchor on the `## ` header prefix so future summary/evidence text
@@ -1035,10 +1015,8 @@ fn mitre_grouping_sorts_within_tactic_by_verdict_then_confidence() {
     ];
     let reporter = TerminalReporter {
         use_color: false,
-        show_mitre_grouping: true,
         show_hosts_breakdown: false,
-        // STORY-118: new field; false = pre-v0.8.0 non-collapse path
-        collapse_findings: false,
+        render: FindingsRender::Grouped,
     };
     let out = reporter.render(&Summary::new(), &findings, &[]);
     let p1 = out.find("first").expect("first missing");
@@ -1070,10 +1048,8 @@ fn mitre_grouping_buckets_none_and_unknown_under_uncategorized() {
     ];
     let reporter = TerminalReporter {
         use_color: false,
-        show_mitre_grouping: true,
         show_hosts_breakdown: false,
-        // STORY-118: new field; false = pre-v0.8.0 non-collapse path
-        collapse_findings: false,
+        render: FindingsRender::Grouped,
     };
     let out = reporter.render(&Summary::new(), &findings, &[]);
     let uncat_pos = out
@@ -1105,10 +1081,8 @@ fn mitre_grouping_expands_per_finding_line_with_technique_name() {
     )];
     let reporter = TerminalReporter {
         use_color: false,
-        show_mitre_grouping: true,
         show_hosts_breakdown: false,
-        // STORY-118: new field; false = pre-v0.8.0 non-collapse path
-        collapse_findings: false,
+        render: FindingsRender::Grouped,
     };
     let out = reporter.render(&Summary::new(), &findings, &[]);
     assert!(
@@ -1127,10 +1101,8 @@ fn default_rendering_unchanged_when_mitre_flag_off() {
     )];
     let reporter = TerminalReporter {
         use_color: false,
-        show_mitre_grouping: false,
         show_hosts_breakdown: false,
-        // STORY-118: new field; false = pre-v0.8.0 non-collapse path
-        collapse_findings: false,
+        render: FindingsRender::FlatExpanded,
     };
     let out = reporter.render(&Summary::new(), &findings, &[]);
     assert!(out.contains("MITRE: T1046"));
@@ -1154,10 +1126,8 @@ fn mitre_grouping_preserves_emission_order_when_verdict_and_confidence_tie() {
     ];
     let reporter = TerminalReporter {
         use_color: false,
-        show_mitre_grouping: true,
         show_hosts_breakdown: false,
-        // STORY-118: new field; false = pre-v0.8.0 non-collapse path
-        collapse_findings: false,
+        render: FindingsRender::Grouped,
     };
     let out = reporter.render(&Summary::new(), &findings, &[]);
     let pa = out.find("alpha").expect("alpha missing");
@@ -1191,10 +1161,8 @@ fn mitre_grouping_keeps_known_and_unknown_ids_in_separate_buckets() {
     ];
     let reporter = TerminalReporter {
         use_color: false,
-        show_mitre_grouping: true,
         show_hosts_breakdown: false,
-        // STORY-118: new field; false = pre-v0.8.0 non-collapse path
-        collapse_findings: false,
+        render: FindingsRender::Grouped,
     };
     let out = reporter.render(&Summary::new(), &findings, &[]);
     let discovery_pos = out.find("## Discovery").expect("Discovery header missing");
@@ -2475,10 +2443,8 @@ fn test_story_070_ec001_full_pipeline_esc_in_uri() {
     // Layer 2: terminal reporter escapes to \u{1b} form.
     let terminal_out = TerminalReporter {
         use_color: false,
-        show_mitre_grouping: false,
         show_hosts_breakdown: false,
-        // STORY-118: new field; false = pre-v0.8.0 non-collapse path
-        collapse_findings: false,
+        render: FindingsRender::FlatExpanded,
     }
     .render(&Summary::new(), std::slice::from_ref(&finding), &[]);
     assert!(

--- a/tests/reporter_tests.rs
+++ b/tests/reporter_tests.rs
@@ -449,7 +449,10 @@ fn test_terminal_hosts_breakdown_off_by_default() {
     let reporter = TerminalReporter {
         use_color: false,
         show_hosts_breakdown: false,
-        render: FindingsRender { grouping: Grouping::Flat, collapse: Collapse::Expanded },
+        render: FindingsRender {
+            grouping: Grouping::Flat,
+            collapse: Collapse::Expanded,
+        },
     };
     let out = reporter.render(&summary, &[], &[]);
     assert!(
@@ -471,7 +474,10 @@ fn test_terminal_hosts_breakdown_lists_each_host_when_enabled() {
     let reporter = TerminalReporter {
         use_color: false,
         show_hosts_breakdown: true,
-        render: FindingsRender { grouping: Grouping::Flat, collapse: Collapse::Expanded },
+        render: FindingsRender {
+            grouping: Grouping::Flat,
+            collapse: Collapse::Expanded,
+        },
     };
     let out = reporter.render(&summary, &[], &[]);
     assert!(
@@ -520,7 +526,10 @@ fn test_terminal_reporter_shows_skipped_when_nonzero() {
     let reporter = TerminalReporter {
         use_color: false,
         show_hosts_breakdown: false,
-        render: FindingsRender { grouping: Grouping::Flat, collapse: Collapse::Expanded },
+        render: FindingsRender {
+            grouping: Grouping::Flat,
+            collapse: Collapse::Expanded,
+        },
     };
     let mut summary = Summary::new();
     summary.skipped_packets = 5;
@@ -537,7 +546,10 @@ fn test_terminal_reporter_hides_skipped_when_zero() {
     let reporter = TerminalReporter {
         use_color: false,
         show_hosts_breakdown: false,
-        render: FindingsRender { grouping: Grouping::Flat, collapse: Collapse::Expanded },
+        render: FindingsRender {
+            grouping: Grouping::Flat,
+            collapse: Collapse::Expanded,
+        },
     };
     let summary = Summary::new();
 
@@ -557,7 +569,10 @@ fn test_terminal_reporter_escapes_esc_bytes_in_summary() {
     let reporter = TerminalReporter {
         use_color: false,
         show_hosts_breakdown: false,
-        render: FindingsRender { grouping: Grouping::Flat, collapse: Collapse::Expanded },
+        render: FindingsRender {
+            grouping: Grouping::Flat,
+            collapse: Collapse::Expanded,
+        },
     };
     let summary = Summary::new();
     let findings = vec![Finding {
@@ -635,7 +650,10 @@ fn test_output_sanitization_layering_contract() {
     let terminal_output = TerminalReporter {
         use_color: false,
         show_hosts_breakdown: false,
-        render: FindingsRender { grouping: Grouping::Flat, collapse: Collapse::Expanded },
+        render: FindingsRender {
+            grouping: Grouping::Flat,
+            collapse: Collapse::Expanded,
+        },
     }
     .render(&Summary::new(), std::slice::from_ref(&finding), &[]);
     assert!(
@@ -741,7 +759,10 @@ fn test_terminal_reporter_escapes_control_bytes_in_analyzer_summaries() {
     let output = TerminalReporter {
         use_color: false,
         show_hosts_breakdown: false,
-        render: FindingsRender { grouping: Grouping::Flat, collapse: Collapse::Expanded },
+        render: FindingsRender {
+            grouping: Grouping::Flat,
+            collapse: Collapse::Expanded,
+        },
     }
     .render(
         &Summary::new(),
@@ -848,7 +869,10 @@ fn test_http_finding_c1_csi_escaped_by_terminal_reporter() {
     let output = TerminalReporter {
         use_color: false,
         show_hosts_breakdown: false,
-        render: FindingsRender { grouping: Grouping::Flat, collapse: Collapse::Expanded },
+        render: FindingsRender {
+            grouping: Grouping::Flat,
+            collapse: Collapse::Expanded,
+        },
     }
     .render(&Summary::new(), &findings, &[]);
     assert!(
@@ -933,7 +957,10 @@ fn test_http_analyzer_summary_c1_csi_escaped_by_terminal_reporter() {
     let output = TerminalReporter {
         use_color: false,
         show_hosts_breakdown: false,
-        render: FindingsRender { grouping: Grouping::Flat, collapse: Collapse::Expanded },
+        render: FindingsRender {
+            grouping: Grouping::Flat,
+            collapse: Collapse::Expanded,
+        },
     }
     .render(
         &Summary::new(),
@@ -983,7 +1010,10 @@ fn mitre_grouping_emits_tactic_headers_in_canonical_order() {
     let reporter = TerminalReporter {
         use_color: false,
         show_hosts_breakdown: false,
-        render: FindingsRender { grouping: Grouping::Grouped, collapse: Collapse::Expanded },
+        render: FindingsRender {
+            grouping: Grouping::Grouped,
+            collapse: Collapse::Expanded,
+        },
     };
     let out = reporter.render(&Summary::new(), &findings, &[]);
     // Anchor on the `## ` header prefix so future summary/evidence text
@@ -1016,7 +1046,10 @@ fn mitre_grouping_sorts_within_tactic_by_verdict_then_confidence() {
     let reporter = TerminalReporter {
         use_color: false,
         show_hosts_breakdown: false,
-        render: FindingsRender { grouping: Grouping::Grouped, collapse: Collapse::Expanded },
+        render: FindingsRender {
+            grouping: Grouping::Grouped,
+            collapse: Collapse::Expanded,
+        },
     };
     let out = reporter.render(&Summary::new(), &findings, &[]);
     let p1 = out.find("first").expect("first missing");
@@ -1049,7 +1082,10 @@ fn mitre_grouping_buckets_none_and_unknown_under_uncategorized() {
     let reporter = TerminalReporter {
         use_color: false,
         show_hosts_breakdown: false,
-        render: FindingsRender { grouping: Grouping::Grouped, collapse: Collapse::Expanded },
+        render: FindingsRender {
+            grouping: Grouping::Grouped,
+            collapse: Collapse::Expanded,
+        },
     };
     let out = reporter.render(&Summary::new(), &findings, &[]);
     let uncat_pos = out
@@ -1082,7 +1118,10 @@ fn mitre_grouping_expands_per_finding_line_with_technique_name() {
     let reporter = TerminalReporter {
         use_color: false,
         show_hosts_breakdown: false,
-        render: FindingsRender { grouping: Grouping::Grouped, collapse: Collapse::Expanded },
+        render: FindingsRender {
+            grouping: Grouping::Grouped,
+            collapse: Collapse::Expanded,
+        },
     };
     let out = reporter.render(&Summary::new(), &findings, &[]);
     assert!(
@@ -1102,7 +1141,10 @@ fn default_rendering_unchanged_when_mitre_flag_off() {
     let reporter = TerminalReporter {
         use_color: false,
         show_hosts_breakdown: false,
-        render: FindingsRender { grouping: Grouping::Flat, collapse: Collapse::Expanded },
+        render: FindingsRender {
+            grouping: Grouping::Flat,
+            collapse: Collapse::Expanded,
+        },
     };
     let out = reporter.render(&Summary::new(), &findings, &[]);
     assert!(out.contains("MITRE: T1046"));
@@ -1127,7 +1169,10 @@ fn mitre_grouping_preserves_emission_order_when_verdict_and_confidence_tie() {
     let reporter = TerminalReporter {
         use_color: false,
         show_hosts_breakdown: false,
-        render: FindingsRender { grouping: Grouping::Grouped, collapse: Collapse::Expanded },
+        render: FindingsRender {
+            grouping: Grouping::Grouped,
+            collapse: Collapse::Expanded,
+        },
     };
     let out = reporter.render(&Summary::new(), &findings, &[]);
     let pa = out.find("alpha").expect("alpha missing");
@@ -1162,7 +1207,10 @@ fn mitre_grouping_keeps_known_and_unknown_ids_in_separate_buckets() {
     let reporter = TerminalReporter {
         use_color: false,
         show_hosts_breakdown: false,
-        render: FindingsRender { grouping: Grouping::Grouped, collapse: Collapse::Expanded },
+        render: FindingsRender {
+            grouping: Grouping::Grouped,
+            collapse: Collapse::Expanded,
+        },
     };
     let out = reporter.render(&Summary::new(), &findings, &[]);
     let discovery_pos = out.find("## Discovery").expect("Discovery header missing");
@@ -2444,7 +2492,10 @@ fn test_story_070_ec001_full_pipeline_esc_in_uri() {
     let terminal_out = TerminalReporter {
         use_color: false,
         show_hosts_breakdown: false,
-        render: FindingsRender { grouping: Grouping::Flat, collapse: Collapse::Expanded },
+        render: FindingsRender {
+            grouping: Grouping::Flat,
+            collapse: Collapse::Expanded,
+        },
     }
     .render(&Summary::new(), std::slice::from_ref(&finding), &[]);
     assert!(

--- a/tests/reporter_tests.rs
+++ b/tests/reporter_tests.rs
@@ -449,10 +449,7 @@ fn test_terminal_hosts_breakdown_off_by_default() {
     let reporter = TerminalReporter {
         use_color: false,
         show_hosts_breakdown: false,
-        render: FindingsRender {
-            grouping: Grouping::Flat,
-            collapse: Collapse::Expanded,
-        },
+        render: FindingsRender::new(Grouping::Flat, Collapse::Expanded),
     };
     let out = reporter.render(&summary, &[], &[]);
     assert!(
@@ -474,10 +471,7 @@ fn test_terminal_hosts_breakdown_lists_each_host_when_enabled() {
     let reporter = TerminalReporter {
         use_color: false,
         show_hosts_breakdown: true,
-        render: FindingsRender {
-            grouping: Grouping::Flat,
-            collapse: Collapse::Expanded,
-        },
+        render: FindingsRender::new(Grouping::Flat, Collapse::Expanded),
     };
     let out = reporter.render(&summary, &[], &[]);
     assert!(
@@ -526,10 +520,7 @@ fn test_terminal_reporter_shows_skipped_when_nonzero() {
     let reporter = TerminalReporter {
         use_color: false,
         show_hosts_breakdown: false,
-        render: FindingsRender {
-            grouping: Grouping::Flat,
-            collapse: Collapse::Expanded,
-        },
+        render: FindingsRender::new(Grouping::Flat, Collapse::Expanded),
     };
     let mut summary = Summary::new();
     summary.skipped_packets = 5;
@@ -546,10 +537,7 @@ fn test_terminal_reporter_hides_skipped_when_zero() {
     let reporter = TerminalReporter {
         use_color: false,
         show_hosts_breakdown: false,
-        render: FindingsRender {
-            grouping: Grouping::Flat,
-            collapse: Collapse::Expanded,
-        },
+        render: FindingsRender::new(Grouping::Flat, Collapse::Expanded),
     };
     let summary = Summary::new();
 
@@ -569,10 +557,7 @@ fn test_terminal_reporter_escapes_esc_bytes_in_summary() {
     let reporter = TerminalReporter {
         use_color: false,
         show_hosts_breakdown: false,
-        render: FindingsRender {
-            grouping: Grouping::Flat,
-            collapse: Collapse::Expanded,
-        },
+        render: FindingsRender::new(Grouping::Flat, Collapse::Expanded),
     };
     let summary = Summary::new();
     let findings = vec![Finding {
@@ -650,10 +635,7 @@ fn test_output_sanitization_layering_contract() {
     let terminal_output = TerminalReporter {
         use_color: false,
         show_hosts_breakdown: false,
-        render: FindingsRender {
-            grouping: Grouping::Flat,
-            collapse: Collapse::Expanded,
-        },
+        render: FindingsRender::new(Grouping::Flat, Collapse::Expanded),
     }
     .render(&Summary::new(), std::slice::from_ref(&finding), &[]);
     assert!(
@@ -759,10 +741,7 @@ fn test_terminal_reporter_escapes_control_bytes_in_analyzer_summaries() {
     let output = TerminalReporter {
         use_color: false,
         show_hosts_breakdown: false,
-        render: FindingsRender {
-            grouping: Grouping::Flat,
-            collapse: Collapse::Expanded,
-        },
+        render: FindingsRender::new(Grouping::Flat, Collapse::Expanded),
     }
     .render(
         &Summary::new(),
@@ -869,10 +848,7 @@ fn test_http_finding_c1_csi_escaped_by_terminal_reporter() {
     let output = TerminalReporter {
         use_color: false,
         show_hosts_breakdown: false,
-        render: FindingsRender {
-            grouping: Grouping::Flat,
-            collapse: Collapse::Expanded,
-        },
+        render: FindingsRender::new(Grouping::Flat, Collapse::Expanded),
     }
     .render(&Summary::new(), &findings, &[]);
     assert!(
@@ -957,10 +933,7 @@ fn test_http_analyzer_summary_c1_csi_escaped_by_terminal_reporter() {
     let output = TerminalReporter {
         use_color: false,
         show_hosts_breakdown: false,
-        render: FindingsRender {
-            grouping: Grouping::Flat,
-            collapse: Collapse::Expanded,
-        },
+        render: FindingsRender::new(Grouping::Flat, Collapse::Expanded),
     }
     .render(
         &Summary::new(),
@@ -1010,10 +983,7 @@ fn mitre_grouping_emits_tactic_headers_in_canonical_order() {
     let reporter = TerminalReporter {
         use_color: false,
         show_hosts_breakdown: false,
-        render: FindingsRender {
-            grouping: Grouping::Grouped,
-            collapse: Collapse::Expanded,
-        },
+        render: FindingsRender::new(Grouping::Grouped, Collapse::Expanded),
     };
     let out = reporter.render(&Summary::new(), &findings, &[]);
     // Anchor on the `## ` header prefix so future summary/evidence text
@@ -1046,10 +1016,7 @@ fn mitre_grouping_sorts_within_tactic_by_verdict_then_confidence() {
     let reporter = TerminalReporter {
         use_color: false,
         show_hosts_breakdown: false,
-        render: FindingsRender {
-            grouping: Grouping::Grouped,
-            collapse: Collapse::Expanded,
-        },
+        render: FindingsRender::new(Grouping::Grouped, Collapse::Expanded),
     };
     let out = reporter.render(&Summary::new(), &findings, &[]);
     let p1 = out.find("first").expect("first missing");
@@ -1082,10 +1049,7 @@ fn mitre_grouping_buckets_none_and_unknown_under_uncategorized() {
     let reporter = TerminalReporter {
         use_color: false,
         show_hosts_breakdown: false,
-        render: FindingsRender {
-            grouping: Grouping::Grouped,
-            collapse: Collapse::Expanded,
-        },
+        render: FindingsRender::new(Grouping::Grouped, Collapse::Expanded),
     };
     let out = reporter.render(&Summary::new(), &findings, &[]);
     let uncat_pos = out
@@ -1118,10 +1082,7 @@ fn mitre_grouping_expands_per_finding_line_with_technique_name() {
     let reporter = TerminalReporter {
         use_color: false,
         show_hosts_breakdown: false,
-        render: FindingsRender {
-            grouping: Grouping::Grouped,
-            collapse: Collapse::Expanded,
-        },
+        render: FindingsRender::new(Grouping::Grouped, Collapse::Expanded),
     };
     let out = reporter.render(&Summary::new(), &findings, &[]);
     assert!(
@@ -1141,10 +1102,7 @@ fn default_rendering_unchanged_when_mitre_flag_off() {
     let reporter = TerminalReporter {
         use_color: false,
         show_hosts_breakdown: false,
-        render: FindingsRender {
-            grouping: Grouping::Flat,
-            collapse: Collapse::Expanded,
-        },
+        render: FindingsRender::new(Grouping::Flat, Collapse::Expanded),
     };
     let out = reporter.render(&Summary::new(), &findings, &[]);
     assert!(out.contains("MITRE: T1046"));
@@ -1169,10 +1127,7 @@ fn mitre_grouping_preserves_emission_order_when_verdict_and_confidence_tie() {
     let reporter = TerminalReporter {
         use_color: false,
         show_hosts_breakdown: false,
-        render: FindingsRender {
-            grouping: Grouping::Grouped,
-            collapse: Collapse::Expanded,
-        },
+        render: FindingsRender::new(Grouping::Grouped, Collapse::Expanded),
     };
     let out = reporter.render(&Summary::new(), &findings, &[]);
     let pa = out.find("alpha").expect("alpha missing");
@@ -1207,10 +1162,7 @@ fn mitre_grouping_keeps_known_and_unknown_ids_in_separate_buckets() {
     let reporter = TerminalReporter {
         use_color: false,
         show_hosts_breakdown: false,
-        render: FindingsRender {
-            grouping: Grouping::Grouped,
-            collapse: Collapse::Expanded,
-        },
+        render: FindingsRender::new(Grouping::Grouped, Collapse::Expanded),
     };
     let out = reporter.render(&Summary::new(), &findings, &[]);
     let discovery_pos = out.find("## Discovery").expect("Discovery header missing");
@@ -2492,10 +2444,7 @@ fn test_story_070_ec001_full_pipeline_esc_in_uri() {
     let terminal_out = TerminalReporter {
         use_color: false,
         show_hosts_breakdown: false,
-        render: FindingsRender {
-            grouping: Grouping::Flat,
-            collapse: Collapse::Expanded,
-        },
+        render: FindingsRender::new(Grouping::Flat, Collapse::Expanded),
     }
     .render(&Summary::new(), std::slice::from_ref(&finding), &[]);
     assert!(


### PR DESCRIPTION
## chore: release v0.9.0

> **Promotion PR** — this is a develop→main gitflow release merge.
> All code in this PR was previously reviewed, tested, and converged on the `develop` branch
> through feature PRs #266, #268, #269, #270, #271, #272, #273, #274, #275.
> No new code is introduced here; the diff is exactly the already-reviewed develop commits
> since v0.8.0. Full pr-reviewer/security re-review is not applicable.

---

## Release Contents: v0.9.0

### Feature: E-18 Grouped-Mode Finding-Collapse (issue #62 / #259)

This release completes the E-18 epic: grouped-mode finding-collapse for the `--mitre` terminal
output path, delivered across three stories with full F7 delta-convergence (5 dimensions).

#### STORY-122 / PR #268 — FindingsRender struct reshape (Phase A)

`FindingsRender` was reshaped from a three-variant enum into a **struct of two orthogonal enums**:
`{ grouping: Grouping, collapse: Collapse }`. The four combinations (Grouped+Collapsed,
Grouped+Expanded, Flat+Collapsed, Flat+Expanded) are all valid. The prior three-variant enum
(`Grouped`, `FlatCollapsed`, `FlatExpanded`) no longer exists.

Forward-compatibility (F7-R2): `Grouping`, `Collapse`, and `FindingsRender` are now marked
`#[non_exhaustive]`, allowing future variants or fields without a semver-breaking change.
External crates must construct `FindingsRender` via `FindingsRender::new(grouping, collapse)`.

#### STORY-119/B / PR #269 — `--mitre` default-collapse + `--no-collapse` dual-scope

- `--mitre` now routes through `render_findings_grouped_collapsed` by default, collapsing
  identical findings within each MITRE tactic bucket into a single line with a `(xN)` count
  suffix and up to K=3 representative evidence samples.
- `--no-collapse` is now dual-scope: suppresses collapse in both flat and `--mitre` modes.

#### STORY-120 / PR #266 — FindingsRender enum migration (Phase 0)

Initial migration of `show_mitre_grouping: bool` and `collapse_findings: bool` public fields
on `TerminalReporter` into a single `render: FindingsRender` field (three-variant enum, later
reshaped in Phase A above). All 28 construction sites migrated.

#### Remediation PRs (F5/F7 convergence loop)

- PR #270 — fix(F5/MEDIUM-1): non-tautological grouping construction-site regression guard
- PR #271 — chore(F5/F6): residual cleanup (doc fixes, test hardening)
- PR #272 — docs(F7): convergence doc fixes
- PR #273 — fix(F7-R2): `#[non_exhaustive]` on reporter types; CLI internal-ID sweep; help-provenance CI gate
- PR #274 — docs(F7-R3): ADR-0003 sync (shipped `#[non_exhaustive]` + constructor)
- PR #275 — ci(F7-R4): harden help-provenance-gate (file-not-found false-green, standards-ID false-positive)

### CI Addition: Help-Provenance Gate

A new CI job (`Help-provenance gate (no internal IDs in clap /// doc-comments)`) was added to
block internal factory story/finding IDs from leaking into user-facing `--help` output. This
gate is now part of the required CI check set for all future changes.

---

## Architecture Changes

```mermaid
graph TD
    A[TerminalReporter] --> B[render: FindingsRender]
    B --> C[grouping: Grouping]
    B --> D[collapse: Collapse]
    C --> E[Grouping::Grouped]
    C --> F[Grouping::Flat]
    D --> G[Collapse::Collapsed]
    D --> H[Collapse::Expanded]
    B --> I[FindingsRender::new constructor]
    style B fill:#e8f5e9
    style I fill:#e8f5e9
    note1[All three types are #non_exhaustive]
```

---

## Story Dependencies

```mermaid
graph LR
    S120["STORY-120 PR#266\nFindingsRender enum migration"] --> S122["STORY-122 PR#268\nFindingsRender struct reshape"]
    S122 --> S119["STORY-119/B PR#269\n--mitre collapse + dual-scope --no-collapse"]
    S119 --> R270["PR#270 F5 remediation"]
    S119 --> R273["PR#273 F7-R2 non_exhaustive"]
    S273 --> R274["PR#274 ADR sync"]
    R275["PR#275 CI hardening"] --> REL["release/0.9.0"]
    R270 --> REL
    R271["PR#271 cleanup"] --> REL
    R272["PR#272 doc fixes"] --> REL
    R274 --> REL
    S119 --> REL
    S120 --> REL
    S122 --> REL
```

---

## Spec Traceability

```mermaid
flowchart LR
    BC1["BC-5.34.001\nGrouped-collapse render"] --> AC1["AC-001: --mitre collapses by default"]
    BC1 --> AC2["AC-002: (xN) count suffix"]
    BC1 --> AC3["AC-003: K=3 evidence samples"]
    BC2["BC-5.35.001\nFindingsRender struct"] --> AC4["AC-001: struct of two orthogonal enums"]
    BC2 --> AC5["AC-002: #[non_exhaustive]"]
    BC2 --> AC6["AC-003: FindingsRender::new constructor"]
    AC1 --> T1["render_findings_grouped_collapsed tests"]
    AC4 --> T2["FindingsRender construction tests"]
    AC5 --> T3["#[non_exhaustive] compile-check tests"]
    T1 --> C1["src/reporter/terminal.rs"]
    T2 --> C1
    T3 --> C1
```

---

## Test Evidence

- All CI checks passing on `develop` HEAD (1c89b52) at time of release branch cut.
- `cargo test --all-targets`: PASS (full test suite including new regression guards for
  `render_findings_grouped_collapsed`, `--no-collapse` dual-scope, and help-provenance leak).
- `cargo clippy --all-targets -- -D warnings`: PASS
- `cargo fmt --check`: PASS
- Help-provenance gate: PASS (no internal IDs in clap `///` doc-comments)
- Fuzz build: PASS (4 harnesses compile cleanly)
- Action pin gate: PASS (all `uses:` refs are 40-char SHA-pinned)

---

## Holdout Evaluation

N/A — evaluated at F4 wave gate (holdout PASSED for prior cycles; not re-checked at release per release-config.yaml `require_holdout: false`).

---

## Adversarial Review

N/A — evaluated at Phase F5 (scoped-adversarial 3/3 SATISFIED: STORY-120/122/119). F7 delta-convergence CONVERGED (5 dimensions: spec/tests/impl/verification/docs).

---

## Security Review

N/A — this is a promotion PR of already-reviewed develop commits. No new code is introduced.
The scope of v0.9.0 is limited to terminal display logic (`src/reporter/terminal.rs`, `src/main.rs`)
and CI configuration. No network code, parser code, or authentication paths were changed.

---

## Risk Assessment

- **Blast radius:** Terminal display only (`src/reporter/terminal.rs`, `src/main.rs`). JSON and
  CSV output paths are unaffected. Network analysis, parsers, and ICS protocol handling unchanged.
- **Breaking changes:** `FindingsRender` public API (semver minor bump 0.8.0→0.9.0). External
  crates using `TerminalReporter` must migrate to `FindingsRender::new()`. Internal construction
  sites (28 total) were all migrated as part of STORY-120.
- **Performance impact:** Display-layer only; no impact on analysis throughput.

---

## AI Pipeline Metadata

- Pipeline mode: Feature (F-series: delta analysis, spec evolution, incremental stories, TDD implementation, scoped adversarial, targeted hardening, delta convergence)
- F7 convergence status: CONVERGED (5-dim holistic triple A/B/C CLEAN + consistency audit CONSISTENT)
- Stories delivered: STORY-120, STORY-122, STORY-119/B
- Feature PRs merged to develop: #266, #268, #269, #270, #271, #272, #273, #274, #275

---

## Pre-Merge Checklist

- [x] PR description matches diff (promotion of already-reviewed develop commits)
- [x] All ACs covered (see Spec Traceability above)
- [x] Traceability chain complete (BC → AC → Test → Demo)
- [x] F7 delta-convergence CONVERGED (recorded in .factory/phase-f7-convergence/)
- [x] All dependency PRs merged to develop before release branch cut
- [x] Semantic PR title: `chore: release v0.9.0` (allowed type per repo CLAUDE.md policy)
- [x] Base: `main`, Head: `release/0.9.0` (gitflow release branch)
- [x] No new code — promotion PR only
- [ ] CI checks passing on this PR (pending — see Step 6)
- [ ] Human merge authorization received (provided in dispatch: AUTHORIZED v0.9.0 release)
