### PR TITLE
chore: release v0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ Version numbers follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.9.1] - 2026-06-19
+
+### Fixed
+
+- **`--no-collapse` help text and README referenced non-existent flags
+  `--output json` / `--output csv`.** There is no `--output` flag in wirerust;
+  the real flags are `--json <FILE>`, `--csv <FILE>`, and
+  `--output-format <fmt>`. The doc-comment in `src/cli.rs` and the corresponding
+  line in `README.md` both said "Has no effect on --output json or --output csv."
+  Corrected to "Has no effect on --json, --csv, or --output-format json|csv
+  output." Behavior is unchanged — JSON and CSV output were already
+  collapse-invariant; only the help text wording was wrong.
+
 ## [0.9.0] - 2026-06-19
 
 ### Changed (BREAKING)
@@ -425,7 +438,8 @@ Downstream consumers of wirerust JSON or CSV output must update for this release
 - Output sanitization in the terminal reporter guards against C1 control bytes
   in packet-derived strings.
 
-[Unreleased]: https://github.com/Zious11/wirerust/compare/v0.9.0...HEAD
+[Unreleased]: https://github.com/Zious11/wirerust/compare/v0.9.1...HEAD
+[0.9.1]: https://github.com/Zious11/wirerust/compare/v0.9.0...v0.9.1
 [0.9.0]: https://github.com/Zious11/wirerust/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/Zious11/wirerust/compare/v0.7.1...v0.8.0
 [0.7.1]: https://github.com/Zious11/wirerust/compare/v0.7.0...v0.7.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1637,7 +1637,7 @@ dependencies = [
 
 [[package]]
 name = "wirerust"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wirerust"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2024"
 rust-version = "1.91"
 description = "Fast PCAP forensics and network triage CLI tool"

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Options:
 --arp                                  Analyze ARP traffic (spoofing, GARP, storms, malformed, MAC mismatch; default-off; included in --all)
 --arp-spoof-threshold N                MAC-rebind escalation threshold per IP within 60s window (default: 3)
 --arp-storm-rate N                     ARP storm frames/second per source MAC threshold (default: 50)
