### PR TITLE
feat(cli): protocols subcommand — coverage catalog table + JSON (STORY-152)

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -120,6 +120,21 @@ pub struct Cli {
     pub command: Commands,
 }
 
+/// Filter applied to the `protocols` subcommand.
+///
+/// Exactly three variants: `All` (default when no flag is given), `Supported`,
+/// and `Unsupported`. Mutual exclusion is enforced by clap `conflicts_with_all`
+/// annotations on the corresponding flags (BC-2.12.022 Invariant 2).
+#[derive(Debug, Clone, PartialEq)]
+pub enum ProtocolFilter {
+    /// Show all protocols — equivalent to passing `--all` (BC-2.12.022 Invariant 3).
+    All,
+    /// Show only protocols that wirerust actively dissects.
+    Supported,
+    /// Show only protocols that wirerust does not yet dissect.
+    Unsupported,
+}
+
 #[derive(Subcommand, Debug)]
 pub enum Commands {
     /// Analyze PCAP files for threats and anomalies
@@ -262,5 +277,22 @@ pub enum Commands {
         // LESSON-P1.03
         #[arg(long)]
         hosts: bool,
+    },
+
+    /// List the protocol coverage catalog (BC-2.12.022; BC-2.18.001; BC-2.18.002)
+    ///
+    /// Prints a table of all known ICS/IT protocols — filterable by
+    /// `--supported`, `--unsupported`, or `--all` (default).  Combine with
+    /// the global `--json` flag for machine-readable output.
+    Protocols {
+        /// Show all protocols (default — same as passing no filter flag)
+        #[arg(long, conflicts_with_all = &["supported", "unsupported"])]
+        all: bool,
+        /// Show only protocols that wirerust actively dissects
+        #[arg(long, conflicts_with_all = &["all", "unsupported"])]
+        supported: bool,
+        /// Show only protocols that wirerust does not yet dissect
+        #[arg(long, conflicts_with_all = &["all", "supported"])]
+        unsupported: bool,
     },
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -124,10 +124,10 @@ pub struct Cli {
 ///
 /// Exactly three variants: `All` (default when no flag is given), `Supported`,
 /// and `Unsupported`. Mutual exclusion is enforced by clap `conflicts_with_all`
-/// annotations on the corresponding flags (BC-2.12.022 Invariant 2).
+/// annotations on the corresponding flags.
 #[derive(Debug, Clone, PartialEq)]
 pub enum ProtocolFilter {
-    /// Show all protocols — equivalent to passing `--all` (BC-2.12.022 Invariant 3).
+    /// Show all protocols — equivalent to passing `--all`.
     All,
     /// Show only protocols that wirerust actively dissects.
     Supported,
@@ -279,7 +279,7 @@ pub enum Commands {
         hosts: bool,
     },
 
-    /// List the protocol coverage catalog (BC-2.12.022; BC-2.18.001; BC-2.18.002)
+    /// List the protocol coverage catalog
     ///
     /// Prints a table of all known ICS/IT protocols — filterable by
     /// `--supported`, `--unsupported`, or `--all` (default).  Combine with

--- a/src/main.rs
+++ b/src/main.rs
@@ -667,14 +667,12 @@ fn render_protocols_terminal(protocols: &[&KnownProtocol]) {
 
     // Port-102 collision footnote — conditional on any of the four TCP/102 protocols
     // being in the printed set (BC-2.18.001 PC-6 / Invariant 3).
-    // Protocol names (S7comm, S7comm-plus, IEC 61850 MMS, ICCP/TASE.2) are intentionally
-    // absent from this single footnote line to avoid inflating the row-count test; those
-    // names are visible in the data rows above.  The row-count test (BC-2.18.001 Invariant 2)
-    // counts lines containing a catalog protocol name, so the footnote must not contain any.
+    // Names all four explicitly per AC-152-004 and BC-2.18.001 PC-6.
+    // Row-count tests exclude lines starting with "NOTE:" to avoid counting this footnote.
     if has_port_102 {
         println!();
         println!(
-            "NOTE: TCP/102 is shared by multiple ICS protocols (see table above) \
+            "NOTE: TCP/102 hosts S7comm, S7comm-plus, IEC 61850 MMS, and ICCP/TASE.2 \
              \u{2014} gap reports on port 102 cannot be attributed to a single protocol."
         );
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,9 +30,13 @@ use wirerust::analyzer::enip::EnipAnalyzer;
 use wirerust::analyzer::http::HttpAnalyzer;
 use wirerust::analyzer::modbus::ModbusAnalyzer;
 use wirerust::analyzer::tls::TlsAnalyzer;
-use wirerust::cli::{Cli, Commands, OutputFormat};
+use wirerust::cli::{Cli, Commands, OutputFormat, ProtocolFilter};
 use wirerust::decoder::{DecodedFrame, decode_packet};
 use wirerust::dispatcher::StreamDispatcher;
+use wirerust::protocols::{
+    KnownProtocol, ProtocolCategory, Transport, all_protocols, supported_protocols,
+    unsupported_protocols,
+};
 use wirerust::reader::PcapSource;
 use wirerust::reassembly::handler::StreamAnalyzer;
 use wirerust::reassembly::{ReassemblyConfig, TcpReassembler};
@@ -143,6 +147,20 @@ fn main() -> Result<()> {
         }
         Commands::Summary { targets, hosts } => {
             run_summary(targets, *hosts, use_color, &cli)?;
+        }
+        Commands::Protocols {
+            supported,
+            unsupported,
+            ..
+        } => {
+            let filter = if *supported {
+                ProtocolFilter::Supported
+            } else if *unsupported {
+                ProtocolFilter::Unsupported
+            } else {
+                ProtocolFilter::All
+            };
+            run_protocols(filter, cli.json.is_some());
         }
     }
 
@@ -536,6 +554,195 @@ fn run_analyze(
         std::process::exit(1);
     }
     Ok(())
+}
+
+/// Render the protocol coverage catalog to stdout.
+///
+/// Routes to the terminal table renderer or JSON renderer based on the `json` flag.
+/// Calls `all_protocols()`, `supported_protocols()`, or `unsupported_protocols()`
+/// based on `filter`. Pure CLI→catalog→render; MUST NOT call StreamDispatcher
+/// or any analyzer (BC-2.12.022 Invariant 5; architecture compliance).
+fn run_protocols(filter: ProtocolFilter, json: bool) {
+    let protocols: Vec<&KnownProtocol> = match filter {
+        ProtocolFilter::All => all_protocols().iter().collect(),
+        ProtocolFilter::Supported => supported_protocols(),
+        ProtocolFilter::Unsupported => unsupported_protocols(),
+    };
+    if json {
+        render_protocols_json(&protocols);
+    } else {
+        render_protocols_terminal(&protocols);
+    }
+}
+
+/// Derives whether a protocol entry is supported by wirerust.
+///
+/// A protocol is supported when at least one of its `canonical_ports` is in
+/// `SUPPORTED_PORTS`, or it is ARP (detected via `DecodedFrame::Arp` path —
+/// not port-based).  This is the BC-2.18.003 derivation rule; `KnownProtocol`
+/// carries no `supported` field.
+fn is_protocol_supported(p: &KnownProtocol) -> bool {
+    // ARP special case: detected via DecodedFrame::Arp, not port matching.
+    if p.name == "ARP" {
+        return true;
+    }
+    // All other entries: port intersection check against SUPPORTED_PORTS.
+    supported_protocols().iter().any(|sp| sp.name == p.name)
+}
+
+/// Terminal table renderer for the protocol coverage catalog.
+///
+/// Prints one row per entry in `protocols` (catalog-declaration order).
+/// Columns: Name | Category | Transport | Port(s) | EtherType | Supported.
+///
+/// Footnotes appended after the table when triggered:
+/// - Port-102 collision footnote: present when any of S7comm, S7comm-plus,
+///   IEC 61850 MMS, or ICCP/TASE.2 appear in the printed set
+///   (BC-2.18.001 PC-6 / Invariant 3).
+/// - L2/LinkLayer note: present when any `transport=LinkLayer` entries appear
+///   (BC-2.18.001 PC-7 / Invariant 4).
+fn render_protocols_terminal(protocols: &[&KnownProtocol]) {
+    // Column widths chosen to fit the longest catalog entries legibly.
+    let w_name = 32usize;
+    let w_cat = 8usize;
+    let w_trans = 9usize;
+    let w_ports = 22usize;
+    let w_et = 18usize;
+
+    // Header row.
+    println!(
+        "{:<w_name$} {:<w_cat$} {:<w_trans$} {:<w_ports$} {:<w_et$} Supported",
+        "Name", "Category", "Transport", "Port(s)", "EtherType"
+    );
+    println!(
+        "{}",
+        "-".repeat(w_name + 1 + w_cat + 1 + w_trans + 1 + w_ports + 1 + w_et + 1 + 9)
+    );
+
+    // Scan for footnote triggers before iterating (single pass).
+    const PORT_102_NAMES: &[&str] = &["S7comm", "S7comm-plus", "IEC 61850 MMS", "ICCP/TASE.2"];
+    let has_port_102 = protocols.iter().any(|p| PORT_102_NAMES.contains(&p.name));
+    let has_l2 = protocols
+        .iter()
+        .any(|p| p.transport == Transport::LinkLayer);
+
+    // Data rows — one per protocol, in the supplied (catalog-declaration) order.
+    for p in protocols {
+        let category = match p.category {
+            ProtocolCategory::ICS => "ICS",
+            ProtocolCategory::IT => "IT",
+        };
+        let transport = match p.transport {
+            Transport::Tcp => "TCP",
+            Transport::Udp => "UDP",
+            Transport::LinkLayer => "[L2]",
+        };
+        let ports = if p.canonical_ports.is_empty() {
+            // Em dash — LinkLayer entries have no TCP/UDP port (BC-2.18.001 PC-3).
+            "\u{2014}".to_string()
+        } else {
+            p.canonical_ports
+                .iter()
+                .map(|port| port.to_string())
+                .collect::<Vec<_>>()
+                .join(", ")
+        };
+        // EtherType: `0xHHHH (DDDDD)` for non-None entries; em dash otherwise.
+        // ARP has ethertype: None — displays em dash (BC-2.18.001 PC-5 / EC-004).
+        let ethertype = match p.ethertype {
+            Some(et) => format!("0x{et:04X} ({et})"),
+            None => "\u{2014}".to_string(),
+        };
+        let supported_str = if is_protocol_supported(p) {
+            "yes"
+        } else {
+            "no"
+        };
+
+        println!(
+            "{:<w_name$} {:<w_cat$} {:<w_trans$} {:<w_ports$} {:<w_et$} {}",
+            p.name, category, transport, ports, ethertype, supported_str
+        );
+    }
+
+    // Port-102 collision footnote — conditional on any of the four TCP/102 protocols
+    // being in the printed set (BC-2.18.001 PC-6 / Invariant 3).
+    // Protocol names (S7comm, S7comm-plus, IEC 61850 MMS, ICCP/TASE.2) are intentionally
+    // absent from this single footnote line to avoid inflating the row-count test; those
+    // names are visible in the data rows above.  The row-count test (BC-2.18.001 Invariant 2)
+    // counts lines containing a catalog protocol name, so the footnote must not contain any.
+    if has_port_102 {
+        println!();
+        println!(
+            "NOTE: TCP/102 is shared by multiple ICS protocols (see table above) \
+             \u{2014} gap reports on port 102 cannot be attributed to a single protocol."
+        );
+    }
+
+    // L2/LinkLayer note — present when any LinkLayer entries appear in the output
+    // (BC-2.18.001 PC-7 / Invariant 4).  These entries never appear in gap reports
+    // because the dispatcher and UDP decode loop observe TCP/UDP traffic only.
+    if has_l2 {
+        println!();
+        println!(
+            "NOTE: [L2] entries use EtherType-based detection and do not appear in gap reports \
+             (coverage gap reports track TCP/UDP port coverage only)."
+        );
+    }
+}
+
+/// JSON renderer for the protocol coverage catalog.
+///
+/// Emits a single JSON object `{"protocols":[...]}` to stdout.  Each element
+/// follows the BC-2.18.002 v1.1 schema:
+/// - `"category"`: `"ICS"` or `"IT"` (ADR-012 Decision 7 — no `"L2"` value)
+/// - `"transport"`: `"TCP"`, `"UDP"`, or `"LinkLayer"`
+/// - `"canonical_ports"`: array of integers; `[]` for `port_detectable=false` entries
+/// - `"ethertype"`: decimal integer or `null`
+/// - `"port_detectable"`: boolean
+/// - `"supported"`: boolean (derived — not a field on `KnownProtocol`)
+///
+/// Array elements are in catalog-declaration order (BC-2.18.002 Invariant 1).
+fn render_protocols_json(protocols: &[&KnownProtocol]) {
+    let entries: Vec<serde_json::Value> = protocols
+        .iter()
+        .map(|p| {
+            let category = match p.category {
+                ProtocolCategory::ICS => "ICS",
+                ProtocolCategory::IT => "IT",
+            };
+            let transport = match p.transport {
+                Transport::Tcp => "TCP",
+                Transport::Udp => "UDP",
+                Transport::LinkLayer => "LinkLayer",
+            };
+            let ports: Vec<serde_json::Value> = p
+                .canonical_ports
+                .iter()
+                .map(|&port| serde_json::json!(port))
+                .collect();
+            let ethertype: serde_json::Value = match p.ethertype {
+                Some(et) => serde_json::json!(et),
+                None => serde_json::Value::Null,
+            };
+            serde_json::json!({
+                "name": p.name,
+                "category": category,
+                "transport": transport,
+                "canonical_ports": ports,
+                "ethertype": ethertype,
+                "port_detectable": p.port_detectable,
+                "supported": is_protocol_supported(p),
+            })
+        })
+        .collect();
+
+    let output = serde_json::json!({ "protocols": entries });
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&output)
+            .expect("serde_json serialization of protocol catalog cannot fail")
+    );
 }
 
 fn run_summary(

--- a/tests/cli_story_086_tests.rs
+++ b/tests/cli_story_086_tests.rs
@@ -86,6 +86,7 @@ mod story_086 {
                 assert!(!all, "all should be false");
             }
             Commands::Summary { .. } => panic!("Expected Analyze, got Summary"),
+            Commands::Protocols { .. } => panic!("Expected Analyze, got Protocols"),
         }
     }
 
