### PR TITLE
test: add 10 analyzer-gap captures to E2E corpus (HTTP, DNS-tunnel, pcapng SPB/multi-IDB, IP-frag)

### DIFF
--- a/bin/fetch-e2e-pcaps
+++ b/bin/fetch-e2e-pcaps
@@ -74,6 +74,53 @@ REAL_CAPTURES=(
   # Exercises ISB skip path in the pcapng reader. From Wireshark test suite.
   # Credit: Wireshark Foundation; BSD-style license via wireshark/wireshark repo.
   "http-brotli-isb.pcapng|dc3957f2348adc8f148cd776bef9e4bc2b3d062edc1b2aedc7c2a2b92b60b055|https://gitlab.com/wireshark/wireshark/-/raw/master/test/captures/http-brotli.pcapng"
+  # --- pcapng analyzer-gap suite (BC-2.01.013 SPB path; multi-IDB link-type diversity; LE NRB) ---
+  # SPB-only capture: 1 SHB + 1 IDB + SPBs (Simple Packet Blocks, type 0x00000003).
+  # Exercises the SPB decoding path (BC-2.01.013). Triggers E-INP-010 (IfFcsLen IDB option
+  # framing rejection by pcap-file crate) — clean error, no crash, exit 0.
+  # Credit: Wireshark Foundation (Wireshark GitLab uploads); no per-file license; public sample.
+  "pcapng-spb-only.pcapng|b17e5343901407898ca4cd9612c06611c261780c49a2773a55668197024987a6|https://gitlab.com/wireshark/wireshark/uploads/306fa2c3b67bb7d3011a546698bbbae0/SimplePacketBlockSample.pcapng"
+  # 11 IDB + 11 ISB + NRB: exercises multi-interface + Interface Statistics Block skip path.
+  # First IDB has link type NULL (loopback, type 0) — triggers unsupported-link-type error,
+  # no crash, exit 0. From Wireshark Development/PcapNg wiki page.
+  # Credit: Wireshark Foundation; public sample at wiki.wireshark.org/Development/PcapNg.
+  "pcapng-many-interfaces.pcapng|9bf6c1b68fa59c9e246ddb9f95d0058945cda3dbec624f9e80ef7f27f8c71484|https://wiki.wireshark.org/uploads/__moin_import__/attachments/Development/PcapNg/many_interfaces.pcapng"
+  # DHCP little-endian pcapng: LE NRB control. SHB byte-order LE (magic D4C3B2A1 side).
+  # 4 DHCP/UDP packets. Parses clean, exit 0. From Wireshark wiki uploads.
+  # Credit: Wireshark Foundation; public sample at wiki.wireshark.org.
+  "pcapng-dhcp-little-endian.pcapng|32df980a23be310ad0db9960273ee193d6574d63b4f3a977f061d59de4ddcd2d|https://wiki.wireshark.org/uploads/02e9c71c4512bf63f4577a3487f92a62/dhcp_little_endian.pcapng"
+  # --- HTTP analyzer gap (classic pcap — exercises HTTP analyzer at depth) ---
+  # Real malicious HTTP traffic: malspam campaign downloading .hta + .exe payloads.
+  # 738 packets / 718 HTTP / 10 transactions; POST + GET to malspam C2 hosts.
+  # Credit: mchow01/Bootcamp (GitHub); no explicit LICENSE — local use only, not redistributed.
+  "http-malspam-set6.pcap|bffb320de4361fafae783d7d01145cb3d9ee6b2ef4b3c957c2cbe8826df55d8d|https://raw.githubusercontent.com/mchow01/Bootcamp/master/set6.pcap"
+  # HTTP 401 credential challenge: Tufts EECS grades URL; 168 packets / 75 HTTP / 3 transactions.
+  # Validates HTTP analyzer POST/auth flow detection path.
+  # Credit: mchow01/Bootcamp (GitHub); no explicit LICENSE — local use only, not redistributed.
+  "http-creds-set4.pcap|6c93e7253215c7ab66db466fe82bd51fa39967c1087cd37d9cf105378936cfb3|https://raw.githubusercontent.com/mchow01/Bootcamp/master/set4.pcap"
+  # Practical Packet Analysis HTTP baseline: classic pcap (.cap ext), LE magic d4c3b2a1.
+  # 43 packets / 41 HTTP / benign GET. HTTP analyzer baseline / regression reference.
+  # Credit: markofu/pcaps (GitHub, PracticalPacketAnalysis); no explicit LICENSE — local use only.
+  "http-ppa-baseline.cap|25a72bdf10339f2c29916920c8b9501d294923108de8f29b19aba7cc001ab60d|https://raw.githubusercontent.com/markofu/pcaps/master/PracticalPacketAnalysis/ppa-capture-files/http.cap"
+  # --- DNS-tunnel positives (classic pcap; future DNS-tunnel detector fixtures) ---
+  # dnscat2 DNS-tunneling: 24 packets, 24 DNS, 0 findings (detector not yet implemented).
+  # Retained as future-detector fixture and benign-parse baseline for DNS over UDP.
+  # Credit: dmachard/datasets-malicious-dns (GitHub); no explicit LICENSE — local use only.
+  "dns-tunnel-dnscat2.pcap|904817d65b4bc9949bbb969b5be504faa2c4c41b2041ec3e005b6ee25a20fd45|https://raw.githubusercontent.com/dmachard/datasets-malicious-dns/main/dnscat2.pcap"
+  # iodine DNS-tunneling (dmachard dataset): 24 packets, 24 DNS, 0 findings.
+  # Complements the elastic/examples iodine fixture. Different capture, same tool.
+  # Credit: dmachard/datasets-malicious-dns (GitHub); no explicit LICENSE — local use only.
+  "dns-tunnel-iodine-dmachard.pcap|5d9eb84014c98b4f4b21374178172e45ecfa54c881c1e5a8bdfc719832f6ad8a|https://raw.githubusercontent.com/dmachard/datasets-malicious-dns/main/iodine.pcap"
+  # dns2tcp DNS-tunneling: 26 packets, 26 DNS, 0 findings (detector not yet implemented).
+  # Future-detector fixture for a third DNS-tunnel tool (dns2tcp vs dnscat2 vs iodine).
+  # Credit: dmachard/datasets-malicious-dns (GitHub); no explicit LICENSE — local use only.
+  "dns-tunnel-dns2tcp.pcap|41a50974baa28c7731ed67a460d4e9bd9c0a6231c4ee660b2ee2ce798ab439aa|https://raw.githubusercontent.com/dmachard/datasets-malicious-dns/main/dns2tcp.pcap"
+  # --- IP fragmentation (classic pcap; teardrop DoS overlap) ---
+  # teardrop attack: 6 packets with malformed overlapping IP fragments (UDP payload).
+  # wirerust skips all 6 as decode errors (fragmented IP / no reassembly). Exit 0, no crash.
+  # Validates graceful handling of fragment overlap without panic.
+  # Credit: Wireshark SampleCaptures (wiki.wireshark.org); public sample.
+  "ip-frag-teardrop.cap|e8e4193ae426dabf549cc103c9e93e7d93c6ae049ee9259f1ce2ebdb7315a683|https://wiki.wireshark.org/uploads/__moin_import__/attachments/SampleCaptures/teardrop.cap"
 )
 
 # Link-only captures — NOT auto-fetched. They require manual browser download or are too
