### PR TITLE
fix: read_exact in read_magic eliminates short-read race; fix false wildcard-arm doc (F-F5P5-001/002)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -627,8 +627,8 @@ pub(crate) fn read_magic(path: &std::path::Path) -> Option<[u8; 4]> {
     use std::io::Read as _;
     let mut file = std::fs::File::open(path).ok()?;
     let mut buf = [0u8; 4];
-    let n = file.read(&mut buf).ok()?;
-    if n < 4 { None } else { Some(buf) }
+    file.read_exact(&mut buf).ok()?;
+    Some(buf)
 }
 
 /// Magic byte sets for content-based capture file detection (BC-2.12.011).
@@ -666,7 +666,7 @@ fn resolve_targets(target: &Path) -> Result<Vec<std::path::PathBuf>> {
 
 #[cfg(test)]
 mod tests {
-    use super::{collapse_findings_from_flag, grouping_from_flag};
+    use super::{collapse_findings_from_flag, grouping_from_flag, read_magic};
     use wirerust::reporter::terminal::Grouping;
 
     /// BC-2.11.028: flag absent (false) → collapse ON (true);
@@ -704,6 +704,42 @@ mod tests {
             grouping_from_flag(false),
             Grouping::Flat,
             "--mitre absent (show_mitre_grouping=false) must yield Grouping::Flat"
+        );
+    }
+
+    /// F-F5P5-002 — read_magic robustness: a file with fewer than 4 bytes returns None
+    /// (BC-2.12.011 Inv5 / EC-007).  A single `Read::read` may legally return <4 bytes
+    /// even for a ≥4-byte file; `read_exact` eliminates that race without changing the
+    /// short-file or unreadable-file semantics.
+    #[test]
+    fn test_read_magic_short_file_returns_none() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("short.bin");
+        std::fs::write(&path, b"\xA1\xB2\xC3").expect("write short file");
+
+        // A 3-byte file — cannot fill 4-byte magic buffer → must return None.
+        assert_eq!(
+            read_magic(&path),
+            None,
+            "read_magic on a <4-byte file must return None (BC-2.12.011 EC-007)"
+        );
+    }
+
+    /// F-F5P5-002 — read_magic robustness: a ≥4-byte file with a known magic returns
+    /// exactly those 4 bytes (BC-2.12.011 Inv5 — reads the FIRST 4 BYTES).
+    #[test]
+    fn test_read_magic_valid_file_returns_first_four_bytes() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("capture.pcapng");
+        // pcapng SHB magic followed by additional bytes — read_magic must return exactly
+        // the first 4 bytes and not be influenced by the bytes that follow.
+        let content: &[u8] = &[0x0A, 0x0D, 0x0D, 0x0A, 0xFF, 0xFF, 0xFF, 0xFF];
+        std::fs::write(&path, content).expect("write capture file");
+
+        assert_eq!(
+            read_magic(&path),
+            Some([0x0A, 0x0D, 0x0D, 0x0A]),
+            "read_magic must return the first 4 bytes of a ≥4-byte file (BC-2.12.011 Inv5)"
         );
     }
 }

--- a/tests/bc_2_01_story126_spb_tests.rs
+++ b/tests/bc_2_01_story126_spb_tests.rs
@@ -965,15 +965,13 @@ fn test_BC_2_01_013_spb_captured_len_max_original_len() {
 /// and continued parsing). The named-arm vs wildcard distinction is verified by
 /// the discriminating counter behavior for OPB (dual counter) vs generic (single).
 ///
-/// Note on current state: NRB/ISB/SJE/DSB currently fall to the wildcard `_` arm
-/// which ALSO increments skipped_blocks. So the counter total will be the same.
-/// The key behavioral distinction that WOULD fail is: DSB body bytes NOT logged
-/// (SEC-007) — this is structural and currently satisfied by the wildcard arm too.
-/// The F-07 requirement for EXPLICIT named arms is an implementation contract
-/// (architecture compliance rule 1), but the observable behavior tested here
-/// is counter incrementing and continued parsing. This test will be GREEN
-/// currently because the wildcard handles all of these correctly already.
-/// The test is included for completeness and to document the AC-006 contract.
+/// Implementation note: NRB/ISB/SJE/DSB are handled by EXPLICIT NAMED match arms at
+/// src/reader.rs:1228-1254 (NRB:1228, ISB:1235, SJE:1241, DSB:1247). Only genuinely
+/// unknown/unrecognized block types fall to the wildcard `_` arm (reader.rs:1256).
+/// The DSB arm satisfies SEC-007 (body bytes MUST NOT be logged) structurally — the
+/// named arm increments skipped_blocks and returns without touching body bytes.
+/// This test guards: named-arm dispatch + counter behavior + continued parsing
+/// (BC-2.01.015 AC-001 F-07, SEC-007 DSB boundary).
 #[test]
 fn test_BC_2_01_015_dispatch_known_and_skip_unknown() {
     // Build: SHB + IDB + NRB + ISB + SJE + DSB + unknown + EPB


### PR DESCRIPTION
## Summary

Two F5 Pass-5 findings resolved: a production robustness fix to `read_magic`
(F-F5P5-002, MEDIUM) and a doc correction in the SPB test suite
(F-F5P5-001, LOW). The dominant change is the production code fix.

## Findings Fixed

| ID | Severity | Category | Location |
|----|----------|----------|----------|
| F-F5P5-002 | MEDIUM | Production robustness | `src/main.rs` — `read_magic` |
| F-F5P5-001 | LOW | Doc correctness | `tests/bc_2_01_story126_spb_tests.rs` lines 968-976 |

---

## F-F5P5-002 — `read_magic`: `read_exact` replaces `read` (MEDIUM)

**Problem:** `read_magic` used `Read::read(&mut buf)`, which is legally permitted to
return fewer than 4 bytes for a ≥4-byte file (e.g. a pipe-backed fd at the OS
scheduler boundary, or certain non-regular-file fds). The old code handled the
short-read case with an explicit `if n < 4 { None }` guard — but `read` returning 0
bytes would also yield `None` (correct) while `read` returning 1–3 bytes for a
≥4-byte file would also yield `None` (a false negative — a valid capture file
might be skipped on a congested OS scheduler tick). This is a latent correctness
hazard even though it manifests rarely on regular files.

**Fix:** Replace with `file.read_exact(&mut buf)`, which loops internally until
exactly 4 bytes are consumed or returns `Err(UnexpectedEof)` if the file is truly
short. The `.ok()?` converts both `UnexpectedEof` (file < 4 bytes) and any other
I/O error to `None`, preserving the existing silent-skip semantics for unreadable
files. The `if n < 4 { None }` branch is eliminated (subsumed by `read_exact`
semantics).

**BC traceability:**
- BC-2.12.011 Inv5: "The first 4 bytes of the file are read" — `read_exact`
  guarantees exactly 4 bytes are read when the file is ≥4 bytes, satisfying this
  invariant more strictly than `read` could.
- BC-2.12.011 EC-007 (implied): file < 4 bytes → `None` (skip) — preserved via
  `UnexpectedEof` → `Err` → `.ok()?` → `None`.
- Silent-skip semantics (directory scanning): preserved — all Err variants map to
  `None` identically to the previous implementation.

**FIFO/pipe concern (security/DoS):** `resolve_targets` feeds `read_magic` only
from `std::fs::read_dir` entries where `path.is_file()` is true. On Linux/macOS,
`is_file()` returns false for FIFOs, sockets, and device nodes (it calls `stat`
and checks `S_ISREG`). Therefore `read_magic` is called exclusively on regular
files in the production code path. `read_exact` on a regular file is guaranteed to
return without blocking (the kernel buffers the data). The DoS/block risk from
`read_exact` on a pipe does not apply here. See security review notes.

**Tests added (2):**
1. `test_read_magic_short_file_returns_none` — 3-byte file → `None`
2. `test_read_magic_valid_file_returns_first_four_bytes` — 8-byte pcapng magic file → `Some([0x0A, 0x0D, 0x0D, 0x0A])`

---

## F-F5P5-001 — Doc correction in `test_BC_2_01_015_dispatch_known_and_skip_unknown` (LOW)

**Problem:** The doc-comment block (lines 968-976) contained a present-tense false
claim: "NRB/ISB/SJE/DSB currently fall to the wildcard arm". This was accurate
when the comment was first drafted (before named arms were added), but became
false after `src/reader.rs:1228-1254` introduced explicit named arms for all four
block types.

**Fix:** Replaced the entire false-present-tense block with accurate prose:
- Named arms at `src/reader.rs:1228-1254` (NRB:1228, ISB:1235, SJE:1241, DSB:1247)
- Only genuinely-unknown block types reach the wildcard `_` arm (reader.rs:1256)
- The DSB arm satisfies SEC-007 structurally (named arm returns without touching body bytes)
- The test now accurately documents what it guards: named-arm dispatch + counter
  behavior + continued parsing (BC-2.01.015 AC-001 F-07, SEC-007 DSB boundary)

---

## Architecture Changes

```mermaid
graph TD
    A[resolve_targets] -->|path.is_file| B[read_magic]
    B -->|read_exact 4 bytes| C{Err?}
    C -->|UnexpectedEof / IO err| D[None → skip]
    C -->|Ok| E[Some buf → check CAPTURE_MAGICS]
    E -->|match| F[include in scan]
    E -->|no match| G[skip non-capture file]
```

---

## Spec Traceability

```mermaid
flowchart LR
    BC["BC-2.12.011\nInv5 / EC-007"] --> Test1["test_read_magic_short_file_returns_none"]
    BC --> Test2["test_read_magic_valid_file_returns_first_four_bytes"]
    BC --> Impl["src/main.rs read_magic\nread_exact fix"]
    BC2["BC-2.01.015\nAC-001 F-07"] --> DocFix["tests/bc_2_01_story126_spb_tests.rs\ndoc correction"]
    SEC["SEC-007\nDSB body bytes"] --> DocFix
```

---

## Dependencies

No story dependency graph — this is a standalone F5 pass-5 refinement PR.
Branches from `develop` (HEAD 2dd5209, post-PR #290).

---

## Test Evidence

- `cargo test --all-targets` passes (run in `.worktrees/f5-final`)
- New tests: `test_read_magic_short_file_returns_none`, `test_read_magic_valid_file_returns_first_four_bytes`
- Existing tests: all prior `read_magic`-adjacent tests unchanged
- Lint: `cargo clippy --all-targets -- -D warnings` clean
- Format: `cargo fmt --check` clean

---

## Security Review

Populated after security-reviewer dispatch (Step 4).

---

## Risk Assessment

| Dimension | Assessment |
|-----------|-----------|
| Blast radius | Minimal — `read_magic` is 4 lines; only called from `resolve_targets` directory scan path |
| Behavioral delta | `read_exact` is strictly more correct; no observable change for regular files under normal I/O |
| Regression risk | Low — 2 new tests pin both the short-file and valid-file cases; prior test suite unchanged |
| Performance | Neutral — `read_exact` loops but the overhead is negligible for 4-byte reads on regular files |

---

## AI Pipeline Metadata

| Field | Value |
|-------|-------|
| Pipeline mode | F5 Pass-5 refinement |
| Branch | `fix/f5-final-refinement` |
| Commits | 2 (6e54ed8, 1ce12ca) |
| Base | `develop` (HEAD 2dd5209) |

---

## Pre-Merge Checklist

- [x] PR description matches actual diff
- [x] BC traceability complete (BC-2.12.011 Inv5/EC-007, BC-2.01.015 AC-001 F-07, SEC-007)
- [x] Tests added for production change (2 new tests)
- [x] Doc correction verified against `src/reader.rs:1228-1256`
- [ ] Security review completed
- [ ] Code review completed
- [ ] CI passing