---no-collapse                          Disable collapsing of repeated findings in both flat and grouped (--mitre) terminal output. By default, collapse is enabled in both modes. When --mitre is used, collapse groups identical findings within each MITRE tactic bucket with a (xN) count suffix. Pass --no-collapse to restore one-line-per-finding output in both modes. Has no effect on --output json or --output csv.
+--no-collapse                          Disable collapsing of repeated findings in both flat and grouped (--mitre) terminal output. By default, collapse is enabled in both modes. When --mitre is used, collapse groups identical findings within each MITRE tactic bucket with a (xN) count suffix. Pass --no-collapse to restore one-line-per-finding output in both modes. Has no effect on --json, --csv, or --output-format json|csv output.
 --mitre                                Group findings by MITRE ATT&CK tactic and show technique names; collapses identical findings within each tactic bucket with a (xN) count suffix by default (pass --no-collapse to disable)
 -a, --all                              Run all analyzers
 ```

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -151,7 +151,7 @@ pub enum Commands {
         /// modes. When --mitre is used, collapse groups identical findings
         /// within each MITRE tactic bucket with a `(xN)` count suffix.
         /// Pass --no-collapse to restore one-line-per-finding output in both modes.
-        /// Has no effect on --output json or --output csv.
+        /// Has no effect on --json, --csv, or --output-format json|csv output.
         // BC-2.11.028 precondition 2; dual-scope since STORY-119.
         #[arg(long)]
         no_collapse: bool,

--- a/tests/cli_integration_tests.rs
+++ b/tests/cli_integration_tests.rs
@@ -389,6 +389,113 @@ fn mitre_named_tactic_header_emitted_for_modbus_fixture() {
 //   assertion failed: `--help` must not contain "BC-"; found in stdout
 // Then removing the ID restored the green state.
 
+// ---- v0.9.1 doc-bug regression guard: --no-collapse flag naming ----
+//
+// Pre-0.9.1 the --no-collapse clap doc-comment said "Has no effect on --output
+// json or --output csv." but `--output` does not exist; the real flags are
+// `--json`, `--csv`, and `--output-format`. This test pins the corrected wording
+// so any revert to the bogus substring is caught immediately.
+//
+// FAIL MODE VERIFICATION (performed before committing 0.9.1 fix):
+//   Temporarily restored "Has no effect on --output json or --output csv." in
+//   src/cli.rs and ran: cargo test no_collapse_help_names_real_output_flags
+//   Test failed with:
+//     assertion failed: `--no-collapse` help must NOT contain bogus `--output json`
+//   Then `--output csv` assertion also failed.
+//   Restored corrected wording: test passes.
+//   Assertion (b) was verified green throughout (--json appears in sibling flags).
+
+/// REGRESSION GUARD (v0.9.1): `wirerust analyze --help` `--no-collapse` entry
+/// must NOT reference the non-existent `--output json` / `--output csv` flags,
+/// and MUST reference at least one of the real output flags (`--json`, `--csv`,
+/// `--output-format`).
+///
+/// Scoping: clap renders flags as `\n      --flag-name\n          description`.
+/// The test finds the `--no-collapse` FLAG LINE (a line whose content, when
+/// trimmed, equals `--no-collapse`) and extracts the description lines that
+/// follow until the next flag line.  This prevents the `(pass --no-collapse to
+/// disable)` text in the sibling `--mitre` entry from tainting the assertions.
+///
+/// Fail-mode verification (run before committing 0.9.1 fix):
+///   Restored "Has no effect on --output json or --output csv." in src/cli.rs,
+///   ran cargo test no_collapse_help_names_real_output_flags.
+///   Test failed with:
+///     v0.9.1-reg: `--no-collapse` help must NOT contain bogus `--output json`
+///   and `--output csv` assertion also failed.
+///   Restored corrected wording: both (a) assertions pass, (b) passes.
+#[test]
+fn no_collapse_help_names_real_output_flags() {
+    let output = Command::cargo_bin("wirerust")
+        .expect("binary built")
+        .args(["analyze", "--help"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let help = String::from_utf8(output).expect("utf-8 stdout");
+
+    // Find the line where --no-collapse IS the flag (trimmed line == "--no-collapse"),
+    // not a reference to it inside another flag's description.
+    let nc_flag_line_start = help
+        .lines()
+        .enumerate()
+        .find(|(_, line)| line.trim() == "--no-collapse")
+        .map(|(i, _)| {
+            // Byte offset of the start of this line.
+            help.lines()
+                .take(i)
+                .map(|l| l.len() + 1) // +1 for the \n
+                .sum::<usize>()
+        })
+        .expect("v0.9.1-reg: `--no-collapse` flag line must appear in `analyze --help`");
+
+    let after_nc_line = &help[nc_flag_line_start..];
+
+    // The description is on the lines that follow the flag line.
+    // Collect lines until we hit the next flag line (trimmed starts with "--").
+    let mut nc_block = String::new();
+    let mut saw_flag_line = false;
+    for line in after_nc_line.lines() {
+        if line.trim() == "--no-collapse" {
+            saw_flag_line = true;
+            nc_block.push_str(line);
+            nc_block.push('\n');
+            continue;
+        }
+        if saw_flag_line {
+            // Stop at the next sibling flag line.
+            if line.trim_start().starts_with("--") && line.trim() != "--no-collapse" {
+                break;
+            }
+            nc_block.push_str(line);
+            nc_block.push('\n');
+        }
+    }
+
+    // (a) must NOT contain the bogus non-existent flag spelling.
+    assert!(
+        !nc_block.contains("--output json"),
+        "v0.9.1-reg: `--no-collapse` help must NOT contain bogus `--output json`; \
+         got block:\n{nc_block}"
+    );
+    assert!(
+        !nc_block.contains("--output csv"),
+        "v0.9.1-reg: `--no-collapse` help must NOT contain bogus `--output csv`; \
+         got block:\n{nc_block}"
+    );
+
+    // (b) must reference at least one real output flag.
+    let references_real_flag = nc_block.contains("--json")
+        || nc_block.contains("--csv")
+        || nc_block.contains("--output-format");
+    assert!(
+        references_real_flag,
+        "v0.9.1-reg: `--no-collapse` help must reference a real output flag \
+         (`--json`, `--csv`, or `--output-format`); got block:\n{nc_block}"
+    );
+}
+
 /// REGRESSION GUARD: `wirerust analyze --help` must not contain any of the
 /// internal factory provenance IDs `BC-`, `STORY-`, or `LESSON-`.
 ///


### PR DESCRIPTION
## v0.9.1 — Patch Release (develop → main promotion)

### Summary

- **Fix:** Corrected `--no-collapse` flag help text that incorrectly referenced non-existent `--output json/csv` flags; the correct flags are `--json`, `--csv`, and `--output-format`.
- **Behavior:** Unchanged — this is a documentation/help-text-only fix.
- **Regression test:** Added to prevent help-text drift in future.

### Promotion context

This is a gitflow develop→main promotion PR. The patch was already reviewed and merged to `develop` via PR #277. Branch `release/0.9.1` is byte-identical to develop HEAD (`cffed54`) — zero release-only fixup commits. Full pr-reviewer and security re-review are skipped (redundant for a promotion PR of already-reviewed code). Human has authorized the v0.9.1 release.

### Checklist

- [x] Patch reviewed and merged to develop (PR #277)
- [x] Version bump applied
- [x] CHANGELOG updated
- [x] Regression test added
- [ ] CI green on release/0.9.1
- [ ] Tagged on main after merge