@@ -238,6 +239,7 @@ mod story_086 {
                 assert!(!hosts, "hosts should be false");
             }
             Commands::Analyze { .. } => panic!("Expected Summary, got Analyze"),
+            Commands::Protocols { .. } => panic!("Expected Summary, got Protocols"),
         }
     }
 

--- a/tests/cli_story_096_tests.rs
+++ b/tests/cli_story_096_tests.rs
@@ -469,6 +469,9 @@ mod story_096 {
             wirerust::cli::Commands::Summary { .. } => {
                 panic!("Expected Analyze, got Summary")
             }
+            wirerust::cli::Commands::Protocols { .. } => {
+                panic!("Expected Analyze, got Protocols")
+            }
         }
     }
 
@@ -572,6 +575,9 @@ mod story_096 {
             }
             wirerust::cli::Commands::Summary { .. } => {
                 panic!("Expected Analyze, got Summary")
+            }
+            wirerust::cli::Commands::Protocols { .. } => {
+                panic!("Expected Analyze, got Protocols")
             }
         }
     }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -452,8 +452,7 @@ mod story_152 {
     ///
     /// Canonical value source: IEC 61850-8-1 §4 ("EtherType 0x88B8");
     /// IEEE Registration Authority EtherType registry entry "IEC GOOSE" (decimal 35000).
-    /// 0x88B8 = 35000 decimal (verified: 8*16^3 + 8*16^2 + 11*16 + 8 = 34816+2048+176+8 = wait
-    /// 0x88B8: 0x8000=32768, 0x0800=2048, 0x00B0=176, 0x0008=8 → 32768+2048+176+8 = 35000 ✓).
+    /// 0x88B8 = 32768 + 2048 + 176 + 8 = 35000 (IEC 61850-8-1 §4; IEEE RA "IEC GOOSE").
     ///
     /// Regression guard: fails if the `protocols` subcommand is removed or stops exiting 0.
     #[test]
@@ -969,6 +968,55 @@ mod story_152 {
             "BC-2.12.022 Invariant 3: both default and --all must print exactly {} data rows \
              (== all_protocols().len()); got {count_all}",
             all.len()
+        );
+    }
+
+    /// BC-2.18.002 v1.1 Invariant 1 / PC-4
+    /// `wirerust protocols --json --all` `"protocols"` array preserves the declaration
+    /// order of `all_protocols()` (names must appear in the same sequence).
+    ///
+    /// Invariant 1: JSON output is a faithful, order-preserving serialisation of the
+    /// catalog. Shuffling the array would break deterministic holdout comparisons and
+    /// the BC-2.18.002 PC-4 ordering guarantee.
+    #[allow(non_snake_case)]
+    #[test]
+    fn test_BC_2_18_002_json_declaration_order() {
+        let output = bin()
+            .args(["protocols", "--json", "--all"])
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+        let stdout = String::from_utf8(output).expect("utf-8 stdout");
+        let json: serde_json::Value = serde_json::from_str(&stdout).unwrap_or_else(|e| {
+            panic!(
+                "BC-2.18.002 PC-6: `wirerust protocols --json --all` must produce valid JSON; \
+                 parse error: {e}\nstdout:\n{stdout}"
+            )
+        });
+        let arr = json["protocols"]
+            .as_array()
+            .expect("BC-2.18.002 PC-2: 'protocols' field must be a JSON array");
+
+        // Extract the name sequence from JSON output.
+        let json_names: Vec<&str> = arr
+            .iter()
+            .map(|e| {
+                e["name"]
+                    .as_str()
+                    .expect("BC-2.18.002: every protocols entry must have a string 'name' field")
+            })
+            .collect();
+
+        // Build the expected sequence from all_protocols() declaration order.
+        let catalog_names: Vec<&str> = all_protocols().iter().map(|p| p.name).collect();
+
+        assert_eq!(
+            json_names, catalog_names,
+            "BC-2.18.002 Invariant 1 / PC-4: JSON 'protocols' array must preserve \
+             all_protocols() declaration order; \
+             json_names={json_names:?}, catalog_names={catalog_names:?}"
         );
     }
 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1,0 +1,821 @@
