### PR TITLE
test(e2e): add local-only corpus smoke test (no-panic across fetched captures)

### DIFF
--- a/tests/e2e_corpus_smoke_tests.rs
+++ b/tests/e2e_corpus_smoke_tests.rs
@@ -1,0 +1,196 @@
+//! Local-only E2E corpus smoke test.
+//!
+//! This test iterates every capture file present in `tests/fixtures/local-samples/`
+//! and asserts that none of them panic when passed through
+//! [`wirerust::reader::PcapSource::from_file`] — the same entry point used by
+//! `src/main.rs`. Both `Ok` and `Err` results are accepted; the contract is
+//! strictly **no-panic / no-unwind**, not "must parse successfully."
+//!
+//! Several captures in the corpus are *documented* to return clean errors:
+//! - `pcapng-spb-only.pcapng` → E-INP-010 (IfFcsLen IDB option rejection)
+//! - `pcapng-example.pcapng`  → E-INP-011 (multi-IDB link-type conflict)
+//! - `pcapng-many-interfaces.pcapng` → unsupported link type NULL
+//!
+//! These `Err` results are expected and count as PASS.
+//!
+//! # Fixture hygiene
+//!
+//! The captures are **gitignored** and not stored in the repository. To
+//! reproduce them locally run:
+//!
+//! ```bash
+//! bin/fetch-e2e-pcaps
+//! ```
+//!
+//! This places 28 capture files under `tests/fixtures/local-samples/`.
+//! When that directory is absent or empty the test self-skips (prints a notice
+//! and returns `Ok`) so CI — which has no local-samples — stays green.
+//!
+//! # Decision-thread reference
+//!
+//! Implements decision-thread (c) from `.factory/STATE.md` / PCAP-CORPUS-001:
+//! "a local-only test that iterates all fetched E2E captures asserting each
+//! parses without panic."
+
+use std::panic::{self, AssertUnwindSafe};
+use std::path::{Path, PathBuf};
+
+use wirerust::reader::PcapSource;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Collect all capture files (`.pcap`, `.pcapng`, `.cap`) from `dir`,
+/// sorted for deterministic ordering. Non-capture files (e.g. `README.md`)
+/// are silently skipped.
+fn collect_captures(dir: &Path) -> Vec<PathBuf> {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return Vec::new();
+    };
+
+    let mut paths: Vec<PathBuf> = entries
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .filter(|p| {
+            // Only regular files with a recognized capture extension.
+            if !p.is_file() {
+                return false;
+            }
+            matches!(
+                p.extension()
+                    .and_then(|e| e.to_str())
+                    .map(|s| s.to_ascii_lowercase())
+                    .as_deref(),
+                Some("pcap" | "pcapng" | "cap")
+            )
+        })
+        .collect();
+
+    paths.sort();
+    paths
+}
+
+// ---------------------------------------------------------------------------
+// Outcome enum (for per-file summary reporting)
+// ---------------------------------------------------------------------------
+
+enum Outcome {
+    Ok { packet_count: usize },
+    Err(String),
+    Panic(String),
+}
+
+// ---------------------------------------------------------------------------
+// The smoke test
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_e2e_corpus_no_panic_across_all_local_captures() {
+    let fixtures_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/local-samples");
+
+    // ── Self-skip when fixtures are absent or empty ───────────────────────────
+    if !fixtures_dir.exists() {
+        eprintln!(
+            "[e2e-corpus-smoke] SKIP: `tests/fixtures/local-samples/` not found. \
+             Run `bin/fetch-e2e-pcaps` to populate it."
+        );
+        return;
+    }
+
+    let captures = collect_captures(&fixtures_dir);
+
+    if captures.is_empty() {
+        eprintln!(
+            "[e2e-corpus-smoke] SKIP: `tests/fixtures/local-samples/` is empty. \
+             Run `bin/fetch-e2e-pcaps` to populate it."
+        );
+        return;
+    }
+
+    // ── Exercise each capture ─────────────────────────────────────────────────
+    let mut panic_files: Vec<String> = Vec::new();
+    let mut ok_count = 0usize;
+    let mut err_count = 0usize;
+
+    eprintln!(
+        "\n[e2e-corpus-smoke] Exercising {} capture(s):",
+        captures.len()
+    );
+
+    for path in &captures {
+        let file_name = path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or("<unknown>")
+            .to_owned();
+
+        // Wrap in catch_unwind so a single panicking capture doesn't abort the
+        // whole run — we want to report all offenders in one go.
+        let path_clone = path.clone();
+        let result = panic::catch_unwind(AssertUnwindSafe(|| PcapSource::from_file(&path_clone)));
+
+        let outcome = match result {
+            Ok(Ok(source)) => {
+                let n = source.packets.len();
+                ok_count += 1;
+                Outcome::Ok { packet_count: n }
+            }
+            Ok(Err(e)) => {
+                err_count += 1;
+                Outcome::Err(format!("{e:#}"))
+            }
+            Err(payload) => {
+                // Extract a human-readable message from the panic payload.
+                let msg = if let Some(s) = payload.downcast_ref::<&str>() {
+                    (*s).to_owned()
+                } else if let Some(s) = payload.downcast_ref::<String>() {
+                    s.clone()
+                } else {
+                    "<non-string panic payload>".to_owned()
+                };
+                panic_files.push(file_name.clone());
+                Outcome::Panic(msg)
+            }
+        };
+
+        // Per-file summary line.
+        match &outcome {
+            Outcome::Ok { packet_count } => {
+                eprintln!("  OK  ({:>5} pkts)  {}", packet_count, file_name);
+            }
+            Outcome::Err(msg) => {
+                // Truncate long error messages for readability.
+                let short: String = msg.chars().take(120).collect();
+                eprintln!("  ERR           {}  [{}]", file_name, short);
+            }
+            Outcome::Panic(msg) => {
+                eprintln!("  PANIC         {}  [{}]", file_name, msg);
+            }
+        }
+    }
+
+    // ── Aggregate summary ─────────────────────────────────────────────────────
+    eprintln!(
+        "\n[e2e-corpus-smoke] Results: {} OK, {} ERR (expected), {} PANIC",
+        ok_count,
+        err_count,
+        panic_files.len()
+    );
+
+    // At least one capture must have been exercised when the directory was
+    // non-empty (guards against a bug in collect_captures silently skipping all).
+    assert!(
+        ok_count + err_count + panic_files.len() > 0,
+        "collect_captures returned paths but no capture was actually exercised — \
+         this is a bug in the test harness"
+    );
+
+    // The primary contract: no capture may panic.
+    assert!(
+        panic_files.is_empty(),
+        "[e2e-corpus-smoke] {} capture(s) caused a panic: {}",
+        panic_files.len(),
+        panic_files.join(", ")
+    );
+}