@@ -89,6 +136,11 @@ REAL_CAPTURES=(
 #                                               URL: https://cupid-data-storage.nyc3.digitaloceanspaces.com/
 #                                                    Raw-Baseline-Data/042219_1000_7.pcapng
 #                                               Cite: "CUPID: Corpus for Understanding Packet Intrusion Data"
+# 2014-12-15-traffic-analysis-exercise.pcap.zip (~unknown)
+#   — Malware Traffic Analysis (malware-traffic-analysis.net); password-protected zip (pw on MTA About page)
+#   URL: https://malware-traffic-analysis.net/2014/12/15/2014-12-15-traffic-analysis-exercise.pcap.zip
+#   Bot-blocked and requires password extraction — cannot be auto-fetched. Attribution required; see E2E-PCAPS.md.
+#   Content: HTTP malspam/bot traffic exercise pcap from 2014-12-15 MTA exercise.
 #
 # To fetch manually: download via browser from the URLs in E2E-PCAPS.md and place the file
 # in tests/fixtures/local-samples/. SHA256 values from source are noted there but not

--- a/tests/fixtures/E2E-PCAPS.md
+++ b/tests/fixtures/E2E-PCAPS.md
@@ -41,10 +41,41 @@ All are genuine native pcapng (SHB magic `0x0A0D0D0A` verified). All are auto-fe
 | `dtls12-dsb.pcapng` | 2.0 KB | `23acb003e1e96f993f759289e3dd1853f6d1b5d1082c6cca711b3dff185aac53` | [Wireshark test suite](https://gitlab.com/wireshark/wireshark/-/raw/master/test/captures/dtls12-aes128ccm8-dsb.pcapng) (BSD-style; credit Wireshark Foundation) | DTLS 1.2 / UDP (13 packets) | **DSB** (Decryption Secrets Block, type `0x0000000A`) with DTLS TLS-key log; exercises DSB block read/skip path; LE | exit=0; 13 packets parsed |
 | `dhcp-nanosecond-test.pcapng` | 1.6 KB | `efd90c0d4d35fde4d77557d188553df2a9536c0d0526590476154968e228d507` | [Wireshark test suite](https://gitlab.com/wireshark/wireshark/-/raw/master/test/captures/dhcp-nanosecond.pcapng) (BSD-style; credit Wireshark Foundation) | DHCP/UDP (4 packets) | **IDB `if_tsresol` option** = `0x09` (base-10, exponent 9 = nanosecond timestamps); exercises nanosecond-resolution IDB option parsing path; LE | exit=0; 4 packets parsed |
 | `http-brotli-isb.pcapng` | 1.8 KB | `dc3957f2348adc8f148cd776bef9e4bc2b3d062edc1b2aedc7c2a2b92b60b055` | [Wireshark test suite](https://gitlab.com/wireshark/wireshark/-/raw/master/test/captures/http-brotli.pcapng) (BSD-style; credit Wireshark Foundation) | HTTP/TCP (10 packets) | **ISB** (Interface Statistics Block, type `0x00000005`); exercises ISB block skip/parse path; LE | exit=0; 10 packets parsed (HTTP service detected) |
+| `pcapng-spb-only.pcapng` | 3.1 KB | `b17e5343901407898ca4cd9612c06611c261780c49a2773a55668197024987a6` | [Wireshark GitLab uploads](https://gitlab.com/wireshark/wireshark/uploads/306fa2c3b67bb7d3011a546698bbbae0/SimplePacketBlockSample.pcapng) (public sample; credit Wireshark Foundation) | UDP (SPB-wrapped, 1 IDB) | **SPB** (Simple Packet Block, type `0x00000003`, BC-2.01.013); SHB+IDB+SPBs only, no EPBs. Triggers E-INP-010 (IfFcsLen IDB option framing rejection by pcap-file crate) — clean error, no crash | exit=0 (E-INP-010: IDB IfFcsLen option rejection); 0 packets processed (crate rejects before dispatch) |
+| `pcapng-many-interfaces.pcapng` | 20 KB | `9bf6c1b68fa59c9e246ddb9f95d0058945cda3dbec624f9e80ef7f27f8c71484` | [Wireshark wiki Development/PcapNg](https://wiki.wireshark.org/Development/PcapNg) (public sample; credit Wireshark Foundation) | Mixed (loopback / NULL link type; 11 IDBs + 11 ISBs + NRB) | **11×IDB + 11×ISB + NRB** at once; first IDB has link type NULL (0 = BSD loopback). Triggers unsupported-link-type error — clean, no crash | exit=0 (unsupported link type NULL); 0 packets processed |
+| `pcapng-dhcp-little-endian.pcapng` | 1.5 KB | `32df980a23be310ad0db9960273ee193d6574d63b4f3a977f061d59de4ddcd2d` | [Wireshark wiki uploads](https://wiki.wireshark.org/uploads/02e9c71c4512bf63f4577a3487f92a62/dhcp_little_endian.pcapng) (public sample; credit Wireshark Foundation) | DHCP/UDP (4 packets) | **LE NRB control**: LE-encoded pcapng with Name Resolution Block; complements `dhcp-big-endian.pcapng` for endian-pair coverage | exit=0; 4 packets parsed (4 UDP) |
 
 > A tiny committed fixture, `tests/fixtures/modbus-write.pcap` (8 packets), is
 > tracked in git and used by the automated test suite — it is **not** part of
 > this local-only set.
+
+## HTTP analyzer gap
+
+Real HTTP captures for depth-testing the HTTP analyzer. All are classic pcap (LE magic `d4 c3 b2 a1` verified). All are auto-fetchable.
+
+| File | Size | sha256 | Source | Protocols | Validates |
+|------|------|--------|--------|-----------|-----------|
+| `http-malspam-set6.pcap` | 658 KB | `bffb320de4361fafae783d7d01145cb3d9ee6b2ef4b3c957c2cbe8826df55d8d` | [mchow01/Bootcamp](https://github.com/mchow01/Bootcamp) (no explicit LICENSE — local use only, not redistributed) | HTTP/TCP (738 packets; 718 HTTP; 10 transactions) | Real malspam campaign: POSTs to C2 hosts (`myapplicationsdownload.download`, `josephioseph.com`); downloads `.hta` + `.exe` payloads via GET. HTTP analyzer output: 8× POST + 2× GET, 8×200 + 2×404; IE7 + "Charon; Inferno" user-agents. Validates HTTP analyzer malicious-request detection path. |
+| `http-creds-set4.pcap` | 17 KB | `6c93e7253215c7ab66db466fe82bd51fa39967c1087cd37d9cf105378936cfb3` | [mchow01/Bootcamp](https://github.com/mchow01/Bootcamp) (no explicit LICENSE — local use only, not redistributed) | HTTP/TCP (168 packets; 75 HTTP; 3 transactions) | HTTP 401 credential challenge to Tufts EECS grades URL; 3× GET, 3×401 status. Validates HTTP auth-flow and 4xx status tracking. |
+| `http-ppa-baseline.cap` | 25 KB | `25a72bdf10339f2c29916920c8b9501d294923108de8f29b19aba7cc001ab60d` | [markofu/pcaps (PracticalPacketAnalysis)](https://github.com/markofu/pcaps) (no explicit LICENSE — local use only, not redistributed) | HTTP/TCP (43 packets; 41 HTTP) | Benign HTTP GET baseline from Practical Packet Analysis. Regression reference: 0 malicious findings. `.cap` extension; classic pcap format (verified by magic). |
+
+## DNS-tunnel positives
+
+Classic pcap captures of real DNS-tunneling tool traffic. All are auto-fetchable. wirerust currently produces 0 findings for all (DNS-tunneling detector not yet implemented). Retained as future-detector fixtures and benign-parse baselines.
+
+| File | Size | sha256 | Source | Protocols | Validates |
+|------|------|--------|--------|-----------|-----------|
+| `dns-tunnel-dnscat2.pcap` | 3.5 KB | `904817d65b4bc9949bbb969b5be504faa2c4c41b2041ec3e005b6ee25a20fd45` | [dmachard/datasets-malicious-dns](https://github.com/dmachard/datasets-malicious-dns) (no explicit LICENSE — local use only, not redistributed) | DNS/UDP (24 packets, 2 hosts) | dnscat2 DNS-tunnel traffic. 0 findings (detector unimplemented). Future-detector fixture for DNS-tunnel detection. Parses cleanly. |
+| `dns-tunnel-iodine-dmachard.pcap` | 3.4 KB | `5d9eb84014c98b4f4b21374178172e45ecfa54c881c1e5a8bdfc719832f6ad8a` | [dmachard/datasets-malicious-dns](https://github.com/dmachard/datasets-malicious-dns) (no explicit LICENSE — local use only, not redistributed) | DNS/UDP (24 packets, 2 hosts) | iodine DNS-tunnel traffic (dmachard dataset). Complements the `dns-tunnel-iodine.pcap` (Elastic) fixture — different capture, same tool. 0 findings. |
+| `dns-tunnel-dns2tcp.pcap` | 4.4 KB | `41a50974baa28c7731ed67a460d4e9bd9c0a6231c4ee660b2ee2ce798ab439aa` | [dmachard/datasets-malicious-dns](https://github.com/dmachard/datasets-malicious-dns) (no explicit LICENSE — local use only, not redistributed) | DNS/UDP (26 packets, 2 hosts) | dns2tcp DNS-tunnel traffic. Third distinct tool alongside dnscat2/iodine. 0 findings. Future-detector fixture. |
+
+## IP fragmentation
+
+Classic pcap captures exercising IP fragment handling.
+
+| File | Size | sha256 | Source | Protocols | Validates |
+|------|------|--------|--------|-----------|-----------|
+| `ip-frag-teardrop.cap` | 1.8 KB | `e8e4193ae426dabf549cc103c9e93e7d93c6ae049ee9259f1ce2ebdb7315a683` | [Wireshark SampleCaptures](https://wiki.wireshark.org/SampleCaptures) (public sample; credit Wireshark Foundation) | IP (6 fragmented packets; 2 ICMP + 2 UDP + 2 Other(17)) | teardrop DoS attack: malformed overlapping IP fragments. wirerust skips all 6 as decode errors (no IP-reassembly path). Validates graceful skip-and-continue on fragment overlap without crash. Exit 0. |
 
 ## Direct download URLs (real captures)
 
@@ -63,6 +94,16 @@ All are genuine native pcapng (SHB magic `0x0A0D0D0A` verified). All are auto-fe
 | `dtls12-dsb.pcapng` | `https://gitlab.com/wireshark/wireshark/-/raw/master/test/captures/dtls12-aes128ccm8-dsb.pcapng` |
 | `dhcp-nanosecond-test.pcapng` | `https://gitlab.com/wireshark/wireshark/-/raw/master/test/captures/dhcp-nanosecond.pcapng` |
 | `http-brotli-isb.pcapng` | `https://gitlab.com/wireshark/wireshark/-/raw/master/test/captures/http-brotli.pcapng` |
+| `pcapng-spb-only.pcapng` | `https://gitlab.com/wireshark/wireshark/uploads/306fa2c3b67bb7d3011a546698bbbae0/SimplePacketBlockSample.pcapng` |
+| `pcapng-many-interfaces.pcapng` | `https://wiki.wireshark.org/uploads/__moin_import__/attachments/Development/PcapNg/many_interfaces.pcapng` |
+| `pcapng-dhcp-little-endian.pcapng` | `https://wiki.wireshark.org/uploads/02e9c71c4512bf63f4577a3487f92a62/dhcp_little_endian.pcapng` |
+| `http-malspam-set6.pcap` | `https://raw.githubusercontent.com/mchow01/Bootcamp/master/set6.pcap` |
+| `http-creds-set4.pcap` | `https://raw.githubusercontent.com/mchow01/Bootcamp/master/set4.pcap` |
+| `http-ppa-baseline.cap` | `https://raw.githubusercontent.com/markofu/pcaps/master/PracticalPacketAnalysis/ppa-capture-files/http.cap` |
+| `dns-tunnel-dnscat2.pcap` | `https://raw.githubusercontent.com/dmachard/datasets-malicious-dns/main/dnscat2.pcap` |
+| `dns-tunnel-iodine-dmachard.pcap` | `https://raw.githubusercontent.com/dmachard/datasets-malicious-dns/main/iodine.pcap` |
+| `dns-tunnel-dns2tcp.pcap` | `https://raw.githubusercontent.com/dmachard/datasets-malicious-dns/main/dns2tcp.pcap` |
+| `ip-frag-teardrop.cap` | `https://wiki.wireshark.org/uploads/__moin_import__/attachments/SampleCaptures/teardrop.cap` |
 
 ### Link-only captures (cannot be auto-fetched)
 
@@ -77,6 +118,7 @@ or are too large for routine automated fetching.
 | `maccdc2012_00000.pcap` | ~1 GB | unverified | `https://share.netresec.com/s/7qgDSGNGw2NY8ea/download/maccdc2012_00000.pcap` | Netresec public pcap collection (credit Netresec / maccdc) | Mixed-enterprise scale stressor (HTTP/TLS/DNS/SMB). Optional given 1 GB size; not included in standard fetch. |
 | `asyncrat_1hr.pcapng` | ~4.6 MB | unverified | `https://www.activecountermeasures.com/wp-content/uploads/2021/06/asyncrat_1hr.pcapng` | Active Countermeasures "Malware of the Day: AsyncRAT" (public blog resource) | **Native pcapng**, malware C2 traffic (AsyncRAT), HTTP/DNS/TLS. Exercises pcapng reader with real-world malware capture. Bot-blocked (HTTP 403 from Cloudflare to automated curl) — requires browser download. SHA256 not independently verified. |
 | `042219_1000_7.pcapng` | ~657 MB | unverified | `https://cupid-data-storage.nyc3.digitaloceanspaces.com/Raw-Baseline-Data/042219_1000_7.pcapng` | [CUPID dataset](https://github.com/kaylode/cupid) — Colorado University, CC BY-SA 4.0 (cite: "CUPID: Corpus for Understanding Packet Intrusion Data") | **Large native pcapng** with multiple IDBs and NRBs; real network baseline traffic. Exercises multi-block pcapng at scale. HTTP 200 (direct curl-able); excluded from auto-fetch due to 657 MB size. To add: `curl -fL -o tests/fixtures/local-samples/042219_1000_7.pcapng <URL>`. |
+| `2014-12-15-traffic-analysis-exercise.pcap.zip` | unknown | unverified | `https://malware-traffic-analysis.net/2014/12/15/2014-12-15-traffic-analysis-exercise.pcap.zip` | [Malware Traffic Analysis](https://malware-traffic-analysis.net) — Brad Duncan; see MTA "About" page for terms (password-protected zip; password listed on MTA About page) | **Bot-blocked + password-protected** — cannot be auto-fetched. Password-zip must be downloaded via browser; password on MTA About page. Contains HTTP malspam/bot traffic from MTA 2014-12-15 exercise. Attribution required if used in training material. |
 
 ## Attribution
 
@@ -107,12 +149,49 @@ used in training material. They are not redistributed via this repo.
   is released under the GNU GPLv2; test captures are generally considered BSD-style public
   domain test assets, used locally for validation only, not redistributed.
   Credit: Wireshark Foundation contributors.
+- **`pcapng-spb-only.pcapng`**: Wireshark GitLab uploads. Public sample originally posted
+  to demonstrate SPB (Simple Packet Block) format; no per-file license stated. Credit:
+  Wireshark Foundation. Not redistributed.
+- **`pcapng-many-interfaces.pcapng`**: Wireshark wiki Development/PcapNg page. Public
+  sample demonstrating multi-IDB pcapng structure. No per-file license stated. Credit:
+  Wireshark Foundation. Not redistributed.
+- **`pcapng-dhcp-little-endian.pcapng`**: Wireshark wiki uploads. Public sample demonstrating
+  LE pcapng with NRB. No per-file license stated. Credit: Wireshark Foundation. Not redistributed.
 - **`asyncrat_1hr.pcapng`** (link-only): Active Countermeasures "Malware of the Day" blog
   resource. Public download from WordPress uploads. SHA256 not independently verified.
   Used locally only — not redistributed.
 - **`042219_1000_7.pcapng`** (link-only): CUPID dataset, Colorado University.
   License: CC BY-SA 4.0. Cite: "CUPID: Corpus for Understanding Packet Intrusion Data."
   Not redistributed; see dataset homepage for terms.
+
+### HTTP analyzer captures attribution
+
+- **`http-malspam-set6.pcap`** and **`http-creds-set4.pcap`**: `mchow01/Bootcamp` GitHub
+  repository. No explicit LICENSE file — all-rights-reserved presumed. Used locally for
+  validation only, not redistributed. Credit: mchow01 (GitHub).
+- **`http-ppa-baseline.cap`**: Practical Packet Analysis sample captures, re-hosted in
+  `markofu/pcaps` (no explicit license). Used locally for validation only — not
+  redistributed. Credit: Chris Sanders / No Starch Press.
+
+### DNS-tunnel captures attribution
+
+- **`dns-tunnel-dnscat2.pcap`**, **`dns-tunnel-iodine-dmachard.pcap`**,
+  **`dns-tunnel-dns2tcp.pcap`**: `dmachard/datasets-malicious-dns` GitHub repository.
+  No explicit LICENSE file — used locally for validation only, not redistributed.
+  Credit: dmachard (GitHub).
+
+### IP fragmentation captures attribution
+
+- **`ip-frag-teardrop.cap`**: Wireshark Foundation public SampleCaptures collection.
+  No per-file license stated; distributed as a public sample. Credit: Wireshark Foundation.
+  Not redistributed.
+
+### MTA exercise attribution (link-only)
+
+- **`2014-12-15-traffic-analysis-exercise.pcap.zip`**: Malware Traffic Analysis
+  (malware-traffic-analysis.net) by Brad Duncan. Password-protected zip; password on MTA
+  About page. Attribution required if used in training material — credit Brad Duncan /
+  malware-traffic-analysis.net. Not redistributed.
 
 ## ARP captures (D1 spoof / D2 GARP / D3 storm / D12 MAC mismatch)
 
@@ -161,9 +240,17 @@ They live gitignored under `tests/fixtures/local-samples/` — never committed.
   `0x0A0D0D0A`, regardless of extension (resolves C-2: `arp-baseline-16pkt.cap` now accepted
   and parses to 16 ARP packets). Large TLS-heavy captures previously blocked by pcapng format
   are now candidates for the E2E corpus.
-- **DNS tunneling detection not yet implemented:** `dns-tunnel-iodine.pcap` (and the
-  dnscat2 captures above) currently produce 0 findings. They are retained as benign-parse
-  baselines and future-detector fixtures for whenever DNS-tunneling analysis is added.
+- **DNS tunneling detection not yet implemented:** `dns-tunnel-iodine.pcap` (Elastic),
+  `dns-tunnel-dnscat2.pcap`, `dns-tunnel-iodine-dmachard.pcap`, and `dns-tunnel-dns2tcp.pcap`
+  (all dmachard) currently produce 0 findings. They are retained as benign-parse baselines
+  and future-detector fixtures (covering three distinct DNS-tunnel tools: dnscat2, iodine,
+  dns2tcp) for whenever DNS-tunneling analysis is added.
+- **HTTP analyzer depth:** `http-malspam-set6.pcap`, `http-creds-set4.pcap`, and
+  `http-ppa-baseline.cap` exercise the HTTP analyzer at 3–10 transactions with real-world
+  payloads and malicious URIs. The HTTP analyzer currently parses transactions and tracks
+  hosts/UAs/status-codes but has no malicious-detection findings.
+- **IP fragmentation not reassembled:** `ip-frag-teardrop.cap` confirms wirerust skips
+  fragmented IP packets as decode errors without crashing. No IP-reassembly path exists yet.
 - **Full research write-up:** The evaluation methodology, candidate evaluation, and rationale
   for all selections above is documented at `.factory/research/e2e-pcap-candidates.md`.
 


### PR DESCRIPTION
## Summary

Adds 10 auto-fetchable real packet captures and 1 link-only entry to the E2E corpus
(`bin/fetch-e2e-pcaps` + `tests/fixtures/E2E-PCAPS.md`). No production code changed.
No CI-gated test added. Capture files are gitignored — only the fetcher script and
index are tracked.

## Captures added

### pcapng analyzer-gap (3 new)

| File | Size | What it validates |
|------|------|-------------------|
| `pcapng-spb-only.pcapng` | 3.1 KB | SPB (Simple Packet Block, BC-2.01.013) path — triggers E-INP-010 (IfFcsLen IDB option rejection by pcap-file crate); clean error, exit 0, no crash |
| `pcapng-many-interfaces.pcapng` | 20 KB | 11 IDB + 11 ISB + NRB; first IDB has NULL link type (BSD loopback) — triggers unsupported-link-type error, clean, exit 0 |
| `pcapng-dhcp-little-endian.pcapng` | 1.5 KB | LE NRB control — complements dhcp-big-endian.pcapng for endian-pair coverage; 4 DHCP/UDP packets, exit 0 |

**Caveats:**
- `pcapng-spb-only.pcapng`: The pcap-file crate rejects IfFcsLen IDB options before dispatch, so SPB blocks are not reached. Exit 0 + E-INP-010 error is correct behavior and is the documented limitation for this fixture.
- `pcapng-many-interfaces.pcapng`: wirerust reports unsupported link type NULL (0 = BSD loopback) from first IDB. First unsupported IDB triggers whitelist rejection; the 10 subsequent IDBs are not evaluated.

### HTTP analyzer gap (3 new)

| File | Size | What it validates |
|------|------|-------------------|
| `http-malspam-set6.pcap` | 658 KB | Real malspam: 738 pkts / 10 HTTP transactions / C2 POSTs + .hta + .exe GET downloads; malicious URI detection fixture |
| `http-creds-set4.pcap` | 17 KB | HTTP 401 credential challenge; 168 pkts / 3 transactions; validates auth-flow and 4xx status tracking |
| `http-ppa-baseline.cap` | 25 KB | Benign HTTP GET baseline (Practical Packet Analysis); 43 pkts; regression reference — 0 malicious findings expected |

Note: `http-ppa-baseline.cap` uses the `.cap` extension; classic pcap format verified by LE magic `d4 c3 b2 a1`.

### DNS-tunnel positives (3 new)

All from `dmachard/datasets-malicious-dns`. wirerust currently produces 0 findings for all (DNS-tunneling detection not yet implemented). Retained as future-detector fixtures and benign-parse baselines.

| File | Size | Tool |
|------|------|------|
| `dns-tunnel-dnscat2.pcap` | 3.5 KB | dnscat2 (24 DNS/UDP pkts) |
| `dns-tunnel-iodine-dmachard.pcap` | 3.4 KB | iodine (24 DNS/UDP pkts) — complements existing elastic/examples iodine fixture |
| `dns-tunnel-dns2tcp.pcap` | 4.4 KB | dns2tcp (26 DNS/UDP pkts) |

### IP fragmentation (1 new)

| File | Size | What it validates |
|------|------|-------------------|
| `ip-frag-teardrop.cap` | 1.8 KB | Teardrop DoS: 6 malformed overlapping IP fragments; wirerust skips all as decode errors; validates graceful skip-and-continue without crash, exit 0 |

### Link-only (1 new, MTA exercise)

`2014-12-15-traffic-analysis-exercise.pcap.zip` added to link-only section: Malware Traffic Analysis exercise, HTTP malspam/bot traffic, password-protected zip, bot-blocked CDN — cannot be auto-fetched. Attribution: Brad Duncan / malware-traffic-analysis.net.

## Files changed

- `bin/fetch-e2e-pcaps` — 10 new entries in `REAL_CAPTURES` array (name|sha256|url format, sha256 pins verified); 1 new comment entry in link-only block
- `tests/fixtures/E2E-PCAPS.md` — new sections for pcapng analyzer-gap, HTTP analyzer gap, DNS-tunnel positives, IP fragmentation, updated link-only and attribution sections

## Security review

Not required. This PR contains no executable production code — only:
- A bash script (`bin/fetch-e2e-pcaps`) that downloads files and verifies their sha256 checksums before accepting them. All URLs are SHA-pinned via the inline `sha256` field in each `REAL_CAPTURES` entry; an attacker-supplied file with a non-matching checksum is rejected by `verify()` and the script exits non-zero.
- A markdown index file with no executable content.

No OWASP top-10 surface applies. The download script already defends against substitution attacks via sha256 verification.

## Risk assessment

**Blast radius:** Zero. No production source files, no compiled code, no CI test suite changes. Capture files are gitignored.

**Performance impact:** None. No runtime code path modified.

**Rollback:** Revert a 2-file diff (bash array entries + markdown rows).

## Pre-merge checklist

- [x] Only 2 files changed: `bin/fetch-e2e-pcaps` and `tests/fixtures/E2E-PCAPS.md`
- [x] All 10 REAL_CAPTURES entries follow `name|sha256|url` format
- [x] All sha256 values are 64 hex characters
- [x] sha256 values in fetcher match sha256 column in E2E-PCAPS.md
- [x] URLs in fetcher match Direct download URLs table in E2E-PCAPS.md
- [x] Format labels correct: 3× `.pcapng`, 4× `.pcap`, 2× `.cap` (classic pcap) per magic-byte verification
- [x] Captures are gitignored (local-samples/ directory)
- [x] No production code modified
- [x] Semantic PR title: `test:` type