### PR TITLE
fix(enip): summarize folds open flows so enip_summary reflects live traffic [#316]

### DIFF
--- a/src/analyzer/enip.rs
+++ b/src/analyzer/enip.rs
@@ -1446,13 +1446,43 @@ impl EnipAnalyzer {
     pub fn summarize(&self) -> AnalysisSummary {
         use std::collections::BTreeMap;
 
-        // BC-2.17.021 Invariant 2: reads aggregate fields only — does NOT re-scan self.flows.
+        // BC-2.17.021 Precondition 4 / RULING-W61-001 / F-138-P1-004:
+        // Fold still-open flows on top of the pre-accumulated aggregate counters.
+        // self.flows contains ONLY flows not yet passed to on_flow_close; on_flow_close
+        // removes a flow from self.flows before folding it into the aggregates, so there
+        // is no overlap — folding self.flows.values() here cannot double-count a closed flow.
+        //
+        // write_count and error_count are NOT re-folded from flow state: they are
+        // incremented directly into self.write_count / self.error_count inside process_pdu
+        // (not held as per-flow lifetime totals). Re-folding them would double-count.
         // BC-2.17.021 Postcondition 3: no new findings emitted here.
 
-        // Build the command_distribution JSON map: "{hex_cmd}": count.
-        // Only non-zero entries (all entries in the HashMap are non-zero by construction).
+        // Start from the pre-accumulated aggregates (covers flows closed via on_flow_close).
+        let mut total_pdu_count = self.total_pdu_count;
+        let mut parse_errors = self.parse_errors;
+        let mut open_flow_count: u64 = 0;
+
+        // Build a combined command distribution: start with the closed-flow aggregate,
+        // then fold in still-open flows. Use a local map to avoid mutating self.
+        let mut cmd_dist_combined: HashMap<u16, u64> = self.command_distribution.clone();
+
+        for flow in self.flows.values() {
+            total_pdu_count = total_pdu_count.saturating_add(flow.pdu_count);
+            parse_errors = parse_errors.saturating_add(flow.parse_errors);
+            for (&cmd, &count) in &flow.command_counts {
+                let e = cmd_dist_combined.entry(cmd).or_insert(0);
+                *e = e.saturating_add(count);
+            }
+            open_flow_count = open_flow_count.saturating_add(1);
+        }
+
+        // flows_analyzed = closed flows (on_flow_close increments) + still-open flows.
+        let flows_analyzed = self.flows_analyzed.saturating_add(open_flow_count);
+
+        // Build the command_distribution JSON map from the combined view.
+        // Only non-zero entries (all entries in the map are non-zero by construction).
         let mut cmd_dist: serde_json::Map<String, serde_json::Value> = serde_json::Map::new();
-        for (&cmd, &count) in &self.command_distribution {
+        for (&cmd, &count) in &cmd_dist_combined {
             if count > 0 {
                 cmd_dist.insert(format!("0x{cmd:04X}"), serde_json::json!(count));
             }
@@ -1467,13 +1497,10 @@ impl EnipAnalyzer {
         );
         enip_summary.insert(
             "total_pdu_count".to_string(),
-            serde_json::json!(self.total_pdu_count),
+            serde_json::json!(total_pdu_count),
         );
         // CANONICAL key: "parse_errors" — NOT "total_parse_errors" (BC-2.17.021 Invariant 1).
-        enip_summary.insert(
-            "parse_errors".to_string(),
-            serde_json::json!(self.parse_errors),
-        );
+        enip_summary.insert("parse_errors".to_string(), serde_json::json!(parse_errors));
         enip_summary.insert(
             "write_count".to_string(),
             serde_json::json!(self.write_count),
@@ -1484,7 +1511,7 @@ impl EnipAnalyzer {
         );
         enip_summary.insert(
             "flows_analyzed".to_string(),
-            serde_json::json!(self.flows_analyzed),
+            serde_json::json!(flows_analyzed),
         );
         enip_summary.insert(
             "dropped_findings".to_string(),
@@ -1501,7 +1528,7 @@ impl EnipAnalyzer {
         // BC-2.17.021 Post 2 / Invariant 3: zero-flow case still produces a valid object.
         AnalysisSummary {
             analyzer_name: "EtherNet/IP".to_string(),
-            packets_analyzed: self.total_pdu_count,
+            packets_analyzed: total_pdu_count,
             detail,
         }
     }

--- a/tests/enip_analyzer_tests.rs
+++ b/tests/enip_analyzer_tests.rs
@@ -7472,4 +7472,166 @@ mod summarize_drainage {
             );
         }
     }
+
+    // -----------------------------------------------------------------------
+    // O-3 (adversary hardening) — mixed closed + open flow fold
+    // -----------------------------------------------------------------------
+
+    /// O-3 / BC-2.17.021 Precondition 4 / F-138-P1-004 / RULING-W61-001
+    ///
+    /// Exercises the disjointness/fold arithmetic of `summarize()` across TWO
+    /// flows: one that has been closed (counters in the closed-flow aggregates,
+    /// entry removed from `self.flows`) and one that is still open (entry still
+    /// present in `self.flows`).
+    ///
+    /// Setup:
+    ///   - Flow A (`flow_key_a`): 2 × ListIdentity (0x0063) via `on_data`,
+    ///     then `on_flow_close`.  A's counters are now in the closed aggregates;
+    ///     A is absent from `self.flows`.
+    ///   - Flow B (`flow_key_b`): 1 × SendRRData (0x006F) via `on_data`,
+    ///     NOT closed.  B's counters remain exclusively in `self.flows[flow_key_b]`.
+    ///
+    /// Expected `enip_summary` after a single `summarize()` call:
+    ///   - `flows_analyzed`       == 2  (1 closed + 1 open)
+    ///   - `total_pdu_count`      == 3  (2 from A in aggregates + 1 from B in open fold)
+    ///   - `command_distribution` == { "0x0063": 2, "0x006F": 1 }  (length 2)
+    ///   - `parse_errors`         == 0
+    ///   - `write_count`          == 0
+    ///   - `error_count`          == 0
+    ///   - `dropped_findings`     == 0
+    ///
+    /// This proves simultaneously:
+    ///   (a) No double-count: A was removed from `self.flows` by `on_flow_close`,
+    ///       so the open-flow fold cannot re-count it.
+    ///   (b) Open-flow fold: B (never closed) is folded at `summarize()` time.
+    ///   (c) Two-key merge: the command_distribution map merges disjoint commands
+    ///       from closed and open paths without clobbering either entry.
+    #[test]
+    #[allow(non_snake_case)]
+    fn test_BC_2_17_021_summarize_folds_mixed_closed_and_open_flows() {
+        let mut analyzer = EnipAnalyzer::new(50, 5);
+
+        // Flow A: ip(1):50000 → ip(2):44818 (uses the shared flow_key() shape).
+        let flow_key_a = FlowKey::new(ip(1), 50000, ip(2), 44818);
+        // Flow B: ip(3):50001 → ip(2):44818 — distinct from A.
+        let flow_key_b = FlowKey::new(ip(3), 50001, ip(2), 44818);
+
+        // -------------------------------------------------------------------
+        // Drive 2 ListIdentity frames through Flow A, then close it.
+        // After on_flow_close: A is in closed aggregates, absent from self.flows.
+        // -------------------------------------------------------------------
+        for _ in 0..2 {
+            analyzer.on_data(flow_key_a.clone(), &enip_frame(CMD_LIST_IDENTITY), 0);
+        }
+        // Pre-condition: A must have pdu_count == 2 before close.
+        assert_eq!(
+            analyzer.flows[&flow_key_a].pdu_count, 2,
+            "pre-condition: flow A pdu_count must be 2 before on_flow_close"
+        );
+        analyzer.on_flow_close(flow_key_a.clone());
+        // Post-close: A must be absent from self.flows; aggregates must hold A's counts.
+        assert!(
+            !analyzer.flows.contains_key(&flow_key_a),
+            "post-close: on_flow_close must remove flow A from self.flows (RULING-W61-001)"
+        );
+        assert_eq!(
+            analyzer.total_pdu_count, 2,
+            "post-close: self.total_pdu_count must be 2 (folded from A's pdu_count)"
+        );
+        assert_eq!(
+            analyzer.flows_analyzed, 1,
+            "post-close: self.flows_analyzed must be 1 (one flow closed)"
+        );
+
+        // -------------------------------------------------------------------
+        // Drive 1 SendRRData frame through Flow B — do NOT close it.
+        // B's counters remain exclusively in self.flows[flow_key_b].
+        // -------------------------------------------------------------------
+        const CMD_SEND_RR_DATA: u16 = 0x006F;
+        analyzer.on_data(flow_key_b.clone(), &enip_frame(CMD_SEND_RR_DATA), 0);
+        // Pre-condition: B must have pdu_count == 1 and remain open.
+        assert_eq!(
+            analyzer.flows[&flow_key_b].pdu_count, 1,
+            "pre-condition: flow B pdu_count must be 1 (still open, never closed)"
+        );
+        // Aggregate must still only count A's contribution (B not yet folded).
+        assert_eq!(
+            analyzer.total_pdu_count, 2,
+            "pre-condition: self.total_pdu_count must still be 2 before summarize \
+             (B not folded until summarize() is called)"
+        );
+
+        // -------------------------------------------------------------------
+        // Call summarize() once — the mixed fold.
+        // -------------------------------------------------------------------
+        let summary = analyzer.summarize();
+        let es = summary
+            .detail
+            .get("enip_summary")
+            .expect("enip_summary must be present (BC-2.17.021 Post 1)");
+
+        // flows_analyzed: 1 closed (A) + 1 open (B) = 2.
+        assert_eq!(
+            get_u64(es, "flows_analyzed"),
+            2,
+            "enip_summary.flows_analyzed must be 2 (1 closed A + 1 open B) — \
+             BC-2.17.021 Precond 4 / F-138-P1-004 / RULING-W61-001 / O-3"
+        );
+
+        // total_pdu_count: 2 from A (closed aggregates) + 1 from B (open fold) = 3.
+        assert_eq!(
+            get_u64(es, "total_pdu_count"),
+            3,
+            "enip_summary.total_pdu_count must be 3 (2 from closed A + 1 from open B) — \
+             BC-2.17.021 Precond 4 / F-138-P1-004 / RULING-W61-001 / O-3"
+        );
+
+        // command_distribution: { "0x0063": 2, "0x006F": 1 } — exactly 2 entries.
+        // Key format: format!("0x{cmd:04X}") — uppercase 4-digit hex.
+        let dist = es
+            .get("command_distribution")
+            .expect("command_distribution must be present");
+        let dist_map = dist
+            .as_object()
+            .expect("command_distribution must be a JSON object");
+        assert_eq!(
+            dist_map.len(),
+            2,
+            "command_distribution must have exactly 2 entries (0x0063 from A, 0x006F from B) — \
+             O-3 two-key merge / RULING-W61-001"
+        );
+        assert_eq!(
+            dist_map
+                .get("0x0063")
+                .and_then(serde_json::Value::as_u64)
+                .unwrap_or(0),
+            2,
+            "command_distribution[\"0x0063\"] must be 2 (from closed flow A) — \
+             BC-2.17.021 Precond 4 / F-138-P1-004 / O-3"
+        );
+        assert_eq!(
+            dist_map
+                .get("0x006F")
+                .and_then(serde_json::Value::as_u64)
+                .unwrap_or(0),
+            1,
+            "command_distribution[\"0x006F\"] must be 1 (from open flow B) — \
+             BC-2.17.021 Precond 4 / F-138-P1-004 / RULING-W61-001 / O-3"
+        );
+
+        // Zero fields: no errors, writes, or dropped findings in this scenario.
+        for field in &[
+            "parse_errors",
+            "write_count",
+            "error_count",
+            "dropped_findings",
+        ] {
+            assert_eq!(
+                get_u64(es, field),
+                0,
+                "enip_summary.{field} must be 0 (no errors in mixed closed+open scenario) — \
+                 BC-2.17.021 Post 1 / O-3"
+            );
+        }
+    }
 }

--- a/tests/enip_analyzer_tests.rs
+++ b/tests/enip_analyzer_tests.rs
@@ -7215,3 +7215,261 @@ mod session_lifecycle {
         );
     }
 }
+
+// ---------------------------------------------------------------------------
+// mod summarize_drainage — BC-2.17.021 Precondition 4 / F-138-P1-004 / RULING-W61-001
+//
+// Discriminating tests for the open-flow drainage fix.
+// summarize() MUST fold still-open self.flows.values() into the combined view
+// at call time, without requiring on_flow_close to have been called first.
+//
+// These tests are RED against the unfixed code (summarize() reads only
+// self.total_pdu_count / self.flows_analyzed / self.command_distribution,
+// which are all zero when on_flow_close has never been called → zeros).
+// They go GREEN once the implementer adds the open-flow fold per RULING-W61-001.
+// ---------------------------------------------------------------------------
+mod summarize_drainage {
+    use std::net::{IpAddr, Ipv4Addr};
+
+    use wirerust::analyzer::enip::EnipAnalyzer;
+    use wirerust::reassembly::flow::FlowKey;
+
+    // -----------------------------------------------------------------------
+    // Shared helpers
+    // -----------------------------------------------------------------------
+
+    fn ip(a: u8) -> IpAddr {
+        IpAddr::V4(Ipv4Addr::new(10, 0, 0, a))
+    }
+
+    /// Standard flow key used across all drainage tests.
+    fn flow_key() -> FlowKey {
+        FlowKey::new(ip(1), 50000, ip(2), 44818)
+    }
+
+    /// Build a minimal 24-byte ENIP frame with the given command and zero payload.
+    /// Layout: [command_lo, command_hi, length_lo, length_hi, 20 × 0x00].
+    /// A 24-byte zero-payload frame is a valid ENIP request header (BC-2.17.003).
+    fn enip_frame(command: u16) -> Vec<u8> {
+        let mut buf = vec![0u8; 24];
+        buf[0] = (command & 0xFF) as u8;
+        buf[1] = ((command >> 8) & 0xFF) as u8;
+        // length = 0 (no payload beyond the 24-byte encapsulation header)
+        buf
+    }
+
+    /// 0x0063 — ListIdentity; the canonical BC-2.17.021 test-vector command.
+    const CMD_LIST_IDENTITY: u16 = 0x0063;
+
+    // -----------------------------------------------------------------------
+    // Helper: extract a u64 from enip_summary or panic with a diagnostic.
+    // -----------------------------------------------------------------------
+
+    fn get_u64(enip_summary: &serde_json::Value, field: &str) -> u64 {
+        enip_summary
+            .get(field)
+            .unwrap_or_else(|| panic!("enip_summary must contain '{field}'"))
+            .as_u64()
+            .unwrap_or_else(|| panic!("enip_summary.{field} must be a u64"))
+    }
+
+    // -----------------------------------------------------------------------
+    // F-138-P1-004 / BC-2.17.021 Precondition 4 / RULING-W61-001
+    // Discriminating test: summarize() must reflect open flows even when
+    // on_flow_close has NEVER been called.
+    // -----------------------------------------------------------------------
+
+    /// F-138-P1-004 / BC-2.17.021 Precondition 4 / RULING-W61-001
+    ///
+    /// Drive 3 ListIdentity (0x0063) frames through `on_data` for a single flow,
+    /// then call `summarize()` WITHOUT calling `on_flow_close`.
+    ///
+    /// PART A — open-flow drainage:
+    /// `enip_summary` must reflect the actual traffic:
+    ///   - total_pdu_count  == 3   (folded from the still-open flow)
+    ///   - flows_analyzed   == 1   (the 1 still-open flow counted at summarize time)
+    ///   - command_distribution == { "0x0063": 3 }
+    ///   - parse_errors     == 0
+    ///   - write_count      == 0
+    ///   - error_count      == 0
+    ///   - dropped_findings == 0
+    ///
+    /// PART B — regression guard (no double-count):
+    /// After Part A, call `on_flow_close(flow_key)` and `summarize()` again.
+    /// The values must be IDENTICAL to Part A — proving that the close-then-summarize
+    /// path also produces the correct output and that no double-count occurs
+    /// (RULING-W61-001: on_flow_close removes the flow from self.flows, so a closed
+    /// flow cannot appear in both the aggregate and the open-flow fold).
+    ///
+    /// This test is RED against unfixed code: the pre-fix summarize() reads only
+    /// self.total_pdu_count (== 0), self.flows_analyzed (== 0), and
+    /// self.command_distribution (== {}) because on_flow_close was never called.
+    ///
+    /// Traces: BC-2.17.021 Precondition 4; F-138-P1-004; RULING-W61-001.
+    #[test]
+    #[allow(non_snake_case)]
+    fn test_BC_2_17_021_summarize_reflects_open_flows_without_close() {
+        let mut analyzer = EnipAnalyzer::new(50, 5);
+        let key = flow_key();
+
+        // Drive 3 ListIdentity frames — one flow, never closed.
+        for _ in 0..3 {
+            analyzer.on_data(key.clone(), &enip_frame(CMD_LIST_IDENTITY), 0);
+        }
+        // Pre-condition sanity: the flow must exist with pdu_count == 3.
+        assert_eq!(
+            analyzer.flows[&key].pdu_count, 3,
+            "pre-condition: pdu_count must be 3 in the still-open flow before summarize"
+        );
+        // Pre-condition sanity: aggregate fields are zero (on_flow_close never called).
+        assert_eq!(
+            analyzer.total_pdu_count, 0,
+            "pre-condition: self.total_pdu_count must be 0 before on_flow_close \
+             (confirms on_flow_close was never called)"
+        );
+        assert_eq!(
+            analyzer.flows_analyzed, 0,
+            "pre-condition: self.flows_analyzed must be 0 before on_flow_close"
+        );
+
+        // PART A: call summarize() WITHOUT on_flow_close.
+        // The fix (RULING-W61-001) folds self.flows.values() into a transient combined view.
+        let summary_a = analyzer.summarize();
+        let es_a = summary_a
+            .detail
+            .get("enip_summary")
+            .expect("enip_summary must be present (BC-2.17.021 Post 1)");
+
+        // total_pdu_count: must be 3 (folded from the open flow).
+        // RED: pre-fix code returns 0 (reads self.total_pdu_count == 0).
+        assert_eq!(
+            get_u64(es_a, "total_pdu_count"),
+            3,
+            "enip_summary.total_pdu_count must be 3 (folded from 3 on_data calls on the \
+             open flow); pre-fix code returns 0 — BC-2.17.021 Precond 4 / F-138-P1-004 / \
+             RULING-W61-001"
+        );
+
+        // flows_analyzed: must be 1 (the 1 still-open flow counted at summarize time).
+        // RED: pre-fix code returns 0 (reads self.flows_analyzed == 0).
+        assert_eq!(
+            get_u64(es_a, "flows_analyzed"),
+            1,
+            "enip_summary.flows_analyzed must be 1 (the 1 open flow counted at summarize \
+             time); pre-fix code returns 0 — BC-2.17.021 Precond 4 / F-138-P1-004 / \
+             RULING-W61-001"
+        );
+
+        // command_distribution: must be { "0x0063": 3 }.
+        // RED: pre-fix code returns {} (reads self.command_distribution == {}).
+        // Key format: format!("0x{cmd:04X}") — uppercase 4-digit hex; 0x0063 → "0x0063".
+        let dist_a = es_a
+            .get("command_distribution")
+            .expect("command_distribution must be present");
+        let dist_map_a = dist_a
+            .as_object()
+            .expect("command_distribution must be a JSON object");
+        assert_eq!(
+            dist_map_a.len(),
+            1,
+            "command_distribution must have exactly 1 entry (only 0x0063 was driven); \
+             pre-fix code returns empty map — F-138-P1-004 / RULING-W61-001"
+        );
+        assert_eq!(
+            dist_map_a
+                .get("0x0063")
+                .and_then(serde_json::Value::as_u64)
+                .unwrap_or(0),
+            3,
+            "command_distribution[\"0x0063\"] must be 3; pre-fix code returns absent/0 — \
+             BC-2.17.021 canonical vector / F-138-P1-004 / RULING-W61-001"
+        );
+
+        // parse_errors, write_count, error_count, dropped_findings: all must be 0.
+        for field in &[
+            "parse_errors",
+            "write_count",
+            "error_count",
+            "dropped_findings",
+        ] {
+            assert_eq!(
+                get_u64(es_a, field),
+                0,
+                "enip_summary.{field} must be 0 (no errors, writes, or dropped findings \
+                 in this scenario) — BC-2.17.021 Post 1"
+            );
+        }
+
+        // -----------------------------------------------------------------------
+        // PART B: regression guard — close the flow, then summarize again.
+        // Values must be IDENTICAL to Part A (no double-count).
+        // RULING-W61-001: on_flow_close removes the flow from self.flows.
+        // A flow cannot be in both self.flows (open-fold) and the aggregate
+        // (closed-fold) simultaneously — removal is the gate.
+        // -----------------------------------------------------------------------
+
+        analyzer.on_flow_close(key.clone());
+        // Post-close sanity: flow must be removed from self.flows.
+        assert!(
+            !analyzer.flows.contains_key(&key),
+            "post-close: on_flow_close must remove the flow from self.flows \
+             (BC-2.17.017 Post 1 / RULING-W61-001 no-double-count invariant)"
+        );
+
+        let summary_b = analyzer.summarize();
+        let es_b = summary_b
+            .detail
+            .get("enip_summary")
+            .expect("enip_summary must be present after close");
+
+        // All values must be identical to Part A — no double-count.
+        assert_eq!(
+            get_u64(es_b, "total_pdu_count"),
+            3,
+            "enip_summary.total_pdu_count must still be 3 after on_flow_close + summarize \
+             (no double-count) — RULING-W61-001 no-double-count invariant"
+        );
+        assert_eq!(
+            get_u64(es_b, "flows_analyzed"),
+            1,
+            "enip_summary.flows_analyzed must still be 1 after on_flow_close + summarize \
+             (no double-count) — RULING-W61-001 no-double-count invariant"
+        );
+
+        let dist_b = es_b
+            .get("command_distribution")
+            .expect("command_distribution must be present after close");
+        let dist_map_b = dist_b
+            .as_object()
+            .expect("command_distribution must be a JSON object after close");
+        assert_eq!(
+            dist_map_b.len(),
+            1,
+            "command_distribution must still have 1 entry after on_flow_close + summarize \
+             (no double-count) — RULING-W61-001"
+        );
+        assert_eq!(
+            dist_map_b
+                .get("0x0063")
+                .and_then(serde_json::Value::as_u64)
+                .unwrap_or(0),
+            3,
+            "command_distribution[\"0x0063\"] must still be 3 after on_flow_close + \
+             summarize (no double-count) — RULING-W61-001"
+        );
+
+        for field in &[
+            "parse_errors",
+            "write_count",
+            "error_count",
+            "dropped_findings",
+        ] {
+            assert_eq!(
+                get_u64(es_b, field),
+                0,
+                "enip_summary.{field} must still be 0 after on_flow_close + summarize \
+                 (no double-count) — BC-2.17.021 Post 1"
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes Wave-61 release-blocking finding **F-138-P1-004**: `EnipAnalyzer::summarize()` returned
zeros for `total_pdu_count`, `command_distribution`, `parse_errors`, and `flows_analyzed` on
any real pcap capture because the dispatcher never calls `on_flow_close` for ENIP flows.

Per **RULING-W61-001** (architect binding ruling, 2026-06-26), the fix mirrors the DNP3 sibling
pattern: `summarize()` now folds still-open `self.flows.values()` on top of the pre-accumulated
closed-flow aggregates at call time. `self.flows` is not mutated; no double-count is possible
(disjointness guaranteed by `on_flow_close` removing a flow from `self.flows` before folding
it into aggregates).

Closes F-138-P1-004 · References #316

---

## Problem

`EnipAnalyzer` aggregates four summary fields (`total_pdu_count`, `parse_errors`,
`command_distribution`, `flows_analyzed`) exclusively via `on_flow_close`. The dispatcher's
ENIP flow-close arm is a documented no-op:

```rust
Some(DispatchTarget::Enip) => {
    // EnipAnalyzer does not implement StreamHandler; no forwarding needed.
    let _ = reason;
}
```

For any pcap where TCP sessions are not explicitly torn down (the common case, especially
truncated or one-sided captures), `on_flow_close` is never called. Result in production:

| Field               | Pre-fix production value |
|---------------------|--------------------------|
| `command_distribution` | `{}` (empty map)       |
| `total_pdu_count`   | `0`                      |
| `parse_errors`      | `0`                      |
| `flows_analyzed`    | `0`                      |
| `write_count`       | Correct (direct increment in `process_pdu`) |
| `error_count`       | Correct (direct increment in `process_pdu`) |
| `dropped_findings`  | Correct                  |

The BC-2.17.021 canonical test vector ("3 ListIdentity, 1 flow → flows_analyzed:1,
total_pdu_count:3") was not met in production.

---

## Fix (RULING-W61-001 approach (a) — summarize-time fold)

Change is **confined to `EnipAnalyzer::summarize()` in `src/analyzer/enip.rs`**.
No changes to `dispatcher.rs`, `main.rs`, `on_flow_close`, or any BC other than
the additive Invariant-2 clarification deferred to cycle-close.

### Why approach (a) and not dispatcher drain (b)

1. **Signature mismatch** — `EnipAnalyzer::on_flow_close` takes `flow_key` by value with
   no `reason` parameter; bridging to the dispatcher's `on_flow_close(flow_key, reason)`
   requires changing the ENIP signature (BC-2.17.017 anchor edit) or an adapter.
2. **End-of-capture enumeration** — draining open flows at capture end requires new
   production logic in `dispatcher.rs` / `main.rs`.
3. **DNP3 precedent** — `Dnp3Analyzer::summarize()` uses the same fold pattern; ADR-010
   Decision 4 documents ENIP as mirroring DNP3. Approach (b) creates unjustified asymmetry.
4. **Common pcap case** — approach (b) only helps explicit-teardown flows; approach (a)
   handles both teardown and no-teardown identically.

### No-double-count proof

`on_flow_close` calls `self.flows.remove(&flow_key)` before folding into aggregates.
A flow cannot be simultaneously in `self.flows` AND in the closed-flow aggregates.
Therefore `self.flows.values()` at summarize time contains only flows never passed to
`on_flow_close` — the exact population that must be included.

### DNP3 parity

`Dnp3Analyzer::summarize()` reads `self.flows.len()` and iterates `self.flows.values()`
directly; it has no `flows_analyzed` aggregate field and does not depend on `on_flow_close`
firing. The ENIP fix brings full parity with the sibling.

---

## Architecture Changes

```mermaid
graph TD
    A["on_data(flow_key, bytes, ts)"] --> B["process_pdu: increments flow.pdu_count,\nflow.command_counts, write_count, error_count"]
    B --> C["self.flows[flow_key] (EnipFlowState)"]
    D["on_flow_close(flow_key)"] --> E["folds flow state → aggregates\nremoves from self.flows"]
    E --> F["self.total_pdu_count\nself.flows_analyzed\nself.command_distribution\nself.parse_errors"]
    G["summarize() — FIXED"] --> F
    G --> C
    G --> H["Combined view: aggregates + open flows\n(no mutation of self.flows)"]
    H --> I["AnalysisSummary { enip_summary }"]
    style G fill:#c8e6c9,stroke:#388e3c
    style H fill:#c8e6c9,stroke:#388e3c
```

---

## Story Dependencies

```mermaid
graph LR
    S138["STORY-138 (merged)\nENIP SS-17 delivery"] --> FIX["F-138-P1-004 fix\n(this PR)"]
    RULING["RULING-W61-001\narchitect binding"] --> FIX
    FIX --> REL["v0.11.0 release\n(blocked until merged)"]
```

---

## Spec Traceability

```mermaid
flowchart LR
    BC021["BC-2.17.021\nPrecondition 4\nsummarize folds open flows"] --> T1["test_BC_2_17_021_summarize_reflects_open_flows_without_close\n3 on_data, no close → total_pdu_count==3, flows_analyzed==1\ncommand_distribution=={0x0063:3}"]
    BC021 --> T2["test_BC_2_17_021_summarize_folds_mixed_closed_and_open_flows\n1 closed (A) + 1 open (B) → flows_analyzed==2, total_pdu_count==3\ncommand_distribution=={0x0063:2, 0x006F:1}"]
    T1 --> IMPL["src/analyzer/enip.rs\nsummarize() open-flow fold loop\n+30 lines, -3 lines"]
    T2 --> IMPL
    IMPL --> PR["This PR (fix/enip-summarize-open-flows)"]
```

---

## Test Evidence

| Test | Scenario | Result |
|------|----------|--------|
| `test_BC_2_17_021_summarize_reflects_open_flows_without_close` (Part A) | 3 × ListIdentity on_data, summarize WITHOUT close | total_pdu_count==3, flows_analyzed==1, command_distribution=={0x0063:3} — **GREEN** |
| `test_BC_2_17_021_summarize_reflects_open_flows_without_close` (Part B) | Same + on_flow_close, then summarize | Identical values (no double-count) — **GREEN** |
| `test_BC_2_17_021_summarize_folds_mixed_closed_and_open_flows` | 1 closed flow (A: 2× ListIdentity) + 1 open flow (B: 1× SendRRData) | flows_analyzed==2, total_pdu_count==3, command_distribution=={0x0063:2,0x006F:1} — **GREEN** |
| Full `cargo test --all-targets` | All tests | 0 failures — **GREEN** |
| `cargo clippy --all-targets -- -D warnings` | Lint | Clean — **GREEN** |
| `cargo fmt --check` | Format | Clean — **GREEN** |

Both discriminating tests were **RED before the fix** (pre-fix code returned zeros for all four
aggregate fields when `on_flow_close` was not called).

**Adversarial fix-review result:** CLEAN — 0 HIGH, 0 CRITICAL findings. Fold correctness,
no-double-count invariant, schema preservation, and non-regression all verified.

---

## Holdout Evaluation

N/A — evaluated at wave gate (Wave 61).

---

## Adversarial Review

N/A — evaluated at Phase 5 / Wave 61. Fix-specific adversarial review: CLEAN (0 HIGH/CRITICAL).

---

## Security Review

**Result: CLEAN — 0 CRITICAL, 0 HIGH findings.**

| ID | Severity | CWE | Description | Disposition |
|----|----------|-----|-------------|-------------|
| SEC-001 | LOW | CWE-682 | Disjointness proof: `on_flow_close` remove-before-fold invariant | Proved sound — no action |
| SEC-002 | LOW | CWE-682 | `write_count`/`error_count` exclusion from open-flow fold | Correct by design (per-event not per-flow) — no action |
| SEC-003 | LOW | CWE-190 | Integer overflow — all counters use `saturating_add` | Verified safe — no action |
| SEC-004 | LOW | CWE-400 | `HashMap::clone()` allocation at summarize time | Bounded at 65,536 entries (u16 key space), called once at capture-end — no action |
| SEC-005 | N/A | N/A | New attack surface from fold loop | None introduced — read-only accumulate over already-validated state |
| SEC-006 | MEDIUM | CWE-119 | Pre-existing unsafe split-borrow in `on_data` | Pre-existing, NOT introduced by this PR; maintenance backlog item |

SEC-006 is the only MEDIUM finding and is explicitly pre-existing (not in this PR's diff). The PR is approved from a security standpoint.

---

## Deferred Items (ruling-sanctioned, non-blocking)

1. **BC-2.17.021 Invariant 2 prose clarification** — the current text says "does NOT re-scan
   flow state" and "Aggregate counters must be up-to-date from `on_flow_close`". These clauses
   describe the unimplemented wiring variant (option b) and are now incorrect. The clarification
   is a cycle-close factory-artifacts edit (spec-steward pass), not a code change. RULING-W61-001
   explicitly sanctions this as a post-merge edit.
2. **ENIP hex vs DNP3 decimal command_distribution key format** — pre-existing convention
   difference between subsystems; no action required in this PR.

---

## Risk Assessment

| Dimension | Assessment |
|-----------|-----------|
| Blast radius | Low — one method (`summarize()`), one file (`src/analyzer/enip.rs`) |
| Public API surface | No change — `summarize()` signature and `AnalysisSummary` type unchanged |
| Performance impact | One `HashMap::clone()` per `summarize()` call (called once per run at capture end) — negligible |
| Regression risk | None — `write_count` and `error_count` are NOT re-folded (they are per-event, not per-flow-close aggregates); double-count guard is disjointness via `remove()` |
| Rollback | Revert commits `82ed7ba` and `8e1ffc1` |

---

## AI Pipeline Metadata

| Field | Value |
|-------|-------|
| Pipeline mode | Fix-PR (Wave-61 integration finding) |
| Finding | F-138-P1-004 [release-blocking] |
| Architect ruling | RULING-W61-001 (binding, 2026-06-26) |
| Models used | claude-sonnet-4-6 |
| Fix blast radius | Low (1 method, 1 file) |

---

## Pre-Merge Checklist

- [x] PR description matches actual diff
- [x] Discriminating tests RED before fix, GREEN after
- [x] Full `cargo test --all-targets` green
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] No public API surface changes
- [x] No double-count: disjointness guaranteed by `on_flow_close` remove-before-fold
- [x] DNP3 parity: mirrors `Dnp3Analyzer::summarize()` pattern
- [x] RULING-W61-001 compliance verified
- [ ] Security review complete (Step 4)
- [ ] AI review (pr-reviewer) converged to APPROVE
- [ ] CI checks passing
- [ ] Human merge authorization received (D-231 halt)