--- a/tests/e2e_corpus_smoke_tests.rs
+++ b/tests/e2e_corpus_smoke_tests.rs
@@ -1,41 +1,114 @@
-//! Local-only E2E corpus smoke test.
+//! Local-only E2E corpus smoke test — pinned-expectation regression guard.
 //!
 //! This test iterates every capture file present in `tests/fixtures/local-samples/`
-//! and asserts that none of them panic when passed through
-//! [`wirerust::reader::PcapSource::from_file`] — the same entry point used by
-//! `src/main.rs`. Both `Ok` and `Err` results are accepted; the contract is
-//! strictly **no-panic / no-unwind**, not "must parse successfully."
+//! and passes each through [`wirerust::reader::PcapSource::from_file`] — the same
+//! entry point used by `src/main.rs`.
 //!
-//! Several captures in the corpus are *documented* to return clean errors:
-//! - `pcapng-spb-only.pcapng` → E-INP-010 (IfFcsLen IDB option rejection)
-//! - `pcapng-example.pcapng`  → E-INP-011 (multi-IDB link-type conflict)
-//! - `pcapng-many-interfaces.pcapng` → unsupported link type NULL
+//! # Pinned-expectation contract
 //!
-//! These `Err` results are expected and count as PASS.
+//! A static `EXPECTED` table maps each known capture filename to one of two
+//! expected outcomes:
 //!
-//! # Fixture hygiene
+//! - `Ok(packet_count)` — `PcapSource::from_file` returns `Ok` and
+//!   `source.packets.len()` equals the pinned count exactly.
+//! - `Err(substr)` — `from_file` returns `Err` and the error's `Display`
+//!   string **contains** the pinned substring (stable, structured token
+//!   preferred, e.g. `E-INP-010`).
 //!
-//! The captures are **gitignored** and not stored in the repository. To
-//! reproduce them locally run:
+//! These pins are regression guards on **reader-level** packet counts (which
+//! may differ from analyzer-level counts in the manifest). If any pinned
+//! capture produces a different result, the test fails and names the offender.
+//!
+//! Files present on disk that are NOT in the table are still exercised for
+//! no-panic (regression safety for dev-added captures) but do NOT cause a
+//! test failure — they are reported as `UNPINNED`.
+//!
+//! # Self-skip behaviour
+//!
+//! When `tests/fixtures/local-samples/` is absent or has zero capture files,
+//! the test prints a skip notice (mentioning `bin/fetch-e2e-pcaps`) and
+//! passes immediately. CI — which has no local-samples — stays green.
+//! **`#[ignore]` is not used** so the test remains in the default test run.
+//!
+//! # Reproducing fixtures
 //!
 //! ```bash
 //! bin/fetch-e2e-pcaps
 //! ```
 //!
-//! This places 28 capture files under `tests/fixtures/local-samples/`.
-//! When that directory is absent or empty the test self-skips (prints a notice
-//! and returns `Ok`) so CI — which has no local-samples — stays green.
+//! This places the 29 canonical captures under `tests/fixtures/local-samples/`.
 //!
 //! # Decision-thread reference
 //!
 //! Implements decision-thread (c) from `.factory/STATE.md` / PCAP-CORPUS-001:
 //! "a local-only test that iterates all fetched E2E captures asserting each
-//! parses without panic."
+//! parses without panic." The pinned expectation table strengthens this to
+//! catch behavioral regressions (wrong packet count, changed error class), not
+//! just panics.
 
 use std::panic::{self, AssertUnwindSafe};
 use std::path::{Path, PathBuf};
 
 use wirerust::reader::PcapSource;
+
+// ---------------------------------------------------------------------------
+// Pinned expectation table
+// ---------------------------------------------------------------------------
+
+/// The expected outcome for a single capture file.
+#[derive(Debug)]
+enum Expected {
+    /// `from_file` must return `Ok` and `source.packets.len()` must equal this.
+    OkCount(usize),
+    /// `from_file` must return `Err` whose `Display` string contains this
+    /// stable substring (typically a structured error code like `E-INP-010`).
+    ErrContains(&'static str),
+}
+
+/// Canonical per-capture expectation table.
+///
+/// Keys are bare filenames (no directory prefix). Values were recorded from
+/// the first verified run on the fetched corpus and are the authoritative
+/// reader-level baseline.
+const EXPECTED: &[(&str, Expected)] = &[
+    // ── Ok captures (reader packet count) ─────────────────────────────────
+    ("220703_arp-storm-nrb.pcapng", Expected::OkCount(622)),
+    ("4SICS-GeekLounge-151020.pcap", Expected::OkCount(246137)),
+    ("4SICS-GeekLounge-151021.pcap", Expected::OkCount(1253100)),
+    ("4SICS-GeekLounge-151022.pcap", Expected::OkCount(2274747)),
+    ("arp-baseline-16pkt.cap", Expected::OkCount(16)),
+    ("arp-storm.pcap", Expected::OkCount(622)),
+    ("arpspoof.pcap", Expected::OkCount(16285)),
+    ("dhcp-big-endian.pcapng", Expected::OkCount(4)),
+    ("dhcp-nanosecond-test.pcapng", Expected::OkCount(4)),
+    ("dnp3dataset_capture.pcap", Expected::OkCount(26058)),
+    ("dns-tunnel-dns2tcp.pcap", Expected::OkCount(26)),
+    ("dns-tunnel-dnscat2.pcap", Expected::OkCount(24)),
+    ("dns-tunnel-iodine-dmachard.pcap", Expected::OkCount(24)),
+    ("dns-tunnel-iodine.pcap", Expected::OkCount(438)),
+    ("dtls12-dsb.pcapng", Expected::OkCount(13)),
+    ("gratuitous-arp-hsrp.cap", Expected::OkCount(6)),
+    ("http-brotli-isb.pcapng", Expected::OkCount(10)),
+    ("http-creds-set4.pcap", Expected::OkCount(170)),
+    ("http-malspam-set6.pcap", Expected::OkCount(738)),
+    ("http-ppa-baseline.cap", Expected::OkCount(43)),
+    ("ip-frag-teardrop.cap", Expected::OkCount(17)),
+    ("modbus-large.pcap", Expected::OkCount(85)),
+    ("pcapng-comments.pcapng", Expected::OkCount(5)),
+    ("pcapng-dhcp-little-endian.pcapng", Expected::OkCount(4)),
+    ("ppa-arp.pcap", Expected::OkCount(2)),
+    ("rsasnakeoil2.pcap", Expected::OkCount(58)),
+    // ── Err captures (stable error substring) ─────────────────────────────
+    // E-INP-011: multi-IDB link-type conflict (message ends with "(E-INP-011)")
+    ("pcapng-example.pcapng", Expected::ErrContains("E-INP-011")),
+    // NULL link type not supported; message leads with "Unsupported pcap link type: NULL"
+    (
+        "pcapng-many-interfaces.pcapng",
+        Expected::ErrContains("Unsupported pcap link type: NULL"),
+    ),
+    // E-INP-010: IfFcsLen IDB option rejection
+    ("pcapng-spb-only.pcapng", Expected::ErrContains("E-INP-010")),
+];
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -53,7 +126,6 @@ fn collect_captures(dir: &Path) -> Vec<PathBuf> {
         .filter_map(|e| e.ok())
         .map(|e| e.path())
         .filter(|p| {
-            // Only regular files with a recognized capture extension.
             if !p.is_file() {
                 return false;
             }
@@ -71,8 +143,13 @@ fn collect_captures(dir: &Path) -> Vec<PathBuf> {
     paths
 }
 
+/// Build a lookup from filename → `Expected` from the static table.
+fn expected_map() -> std::collections::HashMap<&'static str, &'static Expected> {
+    EXPECTED.iter().map(|(name, exp)| (*name, exp)).collect()
+}
+
 // ---------------------------------------------------------------------------
-// Outcome enum (for per-file summary reporting)
+// Actual outcome (runtime)
 // ---------------------------------------------------------------------------
 
 enum Outcome {
@@ -108,13 +185,15 @@ fn test_e2e_corpus_no_panic_across_all_local_captures() {
         return;
     }
 
-    // ── Exercise each capture ─────────────────────────────────────────────────
+    let exp_map = expected_map();
+
+    // ── Per-file tracking ─────────────────────────────────────────────────────
     let mut panic_files: Vec<String> = Vec::new();
-    let mut ok_count = 0usize;
-    let mut err_count = 0usize;
+    let mut mismatches: Vec<String> = Vec::new();
+    let mut verified_count = 0usize;
 
     eprintln!(
-        "\n[e2e-corpus-smoke] Exercising {} capture(s):",
+        "\n[e2e-corpus-smoke] Exercising {} capture(s) against pinned expectation table:",
         captures.len()
     );
 
@@ -133,15 +212,10 @@ fn test_e2e_corpus_no_panic_across_all_local_captures() {
         let outcome = match result {
             Ok(Ok(source)) => {
                 let n = source.packets.len();
-                ok_count += 1;
                 Outcome::Ok { packet_count: n }
             }
-            Ok(Err(e)) => {
-                err_count += 1;
-                Outcome::Err(format!("{e:#}"))
-            }
+            Ok(Err(e)) => Outcome::Err(format!("{e:#}")),
             Err(payload) => {
-                // Extract a human-readable message from the panic payload.
                 let msg = if let Some(s) = payload.downcast_ref::<&str>() {
                     (*s).to_owned()
                 } else if let Some(s) = payload.downcast_ref::<String>() {
@@ -154,43 +228,115 @@ fn test_e2e_corpus_no_panic_across_all_local_captures() {
             }
         };
 
-        // Per-file summary line.
-        match &outcome {
-            Outcome::Ok { packet_count } => {
-                eprintln!("  OK  ({:>5} pkts)  {}", packet_count, file_name);
+        // ── Compare against pinned expectation ────────────────────────────
+        let label = match exp_map.get(file_name.as_str()) {
+            Some(Expected::OkCount(expected_n)) => {
+                // File is in the table — verify it.
+                verified_count += 1;
+                match &outcome {
+                    Outcome::Ok { packet_count } if packet_count == expected_n => {
+                        format!("OK({packet_count})")
+                    }
+                    Outcome::Ok { packet_count } => {
+                        let msg = format!(
+                            "{file_name}: expected Ok({expected_n}) but got Ok({packet_count})"
+                        );
+                        mismatches.push(msg);
+                        format!("MISMATCH(exp Ok({expected_n})/act Ok({packet_count}))")
+                    }
+                    Outcome::Err(e) => {
+                        let short: String = e.chars().take(80).collect();
+                        let msg =
+                            format!("{file_name}: expected Ok({expected_n}) but got Err({short})");
+                        mismatches.push(msg);
+                        format!("MISMATCH(exp Ok({expected_n})/act ERR)")
+                    }
+                    Outcome::Panic(p) => {
+                        // Already recorded in panic_files above.
+                        format!("PANIC({p})")
+                    }
+                }
             }
-            Outcome::Err(msg) => {
-                // Truncate long error messages for readability.
-                let short: String = msg.chars().take(120).collect();
-                eprintln!("  ERR           {}  [{}]", file_name, short);
+            Some(Expected::ErrContains(substr)) => {
+                verified_count += 1;
+                match &outcome {
+                    Outcome::Err(e) if e.contains(substr) => {
+                        format!("ERR({substr})")
+                    }
+                    Outcome::Err(e) => {
+                        let short: String = e.chars().take(80).collect();
+                        let msg = format!(
+                            "{file_name}: expected Err containing {substr:?} but \
+                             got Err({short})"
+                        );
+                        mismatches.push(msg);
+                        format!("MISMATCH(exp ERR({substr})/act ERR(different))")
+                    }
+                    Outcome::Ok { packet_count } => {
+                        let msg = format!(
+                            "{file_name}: expected Err containing {substr:?} but \
+                             got Ok({packet_count})"
+                        );
+                        mismatches.push(msg);
+                        format!("MISMATCH(exp ERR({substr})/act Ok({packet_count}))")
+                    }
+                    Outcome::Panic(p) => {
+                        format!("PANIC({p})")
+                    }
+                }
             }
-            Outcome::Panic(msg) => {
-                eprintln!("  PANIC         {}  [{}]", file_name, msg);
+            None => {
+                // Unknown capture — still exercise for no-panic but don't fail.
+                match &outcome {
+                    Outcome::Ok { packet_count } => {
+                        format!("UNPINNED Ok({packet_count}) -- add to expected table")
+                    }
+                    Outcome::Err(e) => {
+                        let short: String = e.chars().take(80).collect();
+                        format!("UNPINNED ERR({short}) -- add to expected table")
+                    }
+                    Outcome::Panic(p) => {
+                        format!("UNPINNED PANIC({p})")
+                    }
+                }
             }
-        }
+        };
+
+        eprintln!("  {}  {}", label, file_name);
     }
 
     // ── Aggregate summary ─────────────────────────────────────────────────────
     eprintln!(
-        "\n[e2e-corpus-smoke] Results: {} OK, {} ERR (expected), {} PANIC",
-        ok_count,
-        err_count,
+        "\n[e2e-corpus-smoke] Verified {verified_count} pinned entries, \
+         {} mismatch(es), {} panic(s)",
+        mismatches.len(),
         panic_files.len()
     );
 
-    // At least one capture must have been exercised when the directory was
-    // non-empty (guards against a bug in collect_captures silently skipping all).
+    // When fixtures were present, at least one expected entry must have been
+    // verified (guards against a bug where collect_captures skips everything or
+    // the EXPECTED table is somehow empty).
     assert!(
-        ok_count + err_count + panic_files.len() > 0,
-        "collect_captures returned paths but no capture was actually exercised — \
-         this is a bug in the test harness"
+        verified_count > 0,
+        "[e2e-corpus-smoke] No pinned captures were verified — either the \
+         EXPECTED table is empty or no expected filenames matched anything on \
+         disk. This is a test-harness bug."
     );
 
-    // The primary contract: no capture may panic.
+    // Primary contract: no capture may panic.
     assert!(
         panic_files.is_empty(),
         "[e2e-corpus-smoke] {} capture(s) caused a panic: {}",
         panic_files.len(),
         panic_files.join(", ")
+    );
+
+    // Regression contract: every pinned expectation that is present on disk
+    // must match exactly. Collect all failures and report them together.
+    assert!(
+        mismatches.is_empty(),
+        "[e2e-corpus-smoke] {} pinned expectation(s) did not match:\n  - {}",
+        mismatches.len(),
+        mismatches.join("\n  - ")
     );
 }

--- a/tests/e2e_corpus_smoke_tests.rs
+++ b/tests/e2e_corpus_smoke_tests.rs
@@ -101,10 +101,15 @@ const EXPECTED: &[(&str, Expected)] = &[
     // ── Err captures (stable error substring) ─────────────────────────────
     // E-INP-011: multi-IDB link-type conflict (message ends with "(E-INP-011)")
     ("pcapng-example.pcapng", Expected::ErrContains("E-INP-011")),
-    // NULL link type not supported; message leads with "Unsupported pcap link type: NULL"
+    // NULL link type not supported. No E-INP-* code is assigned to this path
+    // (src/reader.rs whitelist check, line ~1213), so we pin to the stable
+    // message prefix rather than a structured code.  Do not pin the "NULL"
+    // discriminant — the invariant is the rejection of unsupported link types,
+    // not the specific variant name, which can change with pcap-file crate
+    // updates.
     (
         "pcapng-many-interfaces.pcapng",
-        Expected::ErrContains("Unsupported pcap link type: NULL"),
+        Expected::ErrContains("Unsupported pcap link type"),
     ),
     // E-INP-010: IfFcsLen IDB option rejection
     ("pcapng-spb-only.pcapng", Expected::ErrContains("E-INP-010")),
@@ -281,6 +286,7 @@ fn test_e2e_corpus_no_panic_across_all_local_captures() {
                         format!("MISMATCH(exp ERR({substr})/act Ok({packet_count}))")
                     }
                     Outcome::Panic(p) => {
+                        // Already recorded in panic_files above.
                         format!("PANIC({p})")
                     }
                 }
@@ -302,7 +308,7 @@ fn test_e2e_corpus_no_panic_across_all_local_captures() {
             }
         };
 
-        eprintln!("  {}  {}", label, file_name);
+        eprintln!("  {:<55}  {}", label, file_name);
     }
 
     // ── Aggregate summary ─────────────────────────────────────────────────────
@@ -313,6 +319,20 @@ fn test_e2e_corpus_no_panic_across_all_local_captures() {
         panic_files.len()
     );
 
+    // Primary contract: no capture may panic.  Assert this BEFORE the
+    // verified_count guard so that — in the degenerate case where all pinned
+    // captures happen to panic — we get the meaningful "panic" failure message
+    // naming offenders rather than the misleading "no entries verified" message.
+    // Pinned captures that panic still increment verified_count (the counter is
+    // updated before the outcome match), so the harness-bug guard fires correctly
+    // once panics are cleared.
+    assert!(
+        panic_files.is_empty(),
+        "[e2e-corpus-smoke] {} capture(s) caused a panic: {}",
+        panic_files.len(),
+        panic_files.join(", ")
+    );
+
     // When fixtures were present, at least one expected entry must have been
     // verified (guards against a bug where collect_captures skips everything or
     // the EXPECTED table is somehow empty).
@@ -321,14 +341,6 @@ fn test_e2e_corpus_no_panic_across_all_local_captures() {
         "[e2e-corpus-smoke] No pinned captures were verified — either the \
          EXPECTED table is empty or no expected filenames matched anything on \
          disk. This is a test-harness bug."
-    );
-
-    // Primary contract: no capture may panic.
-    assert!(
-        panic_files.is_empty(),
-        "[e2e-corpus-smoke] {} capture(s) caused a panic: {}",
-        panic_files.len(),
-        panic_files.join(", ")
     );
 
     // Regression contract: every pinned expectation that is present on disk


### PR DESCRIPTION
## Polish follow-up (commit `304619c`)

Prior review cosmetic items addressed:

- **I-1:** Reordered asserts so the panic check fires before the `verified_count` guard — a degenerate all-panics scenario now names the offending captures rather than emitting the misleading "no entries verified" message.
- **I-2:** Added symmetric "Already recorded in panic_files above." comment to the `Outcome::Panic` arm inside the `ErrContains` branch.
- **I-3:** Switched per-file `eprintln!` to `{:<55}` left-padded label column for aligned output across all rows.
- **N-1:** Narrowed the `pcapng-many-interfaces.pcapng` pin from `"Unsupported pcap link type: NULL"` to the stable prefix `"Unsupported pcap link type"`. The `NULL` discriminant is a pcap-file crate detail; the invariant is rejection of unsupported link types. No E-INP-* code is assigned to this path, so prose match is intentional — documented with an inline code comment.

Local gate on `304619c`: `cargo test --test e2e_corpus_smoke_tests` PASS (29 verified, 0 mismatch, 0 panic); `cargo test --all-targets` PASS; `cargo clippy --all-targets -- -D warnings` PASS; `cargo fmt --check` PASS.

---

## Summary

This PR implements decision-thread (c) from `.factory/STATE.md` (PCAP-CORPUS-001): a local-only E2E corpus smoke test that iterates every fetched capture file and asserts **no-panic / no-unwind** when passed through `wirerust::reader::PcapSource::from_file`.

This is a **test-only maintenance addition** — no production code changed, no new behavioral contract introduced.

**Commit 2 strengthening (`dd79c59`):** The original no-panic-only contract has been upgraded to a full **pinned-expectation regression guard** — a static `EXPECTED` table maps all 29 corpus captures to exact `Ok(packet_count)` or `Err(substr)` outcomes. Any future change to reader parsing behavior that shifts a packet count or error class will be caught here. Unknown/extra dev-added captures are still exercised for no-panic but do not fail (reported as `UNPINNED`).

---

## What the test does

`tests/e2e_corpus_smoke_tests.rs` adds a single integration test (`test_e2e_corpus_no_panic_across_all_local_captures`) that:

1. Scans `tests/fixtures/local-samples/` for all `.pcap`, `.pcapng`, and `.cap` files (sorted for deterministic ordering).
2. Runs each capture through `PcapSource::from_file` wrapped in `std::panic::catch_unwind`.
3. Checks each result against the static `EXPECTED` table:
   - **Pinned `Ok(n)`:** result must be `Ok` and `source.packets.len()` must equal `n` exactly.
   - **Pinned `Err(substr)`:** result must be `Err` whose `Display` contains `substr`.
   - **UNPINNED (not in table):** exercised for no-panic only; does not fail.
4. Collects all panics and mismatches before asserting, so all failures are reported together.

### Why `Err` is a PASS (3 documented deliberate rejections)

Three corpus captures are known to return clean errors and are **expected** to return `Err`:

| File | Error pin | Reason |
|------|-----------|--------|
| `pcapng-spb-only.pcapng` | `E-INP-010` | IfFcsLen IDB option rejection |
| `pcapng-example.pcapng` | `E-INP-011` | Multi-IDB link-type conflict |
| `pcapng-many-interfaces.pcapng` | `"Unsupported pcap link type"` | DLT_NULL(0) loopback — out of scope |

These are documented behaviors verified in prior PRs (#299, #300). Returning `Err` for them is the correct, tested behavior.

### Self-skip when fixtures are absent (CI safety)

The captures live under `tests/fixtures/local-samples/` which is **gitignored** and is not present in the repository. When CI clones the repo, that directory does not exist. The test detects this and self-skips with an `eprintln!` notice — it never fails in CI.

To reproduce locally:

```bash
bin/fetch-e2e-pcaps
cargo test --test e2e_corpus_smoke_tests
```

`bin/fetch-e2e-pcaps` downloads the sha256-pinned corpus registered in `.factory/code-delivery/E2E-PCAPS.md`.

---

## Architecture Changes

```mermaid
graph TD
    CLI["src/main.rs (CLI entrypoint)"]
    Reader["wirerust::reader::PcapSource::from_file"]
    SmokeTest["tests/e2e_corpus_smoke_tests.rs (NEW — test only)"]
    LocalFixtures["tests/fixtures/local-samples/ (gitignored)"]

    CLI -->|calls| Reader
    SmokeTest -.->|exercises same entry point| Reader
    SmokeTest -.->|reads if present| LocalFixtures
    style SmokeTest fill:#90EE90
    style LocalFixtures fill:#FFFACD
```

No new production module or dependency. The test file exercises the existing `PcapSource::from_file` public API — the same path exercised by the CLI and prior E2E suites.

<details>
<summary><strong>Architecture Decision: local-only / self-skip pattern</strong></summary>

**Context:** 29 real capture files (18 registered in E2E-PCAPS.md + additional variants) are gitignored to keep the repo lean and avoid binary-blob churn. CI must stay green without them.

**Decision:** Test self-skips when `tests/fixtures/local-samples/` is absent or empty, rather than being gated by an env-var or feature flag.

**Rationale:** The `env!("CARGO_MANIFEST_DIR")` path resolution is reliable across platforms; the directory check is cheaper than any env-var scheme; and the self-skip pattern matches how Rust's own standard library handles optional system fixtures.

**Alternatives considered:**
1. `#[cfg(feature = "local-e2e")]` — requires callers to remember the feature flag; forgotten locally defeats the purpose.
2. `SKIP_E2E_CORPUS=1` env-var — more explicit but adds friction; directory-presence is self-documenting.

**Consequences:**
- Positive: zero CI friction; developers who run `bin/fetch-e2e-pcaps` get full coverage automatically.
- Trade-off: a developer who forgets to fetch will see SKIP silently (acceptable — the test is opt-in).

</details>

---

## Story Dependencies

```mermaid
graph LR
    PR299["PR #299<br/>✅ pcapng-e2e-corpus"] --> Smoke["test/e2e-corpus-smoke<br/>🟡 this PR"]
    PR300["PR #300<br/>✅ analyzer-gap captures"] --> Smoke
    Smoke --> None["(no dependents)"]
    style Smoke fill:#FFD700
```

**Upstream (merged):**
- PR #299 — `test/pcapng-e2e-corpus`: 7-capture pcapng block-diversity E2E suite (merged to develop)
- PR #300 — `test/e2e-corpus-analyzer-captures`: HTTP, DNS-tunnel, pcapng SPB/multi-IDB, IP-frag analyzer-gap captures (merged to develop)

**No downstream blockers.**

---

## Spec Traceability

This is a **test-only maintenance addition** — it does not implement a new behavioral contract.

```mermaid
flowchart LR
    StateThread["STATE.md decision-thread (c)<br/>PCAP-CORPUS-001"]
    AC1["no-panic across all fetched captures"]
    AC2["self-skip when fixtures absent"]
    AC3["Err = PASS for documented rejections"]
    AC4["pinned packet counts + error classes<br/>(regression guard — dd79c59)"]
    T1["test_e2e_corpus_no_panic_across_all_local_captures"]
    Impl["tests/e2e_corpus_smoke_tests.rs"]

    StateThread --> AC1
    StateThread --> AC2
    StateThread --> AC3
    StateThread --> AC4
    AC1 --> T1
    AC2 --> T1
    AC3 --> T1
    AC4 --> T1
    T1 --> Impl
```

**Traceability table:**

| Requirement | Acceptance Criterion | Test | Status |
|-------------|---------------------|------|--------|
| STATE.md decision-thread (c) | No capture panics | `test_e2e_corpus_no_panic_across_all_local_captures` | PASS |
| Fixture hygiene | Self-skip when `local-samples/` absent | Self-skip path in same test | PASS (CI green) |
| Documented rejections accepted | E-INP-010, E-INP-011, NULL link type return Err | `Expected::ErrContains` entries in EXPECTED table | PASS |
| Regression guard (dd79c59) | 26 Ok packet counts + 3 Err error-class substrings pinned | `Expected::OkCount` / `Expected::ErrContains` verified entries | PASS (29 verified, 0 mismatch) |

---

## Test Evidence

### Local Gate (run 2026-06-22, commit `304619c`)

| Gate | Result |
|------|--------|
| `cargo test --test e2e_corpus_smoke_tests` | **29 verified (26 Ok / 3 Err), 0 mismatch, 0 panic** |
| `cargo test --all-targets` | PASS |
| `cargo clippy --all-targets -- -D warnings` | PASS (0 warnings) |
| `cargo fmt --check` | PASS |

### Test Flow

```mermaid
graph LR
    Corpus["29 local captures"]
    SmokeTest["e2e_corpus_smoke_tests"]
    OK["26 OkCount pins verified"]
    ERR["3 ErrContains pins verified"]
    PANIC["0 PANIC"]
    MISMATCH["0 MISMATCH"]

    Corpus --> SmokeTest
    SmokeTest --> OK
    SmokeTest --> ERR
    SmokeTest --> PANIC
    SmokeTest --> MISMATCH

    style OK fill:#90EE90
    style ERR fill:#90EE90
    style PANIC fill:#90EE90
    style MISMATCH fill:#90EE90
```

<details>
<summary><strong>Detailed Test Notes</strong></summary>

### Commit 1 (`7900943`) — original no-panic guarantee

| Test | Result | Notes |
|------|--------|-------|
| `test_e2e_corpus_no_panic_across_all_local_captures` | PASS (self-skip in CI) | 26 Ok / 3 Err / 0 PANIC over 29 local captures |

### Commit 2 (`dd79c59`) — pinned-expectation regression guard

| Test | Result | Notes |
|------|--------|-------|
| `test_e2e_corpus_no_panic_across_all_local_captures` | PASS | 29 verified, 0 mismatch, 0 panic — identical to commit 1 outcomes but now pinned |

### Commit 3 (`304619c`) — polish (cosmetic items I-1/I-2/I-3/N-1)

| Test | Result | Notes |
|------|--------|-------|
| `test_e2e_corpus_no_panic_across_all_local_captures` | PASS | 29 verified, 0 mismatch, 0 panic |

The upgrade introduces a static `EXPECTED` table of 29 entries (26 `OkCount` + 3 `ErrContains`). The mismatch assertion catches any future reader change that shifts a packet count or error class. Future-added corpus captures appear as `UNPINNED` in the output and are exercised for no-panic only until explicitly added to the table.

### What "3 ERR pins" means

- `pcapng-spb-only.pcapng`: IfFcsLen option in IDB causes `E-INP-010` clean rejection
- `pcapng-example.pcapng`: Multi-IDB with conflicting link types causes `E-INP-011` clean rejection
- `pcapng-many-interfaces.pcapng`: DLT_NULL(0) link type is unsupported — `"Unsupported pcap link type"` clean rejection, no panic

### CI behavior

When `tests/fixtures/local-samples/` is absent (CI, fresh clone), the test prints:
```
[e2e-corpus-smoke] SKIP: `tests/fixtures/local-samples/` not found. Run `bin/fetch-e2e-pcaps` to populate it.
```
and returns without asserting — the test binary exits 0.

</details>

---

## Holdout Evaluation

N/A — test-only maintenance addition; no new behavioral contract or production code. Holdout evaluation is not applicable. Evaluated at wave gate (STATE.md phase_status: FE-001 COMPLETE).

---

## Adversarial Review

N/A — test-only maintenance addition (one updated test file, 354 lines, no production code). Adversarial review evaluated at Phase 5 for FE-001 cycle (all 3 passes SATISFIED, recorded in STATE.md).

---

## Security Review

```mermaid
graph LR
    Critical["Critical: 0"]
    High["High: 0"]
    Medium["Medium: 0"]
    Low["Low: 0"]

    style Critical fill:#90EE90
    style High fill:#90EE90
    style Medium fill:#90EE90
    style Low fill:#90EE90
```

Test-only diff: one updated file `tests/e2e_corpus_smoke_tests.rs` (354 lines). No production code, no new dependencies, no network calls, no I/O beyond reading local gitignored fixture files. Attack surface delta: zero.

- `std::panic::catch_unwind` is used correctly with `AssertUnwindSafe` — standard pattern for test harnesses.
- File paths are constructed via `env!("CARGO_MANIFEST_DIR")` + `.join(...)` — no path traversal risk.
- The `EXPECTED` table uses `&'static str` keys (no heap allocation for the lookup map at const-eval time).
- No new `unsafe` blocks.

---

## Risk Assessment & Deployment

### Blast Radius

- **Systems affected:** Test suite only (no production binary change)
- **User impact:** Zero — test is local-only, self-skips in CI
- **Data impact:** None
- **Risk Level:** LOW

### Performance Impact

| Metric | Impact |
|--------|--------|
| CI build time | Negligible (test self-skips; zero fixture I/O in CI) |
| Local test time | ~few seconds when fixtures present (29 file reads + `PcapSource::from_file` per file) |
| Binary size | No change (test code excluded from release build) |

<details>
<summary><strong>Rollback Instructions</strong></summary>

**Immediate rollback (< 1 min):**
```bash
git revert HEAD   # reverts the single commit on develop after squash-merge
git push origin develop
```

Since this adds only a test file with zero production impact, rollback has no user-facing consequence.

</details>

### Feature Flags
None — the self-skip-when-fixtures-absent behavior is the "flag" (directory presence).

---

## AI Pipeline Metadata

<details>
<summary><strong>Pipeline Details</strong></summary>

```yaml
ai-generated: true
pipeline-mode: maintenance
factory-version: "1.0.0"
pipeline-stages:
  spec-crystallization: N/A (test-only; resolves STATE.md decision-thread c)
  story-decomposition: N/A
  tdd-implementation: N/A (single file, locally verified by test-writer)
  holdout-evaluation: N/A
  adversarial-review: N/A (light review only — test-only diff)
  formal-verification: N/A
  convergence: N/A
convergence-metrics: N/A (test-only maintenance addition)
adversarial-passes: 0 (not required for test-only additions)
models-used:
  builder: claude-sonnet-4-6
  reviewer: claude-sonnet-4-6
generated-at: "2026-06-22T00:00:00Z"
commits:
  - sha: "7900943"
    msg: "test(e2e): add local-only corpus smoke test (no-panic across all fetched captures)"
  - sha: "dd79c59"
    msg: "test(e2e): pin per-capture expected outcomes (reader packet counts + error classes)"
  - sha: "304619c"
    msg: "test(e2e): polish corpus smoke test (count-on-panic, comment symmetry, aligned output, stable NULL-linktype pin)"
```

</details>

---

## Pre-Merge Checklist

- [x] All CI status checks passing (self-skip path; gated by CI completion check)
- [x] Coverage delta neutral (test-only; no production lines added/removed)
- [x] No critical/high security findings (test-only diff, zero attack surface delta)
- [x] Rollback procedure validated (single commit revert)
- [x] No feature flags required
- [x] Human review: human will approve merge (human-stop-before-merge instruction honored)
- [x] No monitoring alerts required (no production impact)
- [x] Local gate (304619c): 29 verified, 0 mismatch, 0 panic; clippy/fmt/test all green
- [x] Upstream dependencies (PR #299, PR #300) already merged to develop
- [x] Pinned-expectation table: 26 OkCount + 3 ErrContains entries validated against corpus
- [x] Polish items I-1/I-2/I-3/N-1 addressed in commit 304619c
