### PR TITLE
fix(dnp3)!: rename output key total_parse_errors -> parse_errors [PC-014]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ Version numbers follow [Semantic Versioning](https://semver.org/).
   use `"parse_errors"`. JSON consumers reading DNP3 summary output must migrate the key name.
   [PC-014, BC-2.15.020 v1.4, STORY-108 AC-010]
 
+  **Migration:** Replace any lookup of `detail["total_parse_errors"]` with
+  `detail["parse_errors"]` in your consumer. For `jq` users:
+  `jq '.[] | .detail.total_parse_errors'` → `jq '.[] | .detail.parse_errors'`.
+
 ## [0.9.4] - 2026-06-23
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ Version numbers follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Breaking Changes
+
+- **DNP3 analyzer output: renamed summary key `total_parse_errors` → `parse_errors`.**
+  The `detail` map produced by the DNP3 analyzer now uses the key `"parse_errors"` instead of
+  `"total_parse_errors"`, aligning DNP3 with sibling analyzers (HTTP, TLS, Modbus) that already
+  use `"parse_errors"`. JSON consumers reading DNP3 summary output must migrate the key name.
+  [PC-014, BC-2.15.020 v1.4, STORY-108 AC-010]
+
 ## [0.9.4] - 2026-06-23
 
 ### Added

--- a/src/analyzer/dnp3.rs
+++ b/src/analyzer/dnp3.rs
@@ -1382,7 +1382,7 @@ impl Dnp3Analyzer {
 
         let flows_analyzed = self.flows.len() as u64;
         let total_frames: u64 = self.flows.values().map(|f| f.frame_count).sum();
-        let parse_errors: u64 = self.flows.values().map(|f| f.parse_errors).sum();
+        let aggregate_parse_errors: u64 = self.flows.values().map(|f| f.parse_errors).sum();
 
         // BC-2.15.020 postcondition 1: function_code_distribution — only FCs with count > 0.
         // Keys are decimal strings of the FC byte (e.g. "5" for 0x05 DIRECT_OPERATE).
@@ -1423,7 +1423,7 @@ impl Dnp3Analyzer {
         );
         detail.insert(
             "parse_errors".to_string(),
-            serde_json::Value::Number(parse_errors.into()),
+            serde_json::Value::Number(aggregate_parse_errors.into()),
         );
         detail.insert(
             "flows_analyzed".to_string(),

--- a/src/analyzer/dnp3.rs
+++ b/src/analyzer/dnp3.rs
@@ -1372,7 +1372,7 @@ impl Dnp3Analyzer {
     ///
     /// Aggregates across all flows: `function_code_distribution` (from
     /// `self.fn_code_counts`, zero-count FCs suppressed), `control_operation_counts`
-    /// (per-flow `direct_operate_count`), `total_frames`, `total_parse_errors`,
+    /// (per-flow `direct_operate_count`), `total_frames`, `parse_errors`,
     /// `flows_analyzed`. Returns a populated `AnalysisSummary` even when zero flows
     /// were processed (all counts zero, maps empty — BC-2.15.020 postcondition 2).
     ///
@@ -1382,7 +1382,7 @@ impl Dnp3Analyzer {
 
         let flows_analyzed = self.flows.len() as u64;
         let total_frames: u64 = self.flows.values().map(|f| f.frame_count).sum();
-        let total_parse_errors: u64 = self.flows.values().map(|f| f.parse_errors).sum();
+        let parse_errors: u64 = self.flows.values().map(|f| f.parse_errors).sum();
 
         // BC-2.15.020 postcondition 1: function_code_distribution — only FCs with count > 0.
         // Keys are decimal strings of the FC byte (e.g. "5" for 0x05 DIRECT_OPERATE).
@@ -1422,8 +1422,8 @@ impl Dnp3Analyzer {
             serde_json::Value::Number(total_frames.into()),
         );
         detail.insert(
-            "total_parse_errors".to_string(),
-            serde_json::Value::Number(total_parse_errors.into()),
+            "parse_errors".to_string(),
+            serde_json::Value::Number(parse_errors.into()),
         );
         detail.insert(
             "flows_analyzed".to_string(),

--- a/tests/bc_2_15_110_dnp3_dispatcher_tests.rs
+++ b/tests/bc_2_15_110_dnp3_dispatcher_tests.rs
@@ -956,9 +956,9 @@ mod story_110 {
         let dnp3 = dispatcher.take_dnp3_analyzer().unwrap();
         // The carry mechanism must have assembled the full frame and processed it.
         // parse_errors == 0 (no structural failure from the split).
-        let total_parse_errors: u64 = dnp3.flows.values().map(|f| f.parse_errors).sum();
+        let parse_errors: u64 = dnp3.flows.values().map(|f| f.parse_errors).sum();
         assert_eq!(
-            total_parse_errors, 0,
+            parse_errors, 0,
             "EC-003: split frame across two on_data calls must produce ZERO parse errors \
              (carry buffer reassembles the frame cleanly)"
         );

--- a/tests/dnp3_detection_tests.rs
+++ b/tests/dnp3_detection_tests.rs
@@ -990,14 +990,14 @@ mod story_108 {
             "AC-011: total_frames must be 0 when no flows processed"
         );
 
-        let total_parse_errors = summary
+        let parse_errors = summary
             .detail
-            .get("total_parse_errors")
+            .get("parse_errors")
             .and_then(|v| v.as_u64())
             .unwrap_or(u64::MAX);
         assert_eq!(
-            total_parse_errors, 0,
-            "AC-011: total_parse_errors must be 0 when no flows processed"
+            parse_errors, 0,
+            "AC-011: parse_errors must be 0 when no flows processed"
         );
 
         // function_code_distribution must be present (as empty object, not absent)
@@ -1352,10 +1352,10 @@ mod story_108 {
     }
 
     // -----------------------------------------------------------------------
-    // total_parse_errors in summary
+    // parse_errors in summary
     // -----------------------------------------------------------------------
 
-    /// Verifies summarize() includes total_parse_errors (BC-2.15.020 postcondition 1).
+    /// Verifies summarize() includes parse_errors (BC-2.15.020 postcondition 1).
     ///
     /// Traces to: BC-2.15.020 postcondition 1; STORY-108 AC-011.
     #[test]
@@ -1373,10 +1373,10 @@ mod story_108 {
 
         let summary = analyzer.summarize();
 
-        // total_parse_errors must be present
+        // parse_errors must be present
         assert!(
-            summary.detail.contains_key("total_parse_errors"),
-            "BC-2.15.020: total_parse_errors key must be present in summary detail"
+            summary.detail.contains_key("parse_errors"),
+            "BC-2.15.020: parse_errors key must be present in summary detail"
         );
     }
 
@@ -1567,6 +1567,51 @@ mod story_108 {
             "Test B (IF branch): source_ip must be Some(10.0.0.9) = master (upper_ip); \
              lower_port=20000 takes IF → upper_ip; got {:?}",
             f.source_ip
+        );
+    }
+    // -----------------------------------------------------------------------
+    // Red Gate — BC-2.15.020 v1.4: parse_errors key rename (D-220, human-approved)
+    //
+    // This test MUST FAIL on current code (which emits "total_parse_errors") and
+    // MUST PASS after the implementer renames the key to "parse_errors" in
+    // src/analyzer/dnp3.rs:1425.
+    //
+    // Traces to: BC-2.15.020 v1.4 postcondition 1 (BREAKING rename D-220);
+    //            scope.md PC-014; test-vector row "Red Gate — key name".
+    // -----------------------------------------------------------------------
+
+    /// BC-2.15.020 v1.4 Red Gate: summarize() detail map MUST use key "parse_errors",
+    /// NOT "total_parse_errors" (D-220 breaking rename — aligns DNP3 with HTTP/TLS/Modbus).
+    ///
+    /// Traces to: BC-2.15.020 v1.4 postcondition 1; PC-014 scope.md §4.
+    #[test]
+    fn test_BC_2_15_020_parse_errors_key_name_is_parse_errors() {
+        let mut analyzer = Dnp3Analyzer::new(10);
+        let key = test_flow_key();
+
+        // Deliver a frame with invalid LENGTH (4 < 5) to produce a parse error,
+        // mirroring the approach used by test_BC_2_15_020_summarize_includes_parse_errors.
+        let mut bad_frame = vec![0u8; 10];
+        bad_frame[0] = 0x05;
+        bad_frame[1] = 0x64;
+        bad_frame[2] = 4; // invalid LENGTH — triggers parse error counter
+        bad_frame[3] = 0xC4;
+        analyzer.on_data(key.clone(), &bad_frame, 0);
+
+        let summary = analyzer.summarize();
+
+        // MUST be present under the new canonical key name (post-D-220).
+        assert!(
+            summary.detail.contains_key("parse_errors"),
+            "BC-2.15.020 v1.4 D-220: detail map must contain \"parse_errors\" \
+             (aligns with HTTP/TLS/Modbus sibling analyzers)"
+        );
+
+        // MUST NOT be present under the old divergent key name.
+        assert!(
+            !summary.detail.contains_key("total_parse_errors"),
+            "BC-2.15.020 v1.4 D-220: detail map must NOT contain \"total_parse_errors\" \
+             (old key removed by rename; callers must migrate to \"parse_errors\")"
         );
     }
 } // mod story_108


### PR DESCRIPTION
## BREAKING CHANGE — DNP3 JSON Output Key Rename

**Behavioral change:** `Dnp3Analyzer::summarize()` now emits `"parse_errors"` in the `detail` map instead of `"total_parse_errors"`. All JSON consumers reading DNP3 analyzer summary output must rename their key lookup.

### Consumer Migration

Before (v0.9.4 and earlier): `detail["total_parse_errors"]`
After (this PR): `detail["parse_errors"]`

No other DNP3 summary keys changed. Sibling analyzers (HTTP, TLS, Modbus) already use `"parse_errors"` — this rename eliminates the DNP3 inconsistency.

### Rationale

DNP3 was the sole analyzer using a divergent key name (total_parse_errors) while HTTP, TLS, and Modbus all use parse_errors. This inconsistency was a known defect tracked as PC-014 in the fix-pc-013-014-015 bundle. Aligning the key name enables uniform JSON consumer logic across all four analyzers.

Human approval: D-220 (breaking rename pre-approved).

### Spec Traceability

BC-2.15.020 v1.4 postcondition 1 (key name = parse_errors) -> STORY-108 AC-010 (summarize() output keys) -> Red Gate test_BC_2_15_020_parse_errors_key_name_is_parse_errors -> src/analyzer/dnp3.rs:1425 detail.insert("parse_errors", ...)

### Changes

| File | Change |
|------|--------|
| src/analyzer/dnp3.rs | L1382: local var rename; L1425: output map key renamed; L1372/1375: doc comment updated |
| tests/dnp3_detection_tests.rs | Updated 3 existing tests + added Red Gate test |
| tests/bc_2_15_110_dnp3_dispatcher_tests.rs | Local var rename in EC-003 assertion |
| CHANGELOG.md | Breaking Changes entry under [Unreleased] |

### Test Evidence

- Red Gate added: test_BC_2_15_020_parse_errors_key_name_is_parse_errors — asserts detail.contains_key("parse_errors") AND !detail.contains_key("total_parse_errors")
- Existing tests updated: test_BC_2_15_020_summarize_includes_parse_errors, test_summarize_zero_flows (AC-011), bc_2_15_110_dnp3_dispatcher_tests EC-003
- All local gates passed: cargo test --all-targets, cargo clippy --all-targets -- -D warnings, cargo fmt --check

### Consumer-Completeness Audit

- src/reporter/terminal.rs:275 iterates asummary.detail generically; no hardcoded key reference. Safe.
- src/main.rs: no DNP3-key-specific reads of the detail map.
- No other source files reference total_parse_errors (confirmed via grep).

### Bundle Status

Final open item in fix-pc-013-014-015 bundle. PC-013 merged (#310), PC-015 merged (#312), PC-014 this PR.

### Pre-Merge Checklist

- [x] BC-2.15.020 v1.4 postcondition 1 satisfied
- [x] Red Gate test added (positive + negative assertion)
- [x] All existing tests updated to use new key name
- [x] CHANGELOG.md Breaking Changes entry under [Unreleased]
- [x] Consumer-completeness audit: no hardcoded key consumers remain
- [x] All local gates: test, clippy, fmt
- [x] Breaking change pre-approved (D-220)