### PR TITLE
docs(changelog): add v0.11.0 compare links and bump Unreleased base

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -659,7 +659,8 @@ Downstream consumers of wirerust JSON or CSV output must update for this release
 - Output sanitization in the terminal reporter guards against C1 control bytes
   in packet-derived strings.
 
-[Unreleased]: https://github.com/Zious11/wirerust/compare/v0.10.0...HEAD
+[Unreleased]: https://github.com/Zious11/wirerust/compare/v0.11.0...HEAD
+[0.11.0]: https://github.com/Zious11/wirerust/compare/v0.10.0...v0.11.0
 [0.10.0]: https://github.com/Zious11/wirerust/compare/v0.9.4...v0.10.0
 [0.9.4]: https://github.com/Zious11/wirerust/compare/v0.9.3...v0.9.4
 [0.9.3]: https://github.com/Zious11/wirerust/compare/v0.9.2...v0.9.3


### PR DESCRIPTION
Fix CHANGELOG.md footer links left over from the v0.11.0 release: bump the `[Unreleased]` compare base from v0.10.0 to v0.11.0, and add the missing `[0.11.0]:` compare link.