+//! Integration tests for STORY-152: `wirerust protocols` CLI subcommand.
+//!
+//! Behavioral contracts covered:
+//!   BC-2.12.022 v1.0 — `wirerust protocols` Subcommand Dispatch + `--json` Flag
+//!   BC-2.18.001 v1.4 — Terminal Catalog Output (filter flags, [L2], EtherType, footnotes)
+//!   BC-2.18.002 v1.1 — JSON Mode Output Schema
+//!
+//! RED-GATE: All tests in `mod story_152` that assert `.success()` FAIL against
+//! the current binary — the `protocols` subcommand does not yet exist, so clap
+//! exits non-zero with "unrecognized subcommand 'protocols'" for every invocation.
+//!
+//! Exceptions (PASS in Red-Gate — these are regression guards):
+//!   - `test_BC_2_12_022_analyze_unaffected` — exercises existing `analyze` behavior;
+//!     asserts output does NOT gain a `protocols` key (always true today).
+//!   - `test_BC_2_12_022_mutually_exclusive_flags_error` — expects non-zero exit;
+//!     binary already exits non-zero (wrong subcommand) so this passes for the
+//!     wrong reason in Red-Gate. It becomes a true behavioral guard post-implementation.
+//!
+//! Harness: `assert_cmd::Command::cargo_bin("wirerust")` (binary process spawning).
+//! Catalog access: `wirerust::protocols::{all_protocols, supported_protocols,
+//! unsupported_protocols}` imported directly for row-count derivations.
+//!
+//! DF-CANONICAL-FRAME-HOLDOUT-001: EtherType canonical values asserted with spec citations:
+//!   GOOSE   0x88B8 = 35000  — IEC 61850-8-1 §4; IEEE RA "IEC GOOSE"
+//!   POWERLINK 0x88AB = 34987 — IEEE RA "ETHERNET Powerlink"; Wireshark ETHERTYPE_EPL_V2;
+//!              IETF ietf-ethertypes value 34987
+//!   BACnet/IP UDP 47808 = 0xBAC0 — ASHRAE 135-2016 Annex J §J.2.1
+//!   Modbus/TCP TCP 502  — IANA + Modbus App Protocol v1.1b3 §4.3.1
+
+mod story_152 {
+    #![allow(non_snake_case)]
+
+    use assert_cmd::Command;
+    use wirerust::protocols::{all_protocols, supported_protocols, unsupported_protocols};
+
+    /// Smallest pcap fixture used by the existing integration tests (1,209 B).
+    /// Shared with `cli_integration_tests.rs` — no new fixture needed.
+    const ANALYZE_FIXTURE: &str = "tests/fixtures/http-ooo.pcap";
+
+    /// Spawn the `wirerust` binary (debug build).
+    fn bin() -> Command {
+        Command::cargo_bin("wirerust").expect("wirerust binary must be built")
+    }
+
+    // -----------------------------------------------------------------------
+    // BC-2.12.022 — CLI wiring tests
+    // -----------------------------------------------------------------------
+
+    /// BC-2.12.022 PC-1 / Postcondition 6 / Invariant 1
+    /// `wirerust protocols` exits 0 and produces non-empty stdout.
+    ///
+    /// RED-GATE FAIL: the `protocols` subcommand does not exist → clap exits
+    /// non-zero → `.assert().success()` assertion fails.
+    #[test]
+    fn test_BC_2_12_022_protocols_subcommand_exit_0() {
+        let output = bin()
+            .args(["protocols"])
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+        let stdout = String::from_utf8(output).expect("utf-8 stdout");
+        assert!(
+            !stdout.is_empty(),
+            "BC-2.12.022 Invariant 1: `wirerust protocols` must produce non-empty stdout; \
+             got empty output"
+        );
+    }
+
+    /// BC-2.12.022 Invariant 2 / EC-006
+    /// `wirerust protocols --supported --unsupported` exits non-zero (clap conflict).
+    ///
+    /// RED-GATE NOTE: PASSES even before implementation — the binary exits non-zero
+    /// for "unrecognized subcommand 'protocols'" rather than "mutually exclusive flags".
+    /// This test becomes a true behavioral guard after implementation; it would fail if
+    /// the `conflicts_with` annotation were removed from the `protocols` subcommand.
+    #[test]
+    fn test_BC_2_12_022_mutually_exclusive_flags_error() {
+        bin()
+            .args(["protocols", "--supported", "--unsupported"])
+            .assert()
+            .failure();
+    }
+
+    /// BC-2.12.022 Postcondition 3 / EC-002
+    /// `wirerust protocols --supported` output has exactly 7 protocol rows
+    /// (one per `supported_protocols()` entry).
+    ///
+    /// Row count is derived robustly by matching stdout lines against protocol
+    /// names from `supported_protocols()`, not by counting header/footnote lines.
+    ///
+    /// RED-GATE FAIL: clap rejects `protocols` → `.assert().success()` fails.
+    #[test]
+    fn test_BC_2_12_022_protocols_supported_filter() {
+        let output = bin()
+            .args(["protocols", "--supported"])
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+        let stdout = String::from_utf8(output).expect("utf-8 stdout");
+        let supported = supported_protocols();
+        let row_count = stdout
+            .lines()
+            .filter(|line| supported.iter().any(|p| line.contains(p.name)))
+            .count();
+        assert_eq!(
+            row_count, 7,
+            "BC-2.12.022 EC-002: `wirerust protocols --supported` must produce exactly \
+             7 protocol rows (== supported_protocols().len()); got {row_count}.\n\
+             stdout:\n{stdout}"
+        );
+    }
+
+    /// BC-2.12.022 Postcondition 5 / EC-004
+    /// `wirerust protocols --json` stdout is valid JSON containing a `"protocols"` array.
+    ///
+    /// The global `--json` flag (no path) routes output to stdout. Parsed with `serde_json`
+    /// — no shell-out to `jq`.
+    ///
+    /// RED-GATE FAIL: clap rejects `protocols` → `.assert().success()` fails.
+    #[test]
+    fn test_BC_2_12_022_protocols_json_flag() {
+        let output = bin()
+            .args(["protocols", "--json"])
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+        let stdout = String::from_utf8(output).expect("utf-8 stdout");
+        let json: serde_json::Value = serde_json::from_str(&stdout).unwrap_or_else(|e| {
+            panic!(
+                "BC-2.12.022 PC-5: `wirerust protocols --json` must produce valid JSON; \
+                 parse error: {e}\nstdout:\n{stdout}"
+            )
+        });
+        assert!(
+            json.get("protocols").is_some(),
+            "BC-2.12.022 PC-5: JSON output must contain a top-level 'protocols' key; \
+             got JSON: {json}"
+        );
+        assert!(
+            json["protocols"].is_array(),
+            "BC-2.12.022 PC-5: JSON 'protocols' value must be an array; \
+             got: {:?}",
+            json["protocols"]
+        );
+    }
+
+    /// BC-2.12.022 Postcondition 7 / Invariant 7
+    /// `wirerust analyze <fixture>` is unaffected by the addition of the `protocols`
+    /// subcommand: it still exits 0, still contains `"summary"` and `"findings"` keys,
+    /// and does NOT contain a `"protocols"` key.
+    ///
+    /// RED-GATE NOTE: PASSES before implementation — `analyze` already works and
+    /// naturally does not emit a `"protocols"` key. This test is a REGRESSION GUARD:
+    /// it fails only if the `protocols` subcommand implementation breaks `analyze`
+    /// or accidentally injects a `"protocols"` key into the analyze output.
+    #[test]
+    fn test_BC_2_12_022_analyze_unaffected() {
+        let output = bin()
+            .args(["analyze", ANALYZE_FIXTURE, "--all", "--json"])
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+        let stdout = String::from_utf8(output).expect("utf-8 stdout");
+        let json: serde_json::Value = serde_json::from_str(&stdout).unwrap_or_else(|e| {
+            panic!(
+                "BC-2.12.022 Invariant 7: `wirerust analyze --json` must produce valid JSON; \
+                 parse error: {e}\nstdout:\n{stdout}"
+            )
+        });
+        assert!(
+            json.get("summary").is_some(),
+            "analyze JSON output must still contain 'summary' key after adding protocols \
+             subcommand; BC-2.12.022 Invariant 7"
+        );
+        assert!(
+            json.get("findings").is_some(),
+            "analyze JSON output must still contain 'findings' key; BC-2.12.022 Invariant 7"
+        );
+        assert!(
+            json.as_object()
+                .is_some_and(|obj| !obj.contains_key("protocols")),
+            "BC-2.12.022 Invariant 7: `wirerust analyze` JSON output must NOT contain a \
+             'protocols' key after adding the protocols subcommand"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // BC-2.18.001 — Terminal renderer tests
+    // -----------------------------------------------------------------------
+
+    /// BC-2.18.001 v1.4 Postcondition 1 / Invariant 2
+    /// `wirerust protocols --all` prints exactly 30 protocol rows (== `all_protocols().len()`).
+    ///
+    /// Row count is derived by matching stdout lines against protocol names from
+    /// `all_protocols()` — header lines and footnotes are not counted.
+    ///
+    /// RED-GATE FAIL: clap rejects `protocols` → `.assert().success()` fails.
+    #[test]
+    fn test_BC_2_18_001_all_row_count() {
+        let output = bin()
+            .args(["protocols", "--all"])
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+        let stdout = String::from_utf8(output).expect("utf-8 stdout");
+        let all = all_protocols();
+        let row_count = stdout
+            .lines()
+            .filter(|line| all.iter().any(|p| line.contains(p.name)))
+            .count();
+        let expected = all.len(); // == 30
+        assert_eq!(
+            row_count, expected,
+            "BC-2.18.001 Invariant 2: `wirerust protocols --all` must print exactly \
+             {expected} protocol rows (== all_protocols().len()); got {row_count}.\n\
+             stdout:\n{stdout}"
+        );
+    }
+
+    /// BC-2.18.001 v1.4 Postconditions 2 + 3 / EC-001 / EC-002
+    /// `wirerust protocols --supported` output contains ONLY the 7 supported protocols
+    /// and NONE of the unsupported ones.
+    ///
+    /// RED-GATE FAIL: clap rejects `protocols` → `.assert().success()` fails.
+    #[test]
+    fn test_BC_2_18_001_supported_filter() {
+        let output = bin()
+            .args(["protocols", "--supported"])
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+        let stdout = String::from_utf8(output).expect("utf-8 stdout");
+        let supported = supported_protocols();
+        let unsupported = unsupported_protocols();
+
+        // All 7 supported protocol names must appear.
+        for proto in &supported {
+            assert!(
+                stdout.contains(proto.name),
+                "BC-2.18.001 PC-2: `wirerust protocols --supported` must contain '{}'; \
+                 stdout:\n{stdout}",
+                proto.name
+            );
+        }
+        // No unsupported protocol names may appear.
+        for proto in &unsupported {
+            assert!(
+                !stdout.contains(proto.name),
+                "BC-2.18.001 PC-2: `wirerust protocols --supported` must NOT contain \
+                 '{}' (unsupported entry); stdout:\n{stdout}",
+                proto.name
+            );
+        }
+    }
+
+    /// BC-2.18.001 v1.4 Postcondition 6 / Invariant 3
+    /// `wirerust protocols --unsupported` stdout contains the TCP/102 collision note
+    /// (S7comm, S7comm-plus, IEC 61850 MMS, and ICCP/TASE.2 all appear in the set).
+    ///
+    /// RED-GATE FAIL: clap rejects `protocols` → `.assert().success()` fails.
+    #[test]
+    fn test_BC_2_18_001_port102_footnote() {
+        let output = bin()
+            .args(["protocols", "--unsupported"])
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+        let stdout = String::from_utf8(output).expect("utf-8 stdout");
+        // The footnote must reference TCP/102 (exact form may vary; "102" is the minimum signal).
+        assert!(
+            stdout.contains("TCP/102") || stdout.contains("port 102"),
+            "BC-2.18.001 PC-6: `wirerust protocols --unsupported` must include the port-102 \
+             collision footnote (S7comm, S7comm-plus, IEC 61850 MMS, ICCP/TASE.2 all share \
+             TCP/102); stdout:\n{stdout}"
+        );
+    }
+
+    /// BC-2.18.001 v1.4 Postcondition 6 / Invariant 3 (conditional footnote)
+    /// `wirerust protocols --supported` stdout does NOT contain the port-102 footnote:
+    /// none of the four TCP/102 protocols (S7comm, S7comm-plus, IEC 61850 MMS,
+    /// ICCP/TASE.2) appear in the supported set.
+    ///
+    /// RED-GATE FAIL: clap rejects `protocols` → `.assert().success()` fails.
+    #[test]
+    fn test_BC_2_18_001_port102_footnote_absent_supported() {
+        let output = bin()
+            .args(["protocols", "--supported"])
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+        let stdout = String::from_utf8(output).expect("utf-8 stdout");
+        assert!(
+            !stdout.contains("TCP/102"),
+            "BC-2.18.001 PC-6 conditional: `wirerust protocols --supported` must NOT contain \
+             the 'TCP/102' port-102 collision footnote (none of the four TCP/102 protocols \
+             are in the supported set); stdout:\n{stdout}"
+        );
+        assert!(
+            !stdout.contains("NOTE: TCP/102"),
+            "BC-2.18.001 PC-6 conditional: `wirerust protocols --supported` must NOT \
+             contain the NOTE: TCP/102 footnote line; stdout:\n{stdout}"
+        );
+    }
+
+    /// BC-2.18.001 v1.4 Postcondition 6 (footnote names all four)
+    /// The port-102 collision footnote in `--unsupported` output names all four protocols:
+    /// S7comm, S7comm-plus, IEC 61850 MMS, and ICCP (or ICCP/TASE.2).
+    ///
+    /// Source: ISO/IEC standards — S7comm (Siemens RFC), IEC 61850 MMS (IEC 61850-8-1),
+    /// ICCP/TASE.2 (IEC 60870-6). All four share TCP/102 (ISO on TCP / TPKT framing,
+    /// RFC 1006). The footnote must name each to satisfy BC-2.18.001 PC-6 exact text.
+    ///
+    /// RED-GATE FAIL: clap rejects `protocols` → `.assert().success()` fails.
+    #[test]
+    fn test_BC_2_18_001_port102_footnote_names_all_four() {
+        let output = bin()
+            .args(["protocols", "--unsupported"])
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+        let stdout = String::from_utf8(output).expect("utf-8 stdout");
+        assert!(
+            stdout.contains("S7comm"),
+            "BC-2.18.001 PC-6: port-102 footnote must name 'S7comm'; stdout:\n{stdout}"
+        );
+        // S7comm-plus (or equivalent notation).
+        assert!(
+            stdout.contains("S7comm-plus") || stdout.contains("S7comm+"),
+            "BC-2.18.001 PC-6: port-102 footnote must name 'S7comm-plus'; stdout:\n{stdout}"
+        );
+        // IEC 61850 MMS.
+        assert!(
+            stdout.contains("IEC 61850 MMS") || stdout.contains("MMS"),
+            "BC-2.18.001 PC-6: port-102 footnote must name 'IEC 61850 MMS'; stdout:\n{stdout}"
+        );
+        // ICCP or ICCP/TASE.2.
+        assert!(
+            stdout.contains("ICCP") || stdout.contains("TASE.2"),
+            "BC-2.18.001 PC-6: port-102 footnote must name 'ICCP' or 'ICCP/TASE.2'; \
+             stdout:\n{stdout}"
+        );
+    }
+
+    /// BC-2.18.001 v1.4 Postcondition 4 / EC-004
+    /// The GOOSE row in `wirerust protocols --unsupported` contains `[L2]` in the
+    /// transport column (IEC 61850 GOOSE is a `transport=LinkLayer` entry).
+    ///
+    /// RED-GATE FAIL: clap rejects `protocols` → `.assert().success()` fails.
+    #[test]
+    fn test_BC_2_18_001_l2_transport_indicator() {
+        let output = bin()
+            .args(["protocols", "--unsupported"])
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+        let stdout = String::from_utf8(output).expect("utf-8 stdout");
+        let goose_line = stdout
+            .lines()
+            .find(|line| line.contains("GOOSE"))
+            .unwrap_or_else(|| {
+                panic!(
+                    "BC-2.18.001 EC-004: GOOSE entry must appear in --unsupported output; \
+                     stdout:\n{stdout}"
+                )
+            });
+        assert!(
+            goose_line.contains("[L2]"),
+            "BC-2.18.001 PC-4: GOOSE row must contain '[L2]' transport indicator; \
+             got line: {goose_line:?}"
+        );
+    }
+
+    /// BC-2.18.001 v1.4 Postcondition 7 / Invariant 4
+    /// `wirerust protocols --unsupported` stdout contains a note that L2/LinkLayer protocols
+    /// never appear in the dynamic gap report (`CoverageGapsSummary`).
+    ///
+    /// The note may be a table footer, footnote, or column annotation. The test checks
+    /// for the presence of "gap" (a keyword that must appear in any well-formed note
+    /// about gap-report invisibility).
+    ///
+    /// RED-GATE FAIL: clap rejects `protocols` → `.assert().success()` fails.
+    #[test]
+    fn test_BC_2_18_001_l2_note_present() {
+        let output = bin()
+            .args(["protocols", "--unsupported"])
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+        let stdout = String::from_utf8(output).expect("utf-8 stdout");
+        let stdout_lower = stdout.to_lowercase();
+        // The note must communicate that L2 entries are undetectable in gap reports.
+        // "gap" is the minimum distinguishing keyword; a longer phrase is also acceptable.
+        let has_note = stdout_lower.contains("gap report")
+            || stdout_lower.contains("gap reports")
+            || stdout_lower.contains("coveragegap")
+            || (stdout_lower.contains("gap") && stdout.contains("[L2]"));
+        assert!(
+            has_note,
+            "BC-2.18.001 PC-7: `wirerust protocols --unsupported` must include a note about \
+             L2/LinkLayer entries not appearing in gap reports; stdout:\n{stdout}"
+        );
+    }
+
+    /// BC-2.18.001 v1.4 Postcondition 5; DF-CANONICAL-FRAME-HOLDOUT-001
+    /// GOOSE row in `wirerust protocols --unsupported` contains `0x88B8 (35000)`.
+    ///
+    /// Canonical value source: IEC 61850-8-1 §4 ("EtherType 0x88B8");
+    /// IEEE Registration Authority EtherType registry entry "IEC GOOSE" (decimal 35000).
+    /// 0x88B8 = 35000 decimal (verified: 8*16^3 + 8*16^2 + 11*16 + 8 = 34816+2048+176+8 = wait
+    /// 0x88B8: 0x8000=32768, 0x0800=2048, 0x00B0=176, 0x0008=8 → 32768+2048+176+8 = 35000 ✓).
+    ///
+    /// RED-GATE FAIL: clap rejects `protocols` → `.assert().success()` fails.
+    #[test]
+    fn test_BC_2_18_001_goose_ethertype_display() {
+        let output = bin()
+            .args(["protocols", "--unsupported"])
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+        let stdout = String::from_utf8(output).expect("utf-8 stdout");
+        let goose_line = stdout
+            .lines()
+            .find(|line| line.contains("GOOSE"))
+            .unwrap_or_else(|| {
+                panic!(
+                    "DF-CANONICAL-FRAME-HOLDOUT-001: GOOSE entry must appear in \
+                     --unsupported output; stdout:\n{stdout}"
+                )
+            });
+        // 0x88B8 (case-insensitive hex)
+        assert!(
+            goose_line.contains("0x88B8") || goose_line.contains("0x88b8"),
+            "DF-CANONICAL-FRAME-HOLDOUT-001: GOOSE row must display EtherType '0x88B8' \
+             (IEC 61850-8-1 §4; IEEE RA registry \"IEC GOOSE\"); \
+             got line: {goose_line:?}"
+        );
+        // Decimal 35000
+        assert!(
+            goose_line.contains("35000"),
+            "DF-CANONICAL-FRAME-HOLDOUT-001: GOOSE row must display decimal 35000 \
+             (0x88B8 = 35000; IEC 61850-8-1 §4; IEEE RA registry \"IEC GOOSE\"); \
+             got line: {goose_line:?}"
+        );
+    }
+
+    /// BC-2.18.001 v1.4 Postcondition 5; DF-CANONICAL-FRAME-HOLDOUT-001
+    /// POWERLINK row in `wirerust protocols --unsupported` contains `0x88AB (34987)`.
+    ///
+    /// Canonical value source: IEEE Registration Authority EtherType registry entry
+    /// "ETHERNET Powerlink" (0x88AB, decimal 34987); confirmed by Wireshark
+    /// `epan/etypes.h` constant `ETHERTYPE_EPL_V2 = 0x88AB`; IETF `ietf-ethertypes`
+    /// YANG module value 34987. The obsolete V1 value 0x3E3F (16191) must not appear.
+    ///
+    /// RED-GATE FAIL: clap rejects `protocols` → `.assert().success()` fails.
+    #[test]
+    fn test_BC_2_18_001_powerlink_ethertype_display() {
+        let output = bin()
+            .args(["protocols", "--unsupported"])
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+        let stdout = String::from_utf8(output).expect("utf-8 stdout");
+        let powerlink_line = stdout
+            .lines()
+            .find(|line| line.to_lowercase().contains("powerlink"))
+            .unwrap_or_else(|| {
+                panic!(
+                    "DF-CANONICAL-FRAME-HOLDOUT-001: POWERLINK entry must appear in \
+                     --unsupported output; stdout:\n{stdout}"
+                )
+            });
+        // 0x88AB (case-insensitive)
+        assert!(
+            powerlink_line.contains("0x88AB") || powerlink_line.contains("0x88ab"),
+            "DF-CANONICAL-FRAME-HOLDOUT-001: POWERLINK row must display EtherType '0x88AB' \
+             (IEEE RA registry \"ETHERNET Powerlink\"; Wireshark ETHERTYPE_EPL_V2); \
+             got line: {powerlink_line:?}"
+        );
+        // Decimal 34987
+        assert!(
+            powerlink_line.contains("34987"),
+            "DF-CANONICAL-FRAME-HOLDOUT-001: POWERLINK row must display decimal 34987 \
+             (0x88AB = 34987; IEEE RA registry; IETF ietf-ethertypes value 34987); \
+             got line: {powerlink_line:?}"
+        );
+    }
+
+    /// BC-2.18.001 v1.4 Postcondition 5 (ARP ethertype=None → `—`)
+    /// The ARP row in `wirerust protocols --all` displays `—` (em dash, U+2014) in the
+    /// EtherType column. ARP has `ethertype: None` in `KNOWN_PROTOCOLS`.
+    ///
+    /// RED-GATE FAIL: clap rejects `protocols` → `.assert().success()` fails.
+    #[test]
+    fn test_BC_2_18_001_arp_ethertype_dash() {
+        let output = bin()
+            .args(["protocols", "--all"])
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+        let stdout = String::from_utf8(output).expect("utf-8 stdout");
+        // Locate the ARP data row. ARP is unique in KNOWN_PROTOCOLS by name.
+        // Filter for data rows (lines containing "IT" or "ICS" to exclude headers).
+        let arp_line = stdout
+            .lines()
+            .find(|line| {
+                // Match a data row containing "ARP" alongside a category marker.
+                line.contains("ARP")
+                    && (line.contains("ICS") || line.contains("IT") || line.contains("[L2]"))
+            })
+            .unwrap_or_else(|| {
+                panic!(
+                    "BC-2.18.001 PC-5: ARP data row must appear in --all output; \
+                     stdout:\n{stdout}"
+                )
+            });
+        // Em dash U+2014 (—) in EtherType column for entries with ethertype=None.
+        assert!(
+            arp_line.contains('\u{2014}') || arp_line.contains("—"),
+            "BC-2.18.001 PC-5: ARP row EtherType column must be '—' (em dash U+2014; \
+             ARP has ethertype=None in KNOWN_PROTOCOLS); got line: {arp_line:?}"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // BC-2.18.002 — JSON renderer tests
+    // -----------------------------------------------------------------------
+
+    /// BC-2.18.002 v1.1 Postcondition 6 / Invariant 1
+    /// `wirerust protocols --all --json` output is valid JSON; `"protocols"` array
+    /// length equals `all_protocols().len()` (== 30).
+    ///
+    /// No shell-out to `jq` — parsed directly with `serde_json`.
+    ///
+    /// RED-GATE FAIL: clap rejects `protocols` → `.assert().success()` fails.
+    #[test]
+    fn test_BC_2_18_002_json_schema_valid() {
+        let output = bin()
+            .args(["protocols", "--all", "--json"])
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+        let stdout = String::from_utf8(output).expect("utf-8 stdout");
+        let json: serde_json::Value = serde_json::from_str(&stdout).unwrap_or_else(|e| {
+            panic!(
+                "BC-2.18.002 PC-6: `wirerust protocols --all --json` must produce valid JSON; \
+                 parse error: {e}\nstdout:\n{stdout}"
+            )
+        });
+        let arr = json["protocols"]
+            .as_array()
+            .expect("BC-2.18.002 PC-2: 'protocols' field must be a JSON array");
+        let expected_len = all_protocols().len(); // == 30
+        assert_eq!(
+            arr.len(),
+            expected_len,
+            "BC-2.18.002 Invariant 1: 'protocols' array length must equal \
+             all_protocols().len() ({expected_len}); got {}",
+            arr.len()
+        );
+    }
+
+    /// BC-2.18.002 v1.1 Invariant 2
+    /// Every JSON entry with `"port_detectable": false` has `"canonical_ports": []`.
+    ///
+    /// Invariant 2 holds one-way: `port_detectable: false` ⇒ `canonical_ports: []`.
+    /// (ARP is the counterexample to the converse: ARP has empty ports, ethertype=null,
+    /// port_detectable=false — the iff was relaxed in BC v1.1.)
+    ///
+    /// RED-GATE FAIL: clap rejects `protocols` → `.assert().success()` fails.
+    #[test]
+    fn test_BC_2_18_002_l2_entries_no_ports() {
+        let output = bin()
+            .args(["protocols", "--all", "--json"])
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+        let stdout = String::from_utf8(output).expect("utf-8 stdout");
+        let json: serde_json::Value =
+            serde_json::from_str(&stdout).expect("valid JSON (BC-2.18.002 PC-6)");
+        let arr = json["protocols"]
+            .as_array()
+            .expect("'protocols' must be an array");
+        for entry in arr {
+            let name = entry["name"].as_str().unwrap_or("(unnamed)");
+            if !entry["port_detectable"]
+                .as_bool()
+                .expect("port_detectable must be boolean")
+            {
+                let ports = entry["canonical_ports"]
+                    .as_array()
+                    .expect("canonical_ports must be an array");
+                assert!(
+                    ports.is_empty(),
+                    "BC-2.18.002 Invariant 2: entry '{}' has port_detectable=false but \
+                     canonical_ports={:?} (must be [])",
+                    name,
+                    ports
+                );
+            }
+        }
+    }
+
+    /// BC-2.18.002 v1.1 Invariant 1 / EC-001
+    /// `wirerust protocols --supported --json` produces a `"protocols"` array with
+    /// exactly 7 elements (== `supported_protocols().len()`).
+    ///
+    /// RED-GATE FAIL: clap rejects `protocols` → `.assert().success()` fails.
+    #[test]
+    fn test_BC_2_18_002_supported_flag_matches_function() {
+        let output = bin()
+            .args(["protocols", "--supported", "--json"])
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+        let stdout = String::from_utf8(output).expect("utf-8 stdout");
+        let json: serde_json::Value =
+            serde_json::from_str(&stdout).expect("valid JSON (BC-2.18.002 PC-6)");
+        let arr = json["protocols"]
+            .as_array()
+            .expect("'protocols' must be an array");
+        let expected_len = supported_protocols().len(); // == 7
+        assert_eq!(
+            arr.len(),
+            expected_len,
+            "BC-2.18.002 EC-001: `wirerust protocols --supported --json` 'protocols' array \
+             must have {expected_len} entries (== supported_protocols().len()); got {}",
+            arr.len()
+        );
+    }
+
+    /// BC-2.18.002 v1.1 EC-003; DF-CANONICAL-FRAME-HOLDOUT-001
+    /// GOOSE entry in `wirerust protocols --unsupported --json` has:
+    ///   `"ethertype": 35000`, `"transport": "LinkLayer"`, `"category": "ICS"`
+    ///
+    /// Canonical value source: IEC 61850-8-1 §4; IEEE RA registry "IEC GOOSE"
+    /// (0x88B8 = 35000 decimal). Category must be "ICS" not "L2" — ADR-012 Decision 7.
+    ///
+    /// RED-GATE FAIL: clap rejects `protocols` → `.assert().success()` fails.
+    #[test]
+    fn test_BC_2_18_002_goose_json_canonical() {
+        let output = bin()
+            .args(["protocols", "--unsupported", "--json"])
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+        let stdout = String::from_utf8(output).expect("utf-8 stdout");
+        let json: serde_json::Value =
+            serde_json::from_str(&stdout).expect("valid JSON (BC-2.18.002 PC-6)");
+        let arr = json["protocols"]
+            .as_array()
+            .expect("'protocols' must be an array");
+        let goose = arr
+            .iter()
+            .find(|e| e["name"].as_str().is_some_and(|n| n.contains("GOOSE")))
+            .unwrap_or_else(|| {
+                panic!(
+                    "DF-CANONICAL-FRAME-HOLDOUT-001: GOOSE entry must appear in \
+                     --unsupported JSON output; full array:\n{arr:?}"
+                )
+            });
+        // ethertype = 35000 (0x88B8; IEC 61850-8-1 §4; IEEE RA "IEC GOOSE")
+        assert_eq!(
+            goose["ethertype"],
+            serde_json::json!(35000),
+            "DF-CANONICAL-FRAME-HOLDOUT-001: GOOSE 'ethertype' must be 35000 \
+             (0x88B8; IEC 61850-8-1 §4; IEEE RA registry \"IEC GOOSE\")"
+        );
+        // transport = "LinkLayer"
+        assert_eq!(
+            goose["transport"],
+            serde_json::json!("LinkLayer"),
+            "BC-2.18.002 EC-003: GOOSE 'transport' must be \"LinkLayer\""
+        );
+        // category = "ICS" (NOT "L2" — ADR-012 Decision 7; ProtocolCategory has two variants)
+        assert_eq!(
+            goose["category"],
+            serde_json::json!("ICS"),
+            "BC-2.18.002 EC-003 / ADR-012 Decision 7: GOOSE 'category' must be \"ICS\" \
+             (not \"L2\" — ProtocolCategory has exactly two variants: ICS, IT)"
+        );
+    }
+
+    /// BC-2.18.002 v1.1 EC-004; DF-CANONICAL-FRAME-HOLDOUT-001
+    /// BACnet/IP entry in `wirerust protocols --unsupported --json` has:
+    ///   `"transport": "UDP"`, `"canonical_ports": [47808]`
+    ///
+    /// Canonical value source: ASHRAE 135-2016 Annex J §J.2.1
+    /// "UDP Port Number 47808 (0xBAC0)". Port 47808 ∉ SUPPORTED_PORTS, so
+    /// BACnet/IP is unsupported.
+    ///
+    /// RED-GATE FAIL: clap rejects `protocols` → `.assert().success()` fails.
+    #[test]
+    fn test_BC_2_18_002_bacnet_json_canonical() {
+        let output = bin()
+            .args(["protocols", "--unsupported", "--json"])
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+        let stdout = String::from_utf8(output).expect("utf-8 stdout");
+        let json: serde_json::Value =
+            serde_json::from_str(&stdout).expect("valid JSON (BC-2.18.002 PC-6)");
+        let arr = json["protocols"]
+            .as_array()
+            .expect("'protocols' must be an array");
+        let bacnet = arr
+            .iter()
+            .find(|e| e["name"].as_str().is_some_and(|n| n.contains("BACnet")))
+            .unwrap_or_else(|| {
+                panic!(
+                    "DF-CANONICAL-FRAME-HOLDOUT-001: BACnet/IP entry must appear in \
+                     --unsupported JSON output; full array:\n{arr:?}"
+                )
+            });
+        // transport = "UDP"
+        assert_eq!(
+            bacnet["transport"],
+            serde_json::json!("UDP"),
+            "DF-CANONICAL-FRAME-HOLDOUT-001: BACnet/IP 'transport' must be \"UDP\" \
+             (ASHRAE 135-2016 Annex J §J.2.1 — UDP-only canonical model)"
+        );
+        // canonical_ports = [47808] (0xBAC0; ASHRAE 135-2016 Annex J §J.2.1)
+        assert_eq!(
+            bacnet["canonical_ports"],
+            serde_json::json!([47808]),
+            "DF-CANONICAL-FRAME-HOLDOUT-001: BACnet/IP 'canonical_ports' must be [47808] \
+             (0xBAC0; ASHRAE 135-2016 Annex J §J.2.1)"
+        );
+    }
+
+    /// BC-2.18.002 v1.1 EC-005; DF-CANONICAL-FRAME-HOLDOUT-001
+    /// Modbus/TCP entry in `wirerust protocols --supported --json` has:
+    ///   `"transport": "TCP"`, `"canonical_ports": [502]`, `"supported": true`
+    ///
+    /// Canonical value source: IANA port registry + Modbus Application Protocol
+    /// Specification v1.1b3 §4.3.1 "Well-Known TCP Port 0+502".
+    ///
+    /// RED-GATE FAIL: clap rejects `protocols` → `.assert().success()` fails.
+    #[test]
+    fn test_BC_2_18_002_modbus_json_canonical() {
+        let output = bin()
+            .args(["protocols", "--supported", "--json"])
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+        let stdout = String::from_utf8(output).expect("utf-8 stdout");
+        let json: serde_json::Value =
+            serde_json::from_str(&stdout).expect("valid JSON (BC-2.18.002 PC-6)");
+        let arr = json["protocols"]
+            .as_array()
+            .expect("'protocols' must be an array");
+        let modbus = arr
+            .iter()
+            .find(|e| e["name"].as_str().is_some_and(|n| n.contains("Modbus")))
+            .unwrap_or_else(|| {
+                panic!(
+                    "DF-CANONICAL-FRAME-HOLDOUT-001: Modbus/TCP entry must appear in \
+                     --supported JSON output; full array:\n{arr:?}"
+                )
+            });
+        // transport = "TCP"
+        assert_eq!(
+            modbus["transport"],
+            serde_json::json!("TCP"),
+            "DF-CANONICAL-FRAME-HOLDOUT-001: Modbus/TCP 'transport' must be \"TCP\""
+        );
+        // canonical_ports = [502] (IANA + Modbus App Protocol v1.1b3 §4.3.1)
+        assert_eq!(
+            modbus["canonical_ports"],
+            serde_json::json!([502]),
+            "DF-CANONICAL-FRAME-HOLDOUT-001: Modbus/TCP 'canonical_ports' must be [502] \
+             (IANA port registry + Modbus App Protocol v1.1b3 §4.3.1)"
+        );
+        // supported = true
+        assert_eq!(
+            modbus["supported"],
+            serde_json::json!(true),
+            "DF-CANONICAL-FRAME-HOLDOUT-001: Modbus/TCP 'supported' must be true \
+             (port 502 ∈ SUPPORTED_PORTS)"
+        );
+    }
+}

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -5,16 +5,13 @@
 //!   BC-2.18.001 v1.4 — Terminal Catalog Output (filter flags, [L2], EtherType, footnotes)
 //!   BC-2.18.002 v1.1 — JSON Mode Output Schema
 //!
-//! RED-GATE: All tests in `mod story_152` that assert `.success()` FAIL against
-//! the current binary — the `protocols` subcommand does not yet exist, so clap
-//! exits non-zero with "unrecognized subcommand 'protocols'" for every invocation.
-//!
-//! Exceptions (PASS in Red-Gate — these are regression guards):
-//!   - `test_BC_2_12_022_analyze_unaffected` — exercises existing `analyze` behavior;
-//!     asserts output does NOT gain a `protocols` key (always true today).
-//!   - `test_BC_2_12_022_mutually_exclusive_flags_error` — expects non-zero exit;
-//!     binary already exits non-zero (wrong subcommand) so this passes for the
-//!     wrong reason in Red-Gate. It becomes a true behavioral guard post-implementation.
+//! All tests in `mod story_152` are GREEN regression guards for the `protocols`
+//! subcommand introduced in STORY-152. They guard that:
+//!   - the subcommand remains registered in clap and exits 0 for valid invocations,
+//!   - filter flags (`--supported`, `--unsupported`, `--all`) produce the correct row sets,
+//!   - terminal output correctly renders transport, EtherType, and footnotes,
+//!   - JSON output conforms to BC-2.18.002 field schema,
+//!   - the existing `analyze` subcommand is unaffected by the addition.
 //!
 //! Harness: `assert_cmd::Command::cargo_bin("wirerust")` (binary process spawning).
 //! Catalog access: `wirerust::protocols::{all_protocols, supported_protocols,
@@ -49,8 +46,8 @@ mod story_152 {
     /// BC-2.12.022 PC-1 / Postcondition 6 / Invariant 1
     /// `wirerust protocols` exits 0 and produces non-empty stdout.
     ///
-    /// RED-GATE FAIL: the `protocols` subcommand does not exist → clap exits
-    /// non-zero → `.assert().success()` assertion fails.
+    /// Regression guard: fails if the `protocols` subcommand is removed from clap
+    /// or if it starts producing empty stdout.
     #[test]
     fn test_BC_2_12_022_protocols_subcommand_exit_0() {
         let output = bin()
@@ -71,16 +68,24 @@ mod story_152 {
     /// BC-2.12.022 Invariant 2 / EC-006
     /// `wirerust protocols --supported --unsupported` exits non-zero (clap conflict).
     ///
-    /// RED-GATE NOTE: PASSES even before implementation — the binary exits non-zero
-    /// for "unrecognized subcommand 'protocols'" rather than "mutually exclusive flags".
-    /// This test becomes a true behavioral guard after implementation; it would fail if
-    /// the `conflicts_with` annotation were removed from the `protocols` subcommand.
+    /// Guards that clap's `conflicts_with` annotation on `--supported` vs `--unsupported`
+    /// remains in place. Fails if the `conflicts_with` constraint is removed from the
+    /// `protocols` subcommand definition in `src/cli.rs`.
     #[test]
     fn test_BC_2_12_022_mutually_exclusive_flags_error() {
-        bin()
+        let assert = bin()
             .args(["protocols", "--supported", "--unsupported"])
             .assert()
             .failure();
+        // Must be a clap conflict/usage error, not any arbitrary non-zero exit.
+        // clap emits "cannot be used with" for conflicts_with violations.
+        let stderr = String::from_utf8(assert.get_output().stderr.clone()).expect("utf-8 stderr");
+        assert!(
+            stderr.contains("cannot be used with"),
+            "BC-2.12.022 Invariant 2: expected a clap conflict error \
+             (\"cannot be used with\") for `--supported --unsupported`; \
+             got stderr:\n{stderr}"
+        );
     }
 
     /// BC-2.12.022 Postcondition 3 / EC-002
@@ -90,7 +95,7 @@ mod story_152 {
     /// Row count is derived robustly by matching stdout lines against protocol
     /// names from `supported_protocols()`, not by counting header/footnote lines.
     ///
-    /// RED-GATE FAIL: clap rejects `protocols` → `.assert().success()` fails.
+    /// Regression guard: fails if the `protocols` subcommand is removed or stops exiting 0.
     #[test]
     fn test_BC_2_12_022_protocols_supported_filter() {
         let output = bin()
@@ -102,8 +107,10 @@ mod story_152 {
             .clone();
         let stdout = String::from_utf8(output).expect("utf-8 stdout");
         let supported = supported_protocols();
+        // Exclude lines starting with "NOTE:" for robustness against footnote changes.
         let row_count = stdout
             .lines()
+            .filter(|line| !line.starts_with("NOTE:"))
             .filter(|line| supported.iter().any(|p| line.contains(p.name)))
             .count();
         assert_eq!(
@@ -120,7 +127,7 @@ mod story_152 {
     /// The global `--json` flag (no path) routes output to stdout. Parsed with `serde_json`
     /// — no shell-out to `jq`.
     ///
-    /// RED-GATE FAIL: clap rejects `protocols` → `.assert().success()` fails.
+    /// Regression guard: fails if the `protocols` subcommand is removed or stops exiting 0.
     #[test]
     fn test_BC_2_12_022_protocols_json_flag() {
         let output = bin()
@@ -155,10 +162,9 @@ mod story_152 {
     /// subcommand: it still exits 0, still contains `"summary"` and `"findings"` keys,
     /// and does NOT contain a `"protocols"` key.
     ///
-    /// RED-GATE NOTE: PASSES before implementation — `analyze` already works and
-    /// naturally does not emit a `"protocols"` key. This test is a REGRESSION GUARD:
-    /// it fails only if the `protocols` subcommand implementation breaks `analyze`
-    /// or accidentally injects a `"protocols"` key into the analyze output.
+    /// Regression guard for the existing `analyze` subcommand: fails if the `protocols`
+    /// implementation breaks `analyze` output or accidentally injects a `"protocols"` key
+    /// into `analyze --json` output.
     #[test]
     fn test_BC_2_12_022_analyze_unaffected() {
         let output = bin()
@@ -202,7 +208,7 @@ mod story_152 {
     /// Row count is derived by matching stdout lines against protocol names from
     /// `all_protocols()` — header lines and footnotes are not counted.
     ///
-    /// RED-GATE FAIL: clap rejects `protocols` → `.assert().success()` fails.
+    /// Regression guard: fails if the `protocols` subcommand is removed or stops exiting 0.
     #[test]
     fn test_BC_2_18_001_all_row_count() {
         let output = bin()
@@ -214,8 +220,11 @@ mod story_152 {
             .clone();
         let stdout = String::from_utf8(output).expect("utf-8 stdout");
         let all = all_protocols();
+        // Exclude lines starting with "NOTE:" so the port-102 footnote (which names
+        // protocol names per AC-152-004) does not inflate the data-row count.
         let row_count = stdout
             .lines()
+            .filter(|line| !line.starts_with("NOTE:"))
             .filter(|line| all.iter().any(|p| line.contains(p.name)))
             .count();
         let expected = all.len(); // == 30
@@ -231,7 +240,7 @@ mod story_152 {
     /// `wirerust protocols --supported` output contains ONLY the 7 supported protocols
     /// and NONE of the unsupported ones.
     ///
-    /// RED-GATE FAIL: clap rejects `protocols` → `.assert().success()` fails.
+    /// Regression guard: fails if the `protocols` subcommand is removed or stops exiting 0.
     #[test]
     fn test_BC_2_18_001_supported_filter() {
         let output = bin()
@@ -269,7 +278,7 @@ mod story_152 {
     /// `wirerust protocols --unsupported` stdout contains the TCP/102 collision note
     /// (S7comm, S7comm-plus, IEC 61850 MMS, and ICCP/TASE.2 all appear in the set).
     ///
-    /// RED-GATE FAIL: clap rejects `protocols` → `.assert().success()` fails.
+    /// Regression guard: fails if the `protocols` subcommand is removed or stops exiting 0.
     #[test]
     fn test_BC_2_18_001_port102_footnote() {
         let output = bin()
@@ -294,7 +303,7 @@ mod story_152 {
     /// none of the four TCP/102 protocols (S7comm, S7comm-plus, IEC 61850 MMS,
     /// ICCP/TASE.2) appear in the supported set.
     ///
-    /// RED-GATE FAIL: clap rejects `protocols` → `.assert().success()` fails.
+    /// Regression guard: fails if the `protocols` subcommand is removed or stops exiting 0.
     #[test]
     fn test_BC_2_18_001_port102_footnote_absent_supported() {
         let output = bin()
@@ -326,7 +335,7 @@ mod story_152 {
     /// ICCP/TASE.2 (IEC 60870-6). All four share TCP/102 (ISO on TCP / TPKT framing,
     /// RFC 1006). The footnote must name each to satisfy BC-2.18.001 PC-6 exact text.
     ///
-    /// RED-GATE FAIL: clap rejects `protocols` → `.assert().success()` fails.
+    /// Regression guard: fails if the `protocols` subcommand is removed or stops exiting 0.
     #[test]
     fn test_BC_2_18_001_port102_footnote_names_all_four() {
         let output = bin()
@@ -337,25 +346,40 @@ mod story_152 {
             .stdout
             .clone();
         let stdout = String::from_utf8(output).expect("utf-8 stdout");
+        // Locate the footnote line specifically — names must appear IN THE FOOTNOTE,
+        // not just anywhere in stdout (the same names also appear as data rows).
+        // This guards against a regression where the footnote omits the names but
+        // the data rows still satisfy a bare stdout.contains() check.
+        let footnote_line = stdout
+            .lines()
+            .find(|line| line.starts_with("NOTE: TCP/102"))
+            .unwrap_or_else(|| {
+                panic!(
+                    "BC-2.18.001 PC-6: expected a footnote line starting with \
+                     'NOTE: TCP/102' in --unsupported output; stdout:\n{stdout}"
+                )
+            });
         assert!(
-            stdout.contains("S7comm"),
-            "BC-2.18.001 PC-6: port-102 footnote must name 'S7comm'; stdout:\n{stdout}"
+            footnote_line.contains("S7comm"),
+            "BC-2.18.001 PC-6: footnote must name 'S7comm'; footnote line: {footnote_line:?}"
         );
         // S7comm-plus (or equivalent notation).
         assert!(
-            stdout.contains("S7comm-plus") || stdout.contains("S7comm+"),
-            "BC-2.18.001 PC-6: port-102 footnote must name 'S7comm-plus'; stdout:\n{stdout}"
+            footnote_line.contains("S7comm-plus") || footnote_line.contains("S7comm+"),
+            "BC-2.18.001 PC-6: footnote must name 'S7comm-plus'; \
+             footnote line: {footnote_line:?}"
         );
         // IEC 61850 MMS.
         assert!(
-            stdout.contains("IEC 61850 MMS") || stdout.contains("MMS"),
-            "BC-2.18.001 PC-6: port-102 footnote must name 'IEC 61850 MMS'; stdout:\n{stdout}"
+            footnote_line.contains("IEC 61850 MMS") || footnote_line.contains("MMS"),
+            "BC-2.18.001 PC-6: footnote must name 'IEC 61850 MMS'; \
+             footnote line: {footnote_line:?}"
         );
         // ICCP or ICCP/TASE.2.
         assert!(
-            stdout.contains("ICCP") || stdout.contains("TASE.2"),
-            "BC-2.18.001 PC-6: port-102 footnote must name 'ICCP' or 'ICCP/TASE.2'; \
-             stdout:\n{stdout}"
+            footnote_line.contains("ICCP") || footnote_line.contains("TASE.2"),
+            "BC-2.18.001 PC-6: footnote must name 'ICCP' or 'ICCP/TASE.2'; \
+             footnote line: {footnote_line:?}"
         );
     }
 
@@ -363,7 +387,7 @@ mod story_152 {
     /// The GOOSE row in `wirerust protocols --unsupported` contains `[L2]` in the
     /// transport column (IEC 61850 GOOSE is a `transport=LinkLayer` entry).
     ///
-    /// RED-GATE FAIL: clap rejects `protocols` → `.assert().success()` fails.
+    /// Regression guard: fails if the `protocols` subcommand is removed or stops exiting 0.
     #[test]
     fn test_BC_2_18_001_l2_transport_indicator() {
         let output = bin()
@@ -398,7 +422,7 @@ mod story_152 {
     /// for the presence of "gap" (a keyword that must appear in any well-formed note
     /// about gap-report invisibility).
     ///
-    /// RED-GATE FAIL: clap rejects `protocols` → `.assert().success()` fails.
+    /// Regression guard: fails if the `protocols` subcommand is removed or stops exiting 0.
     #[test]
     fn test_BC_2_18_001_l2_note_present() {
         let output = bin()
@@ -431,7 +455,7 @@ mod story_152 {
     /// 0x88B8 = 35000 decimal (verified: 8*16^3 + 8*16^2 + 11*16 + 8 = 34816+2048+176+8 = wait
     /// 0x88B8: 0x8000=32768, 0x0800=2048, 0x00B0=176, 0x0008=8 → 32768+2048+176+8 = 35000 ✓).
     ///
-    /// RED-GATE FAIL: clap rejects `protocols` → `.assert().success()` fails.
+    /// Regression guard: fails if the `protocols` subcommand is removed or stops exiting 0.
     #[test]
     fn test_BC_2_18_001_goose_ethertype_display() {
         let output = bin()
@@ -475,7 +499,7 @@ mod story_152 {
     /// `epan/etypes.h` constant `ETHERTYPE_EPL_V2 = 0x88AB`; IETF `ietf-ethertypes`
     /// YANG module value 34987. The obsolete V1 value 0x3E3F (16191) must not appear.
     ///
-    /// RED-GATE FAIL: clap rejects `protocols` → `.assert().success()` fails.
+    /// Regression guard: fails if the `protocols` subcommand is removed or stops exiting 0.
     #[test]
     fn test_BC_2_18_001_powerlink_ethertype_display() {
         let output = bin()
@@ -515,7 +539,7 @@ mod story_152 {
     /// The ARP row in `wirerust protocols --all` displays `—` (em dash, U+2014) in the
     /// EtherType column. ARP has `ethertype: None` in `KNOWN_PROTOCOLS`.
     ///
-    /// RED-GATE FAIL: clap rejects `protocols` → `.assert().success()` fails.
+    /// Regression guard: fails if the `protocols` subcommand is removed or stops exiting 0.
     #[test]
     fn test_BC_2_18_001_arp_ethertype_dash() {
         let output = bin()
@@ -559,7 +583,7 @@ mod story_152 {
     ///
     /// No shell-out to `jq` — parsed directly with `serde_json`.
     ///
-    /// RED-GATE FAIL: clap rejects `protocols` → `.assert().success()` fails.
+    /// Regression guard: fails if the `protocols` subcommand is removed or stops exiting 0.
     #[test]
     fn test_BC_2_18_002_json_schema_valid() {
         let output = bin()
@@ -596,7 +620,7 @@ mod story_152 {
     /// (ARP is the counterexample to the converse: ARP has empty ports, ethertype=null,
     /// port_detectable=false — the iff was relaxed in BC v1.1.)
     ///
-    /// RED-GATE FAIL: clap rejects `protocols` → `.assert().success()` fails.
+    /// Regression guard: fails if the `protocols` subcommand is removed or stops exiting 0.
     #[test]
     fn test_BC_2_18_002_l2_entries_no_ports() {
         let output = bin()
@@ -636,7 +660,7 @@ mod story_152 {
     /// `wirerust protocols --supported --json` produces a `"protocols"` array with
     /// exactly 7 elements (== `supported_protocols().len()`).
     ///
-    /// RED-GATE FAIL: clap rejects `protocols` → `.assert().success()` fails.
+    /// Regression guard: fails if the `protocols` subcommand is removed or stops exiting 0.
     #[test]
     fn test_BC_2_18_002_supported_flag_matches_function() {
         let output = bin()
@@ -669,7 +693,7 @@ mod story_152 {
     /// Canonical value source: IEC 61850-8-1 §4; IEEE RA registry "IEC GOOSE"
     /// (0x88B8 = 35000 decimal). Category must be "ICS" not "L2" — ADR-012 Decision 7.
     ///
-    /// RED-GATE FAIL: clap rejects `protocols` → `.assert().success()` fails.
+    /// Regression guard: fails if the `protocols` subcommand is removed or stops exiting 0.
     #[test]
     fn test_BC_2_18_002_goose_json_canonical() {
         let output = bin()
@@ -724,7 +748,7 @@ mod story_152 {
     /// "UDP Port Number 47808 (0xBAC0)". Port 47808 ∉ SUPPORTED_PORTS, so
     /// BACnet/IP is unsupported.
     ///
-    /// RED-GATE FAIL: clap rejects `protocols` → `.assert().success()` fails.
+    /// Regression guard: fails if the `protocols` subcommand is removed or stops exiting 0.
     #[test]
     fn test_BC_2_18_002_bacnet_json_canonical() {
         let output = bin()
@@ -772,7 +796,7 @@ mod story_152 {
     /// Canonical value source: IANA port registry + Modbus Application Protocol
     /// Specification v1.1b3 §4.3.1 "Well-Known TCP Port 0+502".
     ///
-    /// RED-GATE FAIL: clap rejects `protocols` → `.assert().success()` fails.
+    /// Regression guard: fails if the `protocols` subcommand is removed or stops exiting 0.
     #[test]
     fn test_BC_2_18_002_modbus_json_canonical() {
         let output = bin()
@@ -816,6 +840,135 @@ mod story_152 {
             serde_json::json!(true),
             "DF-CANONICAL-FRAME-HOLDOUT-001: Modbus/TCP 'supported' must be true \
              (port 502 ∈ SUPPORTED_PORTS)"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Coverage gap tests (Pass-1 findings)
+    // -----------------------------------------------------------------------
+
+    /// BC-2.12.022 EC-152-4 — spurious positional argument rejected
+    /// `wirerust protocols somefile.pcap` exits non-zero; clap rejects the
+    /// unexpected positional argument (the `protocols` subcommand accepts no
+    /// positional args — only `--all`, `--supported`, `--unsupported`, `--json`).
+    #[test]
+    fn test_BC_2_12_022_protocols_spurious_positional_error() {
+        bin()
+            .args(["protocols", "somefile.pcap"])
+            .assert()
+            .failure();
+    }
+
+    /// BC-2.18.002 v1.1 EC-152-10; DF-CANONICAL-FRAME-HOLDOUT-001
+    /// ARP entry in `wirerust protocols --supported --json` has:
+    ///   `"transport": "LinkLayer"`, `"ethertype": null`,
+    ///   `"canonical_ports": []`, `"supported": true`
+    ///
+    /// ARP is in the supported set via the explicit `|| p.name == "ARP"` branch
+    /// in `supported_protocols()` (BC-2.18.003 Invariant 3). Its L2 transport means
+    /// it has no canonical TCP/UDP ports and no EtherType value in KNOWN_PROTOCOLS.
+    #[test]
+    fn test_BC_2_18_002_arp_json_canonical() {
+        let output = bin()
+            .args(["protocols", "--supported", "--json"])
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+        let stdout = String::from_utf8(output).expect("utf-8 stdout");
+        let json: serde_json::Value =
+            serde_json::from_str(&stdout).expect("valid JSON (BC-2.18.002 PC-6)");
+        let arr = json["protocols"]
+            .as_array()
+            .expect("'protocols' must be an array");
+        let arp = arr
+            .iter()
+            .find(|e| e["name"].as_str().is_some_and(|n| n == "ARP"))
+            .unwrap_or_else(|| {
+                panic!(
+                    "BC-2.18.002 EC-152-10: ARP must appear in --supported JSON output \
+                     (ARP is in supported_protocols() via || p.name == \"ARP\"); \
+                     full array:\n{arr:?}"
+                )
+            });
+        assert_eq!(
+            arp["transport"],
+            serde_json::json!("LinkLayer"),
+            "BC-2.18.002 EC-152-10: ARP 'transport' must be \"LinkLayer\""
+        );
+        assert_eq!(
+            arp["ethertype"],
+            serde_json::Value::Null,
+            "BC-2.18.002 EC-152-10: ARP 'ethertype' must be null (ethertype=None in \
+             KNOWN_PROTOCOLS)"
+        );
+        assert_eq!(
+            arp["canonical_ports"],
+            serde_json::json!([]),
+            "BC-2.18.002 EC-152-10: ARP 'canonical_ports' must be [] (LinkLayer entry, \
+             no TCP/UDP port)"
+        );
+        assert_eq!(
+            arp["supported"],
+            serde_json::json!(true),
+            "BC-2.18.002 EC-152-10: ARP 'supported' must be true \
+             (in supported_protocols() via || p.name == \"ARP\")"
+        );
+    }
+
+    /// BC-2.12.022 Invariant 3 — default (no flag) equals `--all`
+    /// `wirerust protocols` with no filter flag prints the same 30 data rows as
+    /// `wirerust protocols --all` (BC-2.12.022 Invariant 3: default == --all).
+    ///
+    /// Row counts exclude lines starting with "NOTE:" so the port-102 footnote
+    /// (which names protocol names per AC-152-004) does not inflate the count.
+    #[test]
+    fn test_BC_2_12_022_default_equals_all() {
+        let all = all_protocols();
+
+        // Count data rows in `--all` output (canonical reference).
+        let output_all = bin()
+            .args(["protocols", "--all"])
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+        let stdout_all = String::from_utf8(output_all).expect("utf-8 stdout");
+        let count_all = stdout_all
+            .lines()
+            .filter(|line| !line.starts_with("NOTE:"))
+            .filter(|line| all.iter().any(|p| line.contains(p.name)))
+            .count();
+
+        // Count data rows in default (no-flag) output.
+        let output_default = bin()
+            .args(["protocols"])
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+        let stdout_default = String::from_utf8(output_default).expect("utf-8 stdout");
+        let count_default = stdout_default
+            .lines()
+            .filter(|line| !line.starts_with("NOTE:"))
+            .filter(|line| all.iter().any(|p| line.contains(p.name)))
+            .count();
+
+        assert_eq!(
+            count_default, count_all,
+            "BC-2.12.022 Invariant 3: `wirerust protocols` (no flag) must print the same \
+             number of data rows as `wirerust protocols --all`; \
+             got default={count_default}, --all={count_all}"
+        );
+        assert_eq!(
+            count_all,
+            all.len(),
+            "BC-2.12.022 Invariant 3: both default and --all must print exactly {} data rows \
+             (== all_protocols().len()); got {count_all}",
+            all.len()
         );
     }
 }


### PR DESCRIPTION
# [STORY-152] `protocols` CLI Subcommand — Coverage Catalog Table + JSON Output

**Epic:** E-21 — feature-protocol-coverage
**Wave:** 68
**Mode:** feature
**Convergence:** CONVERGED after 3 adversarial passes (0 P0/CRITICAL/HIGH findings on d34a05f)

![Tests](https://img.shields.io/badge/tests-25%2F25%20story__152-brightgreen)
![Toolchain](https://img.shields.io/badge/cargo%20test%20--all--targets-PASS-brightgreen)
![Clippy](https://img.shields.io/badge/clippy%20-D%20warnings-CLEAN-brightgreen)
![Fmt](https://img.shields.io/badge/cargo%20fmt%20--check-CLEAN-brightgreen)

This PR delivers the `wirerust protocols` CLI subcommand (BC-2.12.022 + BC-2.18.001 + BC-2.18.002). It adds a `Commands::Protocols` variant with mutually-exclusive `--all/--supported/--unsupported` filter flags and a global `--json` pass-through, a terminal catalog table renderer (Name / Category / Transport / Port(s) / EtherType / Supported columns, `[L2]` indicator, port-102 collision footnote, LinkLayer note), and a structured JSON output path (`{ "protocols": [...] }` per BC-2.18.002 schema, stdout-only by design). The implementation consumes STORY-151's `src/protocols.rs` catalog — `all_protocols()`, `supported_protocols()`, `unsupported_protocols()` — without touching the `analyze` subcommand.

**Diff: 5 files, +1268 lines.** `tests/integration_tests.rs` is a new file (1022 lines, `mod story_152` with 25 tests). The two `cli_story_086_tests.rs` (+2) and `cli_story_096_tests.rs` (+6) edits each add a `Commands::Protocols {..} => panic!()` arm to satisfy Rust's exhaustive match requirement for those files — these are blast-radius fallout from the new enum variant and are NOT functional changes to those test suites.

---

## Architecture Changes

```mermaid
graph TD
    CLI["src/cli.rs<br/>Commands::Protocols variant<br/>ProtocolFilter enum"]
    Main["src/main.rs<br/>dispatch arm<br/>run_protocols()"]
    Catalog["src/protocols.rs<br/>(STORY-151)<br/>all/supported/unsupported_protocols()"]
    Stdout["STDOUT<br/>terminal table or JSON"]

    CLI -->|"clap parse"| Main
    Main -->|"filter dispatch"| Catalog
    Catalog -->|"KnownProtocol slice"| Main
    Main -->|"render"| Stdout

    style CLI fill:#90EE90
    style Main fill:#90EE90
```

<details>
<summary><strong>Architecture Decision Record — ADR-012</strong></summary>

### ADR-012: Protocol Coverage Catalog

**Context:** wirerust needed a static, queryable catalog of all ICS/IT protocols it knows about (both supported and unsupported) to answer "what gaps exist in my network coverage?" without running a live capture.

**Decision 3:** The `protocols` subcommand is a first-class top-level `Commands` variant, not a sub-subcommand of `analyze`. Filter flags (`--all/--supported/--unsupported`) are mutually exclusive via clap `conflicts_with`. Default behavior (no flag) equals `--all`.

**Decision 7:** JSON `"category"` values are `"ICS"` or `"IT"` only — never `"L2"`. The `[L2]` indicator is a transport-layer display annotation in the terminal renderer, not a category value.

**Rationale:** Separation of concerns — catalog lookup is a pure, side-effect-free read with no pcap dependency. Keeping it as a separate `Commands` variant avoids polluting the `analyze` dispatch path and makes the help text clear to operators.

</details>

---

## Story Dependencies

```mermaid
graph LR
    S151["STORY-151<br/>✅ merged<br/>src/protocols.rs catalog"]
    S152["STORY-152<br/>🔶 this PR<br/>protocols subcommand"]
    S154["STORY-154<br/>⏳ pending<br/>depends on S152"]

    S151 --> S152
    S152 --> S154

    style S152 fill:#FFD700
    style S151 fill:#90EE90
    style S154 fill:#D3D3D3
```

**Dependency status:** STORY-151 is merged (`src/protocols.rs` is on `develop`). STORY-154 is pending and blocks on this PR.

---

## Spec Traceability

```mermaid
flowchart LR
    BC1["BC-2.12.022 v1.0<br/>CLI Dispatch + --json"]
    BC2["BC-2.18.001 v1.4<br/>Terminal Table Renderer"]
    BC3["BC-2.18.002 v1.1<br/>JSON Output Schema"]

    BC1 --> AC1["AC-152-001<br/>Commands::Protocols variant"]
    BC1 --> AC2["AC-152-002<br/>Dispatch to run_protocols()"]
    BC2 --> AC3["AC-152-003<br/>Terminal table rows/cols"]
    BC2 --> AC4["AC-152-004<br/>Port-102 footnote"]
    BC2 --> AC5["AC-152-005<br/>L2 note"]
    BC2 --> AC6["AC-152-006<br/>EtherType display"]
    BC3 --> AC7["AC-152-007<br/>JSON schema"]
    BC1 --> AC8["AC-152-008<br/>Exit 0; analyze unchanged"]

    AC1 --> T1["test_BC_2_12_022_protocols_subcommand_exit_0"]
    AC1 --> T2["test_BC_2_12_022_mutually_exclusive_flags_error"]
    AC2 --> T3["test_BC_2_12_022_protocols_json_flag"]
    AC3 --> T4["test_BC_2_18_001_all_row_count"]
    AC4 --> T5["test_BC_2_18_001_port102_footnote_names_all_four"]
    AC6 --> T6["test_BC_2_18_001_goose_ethertype_display<br/>0x88B8 (35000) — DF-CANONICAL-FRAME-HOLDOUT-001"]
    AC7 --> T7["test_BC_2_18_002_goose_json_canonical<br/>ethertype: 35000"]

    T1 --> S1["src/cli.rs + src/main.rs"]
    T4 --> S1
    T6 --> S1
    T7 --> S1
```

---

## Test Evidence

### Coverage Summary

| Metric | Value | Threshold | Status |
|--------|-------|-----------|--------|
| STORY-152 integration tests | 25/25 pass | 100% | PASS |
| Full suite (`cargo test --all-targets`) | all green | 100% | PASS |
| Clippy (`-D warnings`) | 0 warnings | 0 | CLEAN |
| fmt (`--check`) | clean | clean | CLEAN |
| Canonical-frame assertions (DF-CANONICAL-FRAME-HOLDOUT-001) | 6 tests | all pass | PASS |

### Test Flow

```mermaid
graph LR
    UnitBc["BC-2.12.022 tests (5)<br/>CLI dispatch, flags, exit 0"]
    UnitBc2["BC-2.18.001 tests (13)<br/>Terminal table, EtherType, footnotes"]
    UnitBc3["BC-2.18.002 tests (7)<br/>JSON schema, canonical values"]
    Regression["Full regression<br/>cargo test --all-targets"]

    UnitBc -->|"PASS"| Green1["PASS"]
    UnitBc2 -->|"PASS"| Green2["PASS"]
    UnitBc3 -->|"PASS"| Green3["PASS"]
    Regression -->|"PASS"| Green4["PASS"]

    style Green1 fill:#90EE90
    style Green2 fill:#90EE90
    style Green3 fill:#90EE90
    style Green4 fill:#90EE90
```

| Metric | Value |
|--------|-------|
| **New tests** | 25 added (mod story_152 in tests/integration_tests.rs) |
| **Exhaustive-match arms** | 2 files × panic! arms (cli_story_086, cli_story_096) — not new test logic, enum blast-radius only |
| **Canonical-frame tests** | 6 (GOOSE 0x88B8=35000, POWERLINK 0x88AB=34987, BACnet UDP 47808, Modbus TCP 502, ARP ethertype null) |
| **Regressions** | 0 |

<details>
<summary><strong>New Tests (This PR)</strong></summary>

### New Tests — mod story_152 in tests/integration_tests.rs

| Test | BC | Notes |
|------|----|-------|
| `test_BC_2_12_022_protocols_subcommand_exit_0` | BC-2.12.022 | exit 0, non-empty stdout |
| `test_BC_2_12_022_mutually_exclusive_flags_error` | BC-2.12.022 | --supported --unsupported → non-zero exit |
| `test_BC_2_12_022_protocols_supported_filter` | BC-2.12.022 | --supported → 7-row count |
| `test_BC_2_12_022_protocols_json_flag` | BC-2.12.022 | --json → valid JSON with "protocols" |
| `test_BC_2_12_022_analyze_unaffected` | BC-2.12.022 | analyze subcommand regression baseline |
| `test_BC_2_18_001_all_row_count` | BC-2.18.001 | --all → 30 rows |
| `test_BC_2_18_001_supported_filter` | BC-2.18.001 | supported filter set match |
| `test_BC_2_18_001_port102_footnote` | BC-2.18.001 | --unsupported footnote present |
| `test_BC_2_18_001_port102_footnote_absent_supported` | BC-2.18.001 | --supported → no footnote |
| `test_BC_2_18_001_port102_footnote_names_all_four` | BC-2.18.001 | footnote names S7comm, S7comm-plus, IEC 61850 MMS, ICCP |
| `test_BC_2_18_001_l2_transport_indicator` | BC-2.18.001 | GOOSE row shows [L2] |
| `test_BC_2_18_001_l2_note_present` | BC-2.18.001 | L2/LinkLayer note in output |
| `test_BC_2_18_001_goose_ethertype_display` | BC-2.18.001 | 0x88B8 (35000) — DF-CANONICAL-FRAME-HOLDOUT-001 |
| `test_BC_2_18_001_powerlink_ethertype_display` | BC-2.18.001 | 0x88AB (34987) — DF-CANONICAL-FRAME-HOLDOUT-001 |
| `test_BC_2_18_001_arp_ethertype_dash` | BC-2.18.001 | ARP EtherType column is — |
| `test_BC_2_18_002_json_schema_valid` | BC-2.18.002 | jq parseable, .protocols.length == 30 |
| `test_BC_2_18_002_l2_entries_no_ports` | BC-2.18.002 | port_detectable=false → canonical_ports: [] |
| `test_BC_2_18_002_supported_flag_matches_function` | BC-2.18.002 | --json --supported → 7 entries |
| `test_BC_2_18_002_goose_json_canonical` | BC-2.18.002 | ethertype: 35000, transport: LinkLayer — DF-CANONICAL-FRAME-HOLDOUT-001 |
| `test_BC_2_18_002_bacnet_json_canonical` | BC-2.18.002 | UDP, canonical_ports: [47808] — DF-CANONICAL-FRAME-HOLDOUT-001 |
| `test_BC_2_18_002_modbus_json_canonical` | BC-2.18.002 | TCP, canonical_ports: [502], supported: true — DF-CANONICAL-FRAME-HOLDOUT-001 |
| _(additional coverage tests)_ | BC-2.18.002 | JSON declaration-order, ARP canonical, filter composition |

</details>

---

## Demo Evidence

Visual recordings (VHS 0.11.0 — GIF + WebM) are present in the worktree at
`docs/demo-evidence/STORY-152/` (untracked, not in PR diff by design — 5 per-AC recordings × 3 files each + evidence-report.md).

| Recording | Evidences | Key observable |
|-----------|-----------|----------------|
| `AC-152-003-all-catalog` (.gif/.webm) | AC-152-003, BC-2.18.001 | 30-row table, all 6 columns, both footnotes visible |
| `AC-152-004a-supported` (.gif/.webm) | AC-152-003/004/005, EC-152-5 | 7 rows, port-102 footnote absent, L2 note present (ARP) |
| `AC-152-005-unsupported` (.gif/.webm) | AC-152-003/004/005/006 | 23 rows, GOOSE `0x88B8 (35000)`, POWERLINK `0x88AB (34987)`, port-102 footnote naming all 4 |
| `AC-152-007-json` (.gif/.webm) | AC-152-007, BC-2.18.002 | `{"protocols":[...]}` piped through `python3 -m json.tool`, valid structure |
| `AC-152-001-mutual-exclusion` (.gif/.webm) | AC-152-001, EC-152-2 | clap error on `--supported --unsupported`, non-zero exit |

---

## Holdout Evaluation

N/A — evaluated at wave gate. VP-041 regression/relevance reference (VP-041 harnesses anchored by STORY-151; this story consumes `supported_protocols()` / `unsupported_protocols()` which VP-041 validates).

---

## Adversarial Review

| Pass | Context | Findings | CRITICAL | HIGH | P0 | Status |
|------|---------|----------|----------|------|----|--------|
| 1 | Fresh context on d34a05f | F-2 (MEDIUM), F-1 (LOW), F-3 (LOW) | 0 | 0 | 0 | Resolved in branch |
| 2 | Fresh context on d34a05f | 0 | 0 | 0 | 0 | APPROVE |
| 3 | Fresh context on d34a05f | 0 | 0 | 0 | 0 | APPROVE |

**Convergence:** 3 consecutive clean passes on d34a05f — CONVERGED (DF-CONVERGENCE-BEFORE-MERGE-001 satisfied).

**Canonical-frame holdout (DF-CANONICAL-FRAME-HOLDOUT-001):** EtherType constants and port numbers independently verified:
- GOOSE: `0x88B8 = 35000` (IEC 61850-8-1 §4; IEEE RA "IEC GOOSE")
- POWERLINK: `0x88AB = 34987` (IEEE RA "ETHERNET Powerlink"; Wireshark `ETHERTYPE_EPL_V2`)
- BACnet/IP: UDP port `47808` / `0xBAC0` (ASHRAE 135-2016 Annex J §J.2.1)
- Modbus/TCP: port `502` (IANA/Modbus App Protocol v1.1b3 §4.3.1)

**Deferred LOW finding:** Global `--csv`/`--output-format` flags are no-ops when passed with `protocols` (they are parsed but ignored by `run_protocols()`). This is scoped-out per frozen BC-2.12.022 which models `--json` as a `bool` for the protocols path; the PATH component of `--json=<path>` is also not used (stdout-only by design per BC-2.18.002 PC-1). Backlogged as STORY-152-GLOBAL-FLAG-NOOP-001.

<details>
<summary><strong>Pass 1 Findings and Resolutions</strong></summary>

### Finding STORY-152-Pass-1-F-2 (MEDIUM): AC-152-002 over-claim on --json=path routing
- **Location:** STORY-152.md v1.4 AC-152-002
- **Category:** spec-fidelity
- **Problem:** AC-152-002 claimed `--json=<path>` performs file-path routing "at the call site … follows the same pattern as the existing run_analyze() JSON path." This was an over-claim; `protocols` emits to STDOUT only.
- **Resolution:** Story v1.5 corrected to: `protocols --json` always emits to STDOUT; PATH component of `--json=<path>` is NOT used; file-path routing is out of scope (unlike `analyze`).

### Finding STORY-152-Pass-1-F-3 (LOW): GOOSE derivation comment in implementation
- **Location:** `src/main.rs` (GOOSE supported-derivation comment)
- **Category:** code-quality
- **Resolution:** Comment clarified in d34a05f commit 1.

</details>

---

## Security Review

```mermaid
graph LR
    Critical["Critical: 0"]
    High["High: 0"]
    Medium["Medium: 0"]
    Low["Low: 0 (INFO: 2)"]

    style Critical fill:#90EE90
    style High fill:#90EE90
    style Medium fill:#90EE90
    style Low fill:#87CEEB
```

**Verdict: CLEAN** — CRITICAL 0 | HIGH 0 | MEDIUM 0 | LOW 0 | INFO 2

<details>
<summary><strong>Security Scan Details</strong></summary>

### CLI Argument Handling (CWE-88)
Not applicable. Three boolean flags (`--all/--supported/--unsupported`) with clap `conflicts_with_all` mutual exclusion. No string-valued arguments, no positional arguments, no process execution inside `run_protocols`.

### Output Rendering (CWE-134)
Not applicable. All `println!`/`format!` format strings are compile-time literals. Data values are typed macro arguments.

### JSON Serialization (CWE-116)
Not applicable. Output via `serde_json::json!` and `serde_json::to_string_pretty`. All values originate from `&'static str` catalog names, `u16` ports, `Option<u16>` ethertypes, and booleans. `serde_json` escapes all string content unconditionally. No user input flows into JSON output.

### Path Traversal (CWE-22)
Not applicable. `run_protocols` contains zero file I/O. The `Option<PathBuf>` inside `--json` is intentionally ignored — `cli.json.is_some()` is used as a pure boolean per frozen BC-2.18.002 PC-1.

### OS Command Injection (CWE-78)
Not applicable. No `Command::new`, `process::Command`, or shell invocation in new code.

### Resource Consumption (CWE-400)
Not applicable. `KNOWN_PROTOCOLS` is a compile-time `&'static [KnownProtocol]` constant with fixed length 30. Fully bounded at compile time.

### Supply Chain (OWASP A06)
No new dependencies. Pre-existing `serde_json` and `clap` unchanged.

### INFO Observations (non-blocking, non-security)

**INFO-001:** `is_protocol_supported` contains a hardcoded `if p.name == "ARP"` string literal at `src/main.rs`. This creates a maintenance coupling: if the catalog name ever changes, the branch silently stops matching. Not a security vulnerability; a `const ARP_NAME` shared reference would be cleaner. (Consistent with the same INFO observation from the PR reviewer's cosmetic finding.)

**INFO-002:** `is_protocol_supported` calls `supported_protocols()` per iteration inside the rendering loop — O(N²) at N=30 (900 comparisons). No practical impact; noted for completeness if catalog grows.

</details>

---

## Risk Assessment

### Blast Radius
- **Systems affected:** `src/cli.rs` (new enum variant — triggers exhaustive-match compiler errors in any file matching on `Commands`), `src/main.rs` (new dispatch arm and `run_protocols()` function), `tests/integration_tests.rs` (new file)
- **Exhaustive-match fallout:** `tests/cli_story_086_tests.rs` and `tests/cli_story_096_tests.rs` each received a `Commands::Protocols {..} => panic!()` arm. These are compile-required changes with no behavioral effect on those test suites — reviewers should NOT flag them as stray modifications.
- **User impact:** Additive only — new `protocols` subcommand. `analyze` subcommand behavior is unchanged (AC-152-008, `test_BC_2_12_022_analyze_unaffected`).
- **Data impact:** None. Read-only catalog lookup; no pcap, no state mutation.
- **Risk Level:** LOW

### Performance Impact
| Metric | Notes |
|--------|-------|
| Binary size | Negligible delta — static string table + JSON serialization |
| Runtime | Catalog lookup is O(30) static slice iteration; sub-millisecond |
| `analyze` path | Unchanged; no shared mutable state |

<details>
<summary><strong>Rollback Instructions</strong></summary>

**Immediate rollback:**
```bash
git revert <squash-commit-sha>
git push origin develop
```

After rollback, `wirerust protocols` will return `error: unrecognized subcommand 'protocols'`. `wirerust analyze` is unaffected.

</details>

### Feature Flags
None. The `protocols` subcommand is always available once this PR merges.

---

## Traceability

| BC | AC | Test | Status |
|----|-----|------|--------|
| BC-2.12.022 PC-1 | AC-152-001 | `test_BC_2_12_022_protocols_subcommand_exit_0` | PASS |
| BC-2.12.022 Invariant 2 | AC-152-001 | `test_BC_2_12_022_mutually_exclusive_flags_error` | PASS |
| BC-2.12.022 Invariant 3 | AC-152-001 | `test_BC_2_12_022_protocols_supported_filter` | PASS |
| BC-2.12.022 PC-2,3 | AC-152-002 | `test_BC_2_12_022_protocols_json_flag` | PASS |
| BC-2.12.022 Invariant 7 | AC-152-008 | `test_BC_2_12_022_analyze_unaffected` | PASS |
| BC-2.18.001 PC-1..3 | AC-152-003 | `test_BC_2_18_001_all_row_count` | PASS |
| BC-2.18.001 PC-6 | AC-152-004 | `test_BC_2_18_001_port102_footnote_names_all_four` | PASS |
| BC-2.18.001 PC-7 | AC-152-005 | `test_BC_2_18_001_l2_note_present` | PASS |
| BC-2.18.001 PC-5 (DF-CANONICAL-FRAME-HOLDOUT-001) | AC-152-006 | `test_BC_2_18_001_goose_ethertype_display` | PASS |
| BC-2.18.001 PC-5 (DF-CANONICAL-FRAME-HOLDOUT-001) | AC-152-006 | `test_BC_2_18_001_powerlink_ethertype_display` | PASS |
| BC-2.18.002 PC-3 | AC-152-007 | `test_BC_2_18_002_json_schema_valid` | PASS |
| BC-2.18.002 EC-003 (DF-CANONICAL-FRAME-HOLDOUT-001) | AC-152-007 | `test_BC_2_18_002_goose_json_canonical` | PASS |
| BC-2.18.002 (DF-CANONICAL-FRAME-HOLDOUT-001) | AC-152-007 | `test_BC_2_18_002_bacnet_json_canonical` | PASS |
| BC-2.18.002 (DF-CANONICAL-FRAME-HOLDOUT-001) | AC-152-007 | `test_BC_2_18_002_modbus_json_canonical` | PASS |

<details>
<summary><strong>Full VSDD Contract Chain</strong></summary>

```
BC-2.12.022 v1.0 -> AC-152-001/002 -> test_BC_2_12_022_* -> src/cli.rs:Protocols + src/main.rs:run_protocols() -> ADV-PASS-3-CLEAN
BC-2.18.001 v1.4 -> AC-152-003..006 -> test_BC_2_18_001_* -> src/main.rs:run_protocols(terminal) -> ADV-PASS-3-CLEAN
BC-2.18.002 v1.1 -> AC-152-007 -> test_BC_2_18_002_* -> src/main.rs:run_protocols(json) -> ADV-PASS-3-CLEAN
DF-CANONICAL-FRAME-HOLDOUT-001 -> 6 canonical-value tests -> GOOSE/POWERLINK/BACnet/Modbus values verified
ADR-012 Decision 3 -> Commands::Protocols is top-level variant (not analyze sub-subcommand)
ADR-012 Decision 7 -> JSON "category" values: "ICS" | "IT" only (no "L2")
```

</details>

---

## AI Pipeline Metadata

<details>
<summary><strong>Pipeline Details</strong></summary>

```yaml
ai-generated: true
pipeline-mode: feature
factory-version: "1.0.0-rc.21"
pipeline-stages:
  spec-crystallization: completed (v1.5 — F3 pass 13)
  story-decomposition: completed (STORY-152 v1.5)
  tdd-implementation: completed (4 commits on feature/story-152-protocols-subcommand)
  holdout-evaluation: N/A — evaluated at wave gate
  adversarial-review: completed (3 fresh-context passes, 0 HIGH/CRITICAL on d34a05f)
  formal-verification: skipped (CLI output path; pure catalog lookup)
  convergence: achieved (DF-CONVERGENCE-BEFORE-MERGE-001)
convergence-metrics:
  adversarial-passes: 3
  blocking-findings-at-convergence: 0
  canonical-frame-assertions: 6 (DF-CANONICAL-FRAME-HOLDOUT-001)
models-used:
  builder: claude-sonnet-4-6
  adversary: claude-sonnet-4-6 (fresh-context passes)
generated-at: "2026-07-03"
```

</details>

---

## Pre-Merge Checklist

- [ ] All CI status checks passing
- [x] 25/25 STORY-152 integration tests green
- [x] Full `cargo test --all-targets` regression clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] 3 adversarial passes converged (0 CRITICAL/HIGH on d34a05f)
- [x] DF-CANONICAL-FRAME-HOLDOUT-001 — canonical-frame values verified
- [x] Demo evidence present (5 VHS recordings, docs/demo-evidence/STORY-152/)
- [x] STORY-151 merged (catalog dependency)
- [x] Exhaustive-match arms in cli_story_086/096 explained in PR body
- [x] AI PR review (pr-reviewer) APPROVE — 0 blocking, 1 cosmetic (redundant ARP short-circuit)
- [x] Security review (security-reviewer) CLEAN — CRITICAL 0, HIGH 0, MEDIUM 0, LOW 0, INFO 2
- [ ] Human approval for squash merge
