### PR TITLE
docs: document shipped pcapng support, remove stale roadmap entry (F7-003)

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,27 @@ CLI flags:
 [^1]: D3 storm findings emit `mitre_techniques: []` (no technique attributed). T0814 attribution
 is pending validation per DF-VALIDATION-001 / BC-2.16.008 Invariant 3.
 
-## Supported Link Types
+## Supported Capture Formats
+
+Both classic pcap (libpcap) and pcapng files are supported. Format is detected
+automatically by a magic-byte probe on the first four bytes of the file — no
+file extension is required.
+
+**Classic pcap** (.pcap) — all four byte-order and timestamp-resolution variants
+(big/little-endian, microsecond/nanosecond) are accepted. Snaplen-truncated captures
+(e.g. `tcpdump -s 96`) are read correctly.
+
+**pcapng** (.pcapng) — the reader parses SHB, IDB, EPB, and SPB blocks. NRB, ISB,
+SJE, DSB (Decryption Secrets), OPB, and unrecognized block types are silently
+skipped. Up to 65,535 Interface Description Blocks are accepted per file; all
+interfaces in a single file must share the same link type. Multi-section files
+(a second SHB block) are not supported — use `mergecap` or `editcap` to
+re-save as a single-section file. The all-in-memory model imposes a 4 GiB
+per-file size cap (E-INP-014).
+
+### Supported Link Types
+
+The following link-layer types are supported in both classic pcap and pcapng files:
 
 | Type | ID | Status |
 |------|-----|--------|
@@ -209,7 +229,6 @@ is pending validation per DF-VALIDATION-001 / BC-2.16.008 Invariant 3.
 | Linux Cooked (SLL) | 113 | Supported |
 | IPv4 | 228 | Supported |
 | IPv6 | 229 | Supported |
-| pcapng | — | Not yet supported |
 
 ## Extending
 
@@ -266,7 +285,6 @@ See [open issues](https://github.com/Zious11/wirerust/issues) for planned featur
 - C2 beaconing detection
 - SQLite export
 - Parallel file processing
-- pcapng format support
 
 ## License
 


### PR DESCRIPTION
## Summary

Fixes stale README claims introduced before pcapng reading shipped (FE-001). The README previously listed pcapng as "Not yet supported" in the link-types table and as a future roadmap item. Both entries are now removed and replaced with accurate documentation of the shipped behavior.

## What changed

**Section renamed and expanded — "Supported Link Types" → "Supported Capture Formats"**

- Added a new top-level prose section documenting both classic pcap and pcapng support
- Classic pcap: all four byte-order/timestamp variants accepted; snaplen-truncated captures noted
- pcapng: magic-byte auto-detection (first 4 bytes, no file extension required); SHB, IDB, EPB, SPB parsed; NRB, ISB, SJE, DSB, OPB, and unrecognized block types silently skipped; 65,535 IDB cap per file; all interfaces must share the same link type; multi-section files (second SHB) unsupported; 4 GiB per-file cap (E-INP-014)
- Supported Link Types sub-section updated: removed "pcapng | — | Not yet supported" row; heading note clarifies both pcap and pcapng share the same supported link types

**Roadmap section**

- Removed "pcapng format support" bullet (shipped in FE-001)

## Traceability

| Item | Value |
|------|-------|
| Finding | F7-003 — stale pcapng "not supported" claim |
| Source | FE-001 pcapng reading (STORY-128 / PR #286) |
| Files changed | README.md only — zero code changes |

## Verification

All README claims were verified against src/reader.rs:
- Magic-byte probe: PCAPNG_MAGIC constant + routing logic confirmed
- SHB/IDB/EPB/SPB parsed: block-type constants and match arms confirmed
- NRB/ISB/SJE/DSB/OPB skipped: explicit skip arms (BC-2.01.015 AC-001 F-07) confirmed
- 65,535 IDB cap: MAX_INTERFACE_TABLE_ENTRIES: usize = 65_535 confirmed
- 4 GiB limit: MAX_PCAPNG_FILE_BYTES: u64 = 4_294_967_296 + E-INP-014 error confirmed
- Single link-type constraint: conflict check at line 1227 confirmed
- Second-SHB rejection: E-INP-012 error at line 1142 confirmed

## Pre-Merge Checklist

- [x] README claims verified against src/reader.rs
- [x] Zero code changes (doc-only)
- [x] Semantic PR title (docs: type)
- [ ] CI green
- [ ] pr-reviewer approved