### PR TITLE
chore: release v0.11.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,54 @@ Version numbers follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.11.2] - 2026-07-05
+
+### Added
+
+- **`protocols` subcommand — coverage catalog table + JSON output (STORY-152, PR #353).**
+  A new top-level subcommand `wirerust protocols` prints a formatted table of every protocol
+  in the `KNOWN_PROTOCOLS` catalog alongside its classification (analyzed, gap, or
+  unclassified) and associated CLI flag. Pass `--json [FILE]` to emit the catalog as
+  structured JSON suitable for downstream tooling. `--csv` is explicitly rejected with a
+  clear error. The subcommand is available without any input file.
+
+- **`analyze --coverage-gaps` flag — tri-state CoverageGapsSummary report (STORY-154,
+  PR #355).** When `--coverage-gaps` is passed to `wirerust analyze`, the analysis output
+  includes a `CoverageGapsSummary` section that classifies each protocol in the capture into
+  one of three states: `covered` (traffic observed and an analyzer was enabled), `gap`
+  (traffic observed but no analyzer enabled), or `unclassified` (traffic observed for a
+  protocol not in `KNOWN_PROTOCOLS`). The tri-state report is emitted in both terminal and
+  JSON output and is designed for gap-driven coverage workflows.
+
+- **`KNOWN_PROTOCOLS` catalog + partition functions — SS-18 (STORY-151, PR #351).**
+  A new static catalog `KNOWN_PROTOCOLS` enumerates all protocols wirerust is aware of,
+  together with their default port(s), CLI flag, and category. Partition functions
+  (`is_covered`, `is_gap`, `is_unclassified`) operate over capture traffic against the
+  catalog, forming the data backbone for the protocols subcommand and coverage-gaps report.
+  VP-041 formally verified via Kani.
+
+- **Dispatcher unclassified-protocol gap counters for TCP + UDP (STORY-153, PR #352).**
+  The `StreamDispatcher` now accumulates per-port counters for TCP and UDP traffic that
+  does not match any known protocol rule. These counters feed the `unclassified` bucket in
+  the `CoverageGapsSummary`, giving operators visibility into novel or undocumented
+  protocols in a capture.
+
+### Fixed
+
+- **`protocols --json=PATH` path argument honored; `--csv` rejected (PR #354, wave-68
+  F-W68-01).** The `protocols` subcommand now correctly writes JSON output to the path
+  supplied via `--json=PATH` (previously ignored, always writing to stdout). Passing `--csv`
+  to `protocols` now returns a clear validation error — CSV output is not defined for the
+  protocols catalog.
+
+### Security
+
+- **E-21 formal hardening — VP-041/042/043 proven (PR #357).** Kani proof harnesses
+  Sub-A through Sub-C verify partition-function totality (VP-041), coverage-gap
+  classification correctness (VP-042), and unclassified-counter monotonicity (VP-043).
+  A cargo-fuzz target and mutation-testing pass cover the new dispatcher counter paths,
+  achieving a 100 % effective kill rate on the E-21 detection delta.
+
 ## [0.11.1] - 2026-07-01
 
 ### Fixed
@@ -805,7 +853,8 @@ Downstream consumers of wirerust JSON or CSV output must update for this release
 - Output sanitization in the terminal reporter guards against C1 control bytes
   in packet-derived strings.
 
-[Unreleased]: https://github.com/Zious11/wirerust/compare/v0.11.1...HEAD
+[Unreleased]: https://github.com/Zious11/wirerust/compare/v0.11.2...HEAD
+[0.11.2]: https://github.com/Zious11/wirerust/compare/v0.11.1...v0.11.2
 [0.11.1]: https://github.com/Zious11/wirerust/compare/v0.11.0...v0.11.1
 [0.11.0]: https://github.com/Zious11/wirerust/compare/v0.10.0...v0.11.0
 [0.10.0]: https://github.com/Zious11/wirerust/compare/v0.9.4...v0.10.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ Version numbers follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.11.3] - 2026-07-06
+
+### Security
+
+- **Fixed unbounded per-flow memory growth in the DNP3 and EtherNet/IP (ENIP) analyzers
+  (issue #342, CWE-401/CWE-770).** The stream dispatcher now purges DNP3/ENIP per-flow
+  state on flow close (mirroring Modbus/HTTP/TLS), bounding analyzer memory to live flows;
+  closed-flow state is folded into aggregates so findings/summary output are unchanged.
+  (PR #362)
+
 ## [0.11.2] - 2026-07-05
 
 ### Added
@@ -853,7 +863,8 @@ Downstream consumers of wirerust JSON or CSV output must update for this release
 - Output sanitization in the terminal reporter guards against C1 control bytes
   in packet-derived strings.
 
-[Unreleased]: https://github.com/Zious11/wirerust/compare/v0.11.2...HEAD
+[Unreleased]: https://github.com/Zious11/wirerust/compare/v0.11.3...HEAD
+[0.11.3]: https://github.com/Zious11/wirerust/compare/v0.11.2...v0.11.3
 [0.11.2]: https://github.com/Zious11/wirerust/compare/v0.11.1...v0.11.2
 [0.11.1]: https://github.com/Zious11/wirerust/compare/v0.11.0...v0.11.1
 [0.11.0]: https://github.com/Zious11/wirerust/compare/v0.10.0...v0.11.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1637,7 +1637,7 @@ dependencies = [
 
 [[package]]
 name = "wirerust"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1637,7 +1637,7 @@ dependencies = [
 
 [[package]]
 name = "wirerust"
-version = "0.11.2"
+version = "0.11.3"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wirerust"
-version = "0.11.1"
+version = "0.11.2"
 edition = "2024"
 rust-version = "1.91"
 description = "Fast PCAP forensics and network triage CLI tool"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wirerust"
-version = "0.11.2"
+version = "0.11.3"
 edition = "2024"
 rust-version = "1.91"
 description = "Fast PCAP forensics and network triage CLI tool"

--- a/src/analyzer/dnp3.rs
+++ b/src/analyzer/dnp3.rs
@@ -307,6 +307,28 @@ pub struct Dnp3Analyzer {
     pub fn_code_counts: HashMap<u8, u64>,
     /// Accumulated findings — capped at MAX_FINDINGS (BC-2.15.022).
     pub all_findings: Vec<Finding>,
+
+    // ---- on_flow_close aggregate fields (issue #342 / SEC-006) ----
+    // These fields accumulate per-flow metrics from flows removed at close time
+    // so that summarize() can combine them with still-open flows.
+    /// Count of flows removed via on_flow_close (SEC-006 / issue #342).
+    ///
+    /// Added to `self.flows.len()` by `summarize()` to compute total `flows_analyzed`.
+    pub closed_flows_count: u64,
+    /// Aggregate `frame_count` from flows removed via on_flow_close.
+    ///
+    /// Added to the sum over `self.flows` by `summarize()` for `total_frames`.
+    pub total_frames_closed: u64,
+    /// Aggregate `parse_errors` from flows removed via on_flow_close.
+    ///
+    /// Added to the sum over `self.flows` by `summarize()` for `aggregate_parse_errors`.
+    pub parse_errors_closed: u64,
+    /// Per-closed-flow `(FlowKey, direct_operate_count)` entries.
+    ///
+    /// Accumulated by `on_flow_close`; merged with live `self.flows` entries by
+    /// `summarize()` to produce `control_operation_counts`.  Sorted by FlowKey at
+    /// summarize time, together with still-open flows, ensuring deterministic output.
+    pub closed_flow_direct_operates: Vec<(FlowKey, u32)>,
 }
 
 impl Dnp3Analyzer {
@@ -317,6 +339,38 @@ impl Dnp3Analyzer {
             direct_operate_threshold,
             fn_code_counts: HashMap::new(),
             all_findings: Vec::new(),
+            closed_flows_count: 0,
+            total_frames_closed: 0,
+            parse_errors_closed: 0,
+            closed_flow_direct_operates: Vec::new(),
+        }
+    }
+
+    /// Remove per-flow state for a closed flow and fold its metrics into aggregates.
+    ///
+    /// Mirrors `EnipAnalyzer::on_flow_close` (SEC-006 / issue #342 / BC-2.15.021).
+    ///
+    /// Postconditions:
+    /// 1. `self.flows.remove(&flow_key)` removes the `Dnp3FlowState` entry.
+    /// 2. `self.total_frames_closed += flow.frame_count`
+    /// 3. `self.parse_errors_closed += flow.parse_errors`
+    /// 4. `self.closed_flow_direct_operates.push((flow_key, flow.direct_operate_count))`
+    /// 5. `self.closed_flows_count += 1` when `HashMap::remove` returns `Some`.
+    /// 6. Unknown `flow_key` → no-op; no panic; aggregates NOT modified.
+    ///
+    /// Note: `self.fn_code_counts` is already a process-wide aggregate maintained
+    /// incrementally by `on_data` — it is NOT folded here (no double-counting risk).
+    /// Note: `self.all_findings` is unaffected — findings are emitted during `on_data`.
+    ///
+    /// # Traces
+    /// SEC-006; issue #342; BC-2.15.021; ADR-007 Decision 4.
+    pub fn on_flow_close(&mut self, flow_key: FlowKey) {
+        if let Some(flow) = self.flows.remove(&flow_key) {
+            self.total_frames_closed = self.total_frames_closed.saturating_add(flow.frame_count);
+            self.parse_errors_closed = self.parse_errors_closed.saturating_add(flow.parse_errors);
+            self.closed_flow_direct_operates
+                .push((flow_key, flow.direct_operate_count));
+            self.closed_flows_count = self.closed_flows_count.saturating_add(1);
         }
     }
 
@@ -1661,9 +1715,18 @@ impl Dnp3Analyzer {
     pub fn summarize(&self) -> AnalysisSummary {
         use std::collections::BTreeMap;
 
-        let flows_analyzed = self.flows.len() as u64;
-        let total_frames: u64 = self.flows.values().map(|f| f.frame_count).sum();
-        let aggregate_parse_errors: u64 = self.flows.values().map(|f| f.parse_errors).sum();
+        // SEC-006 / issue #342: combine closed-flow aggregates with still-open flows.
+        // closed_flows_count / total_frames_closed / parse_errors_closed are folded
+        // into these aggregates by on_flow_close; self.flows contains only live flows.
+        let flows_analyzed = self
+            .closed_flows_count
+            .saturating_add(self.flows.len() as u64);
+        let total_frames: u64 = self
+            .total_frames_closed
+            .saturating_add(self.flows.values().map(|f| f.frame_count).sum::<u64>());
+        let aggregate_parse_errors: u64 = self
+            .parse_errors_closed
+            .saturating_add(self.flows.values().map(|f| f.parse_errors).sum::<u64>());
 
         // BC-2.15.020 postcondition 1: function_code_distribution — only FCs with count > 0.
         // Keys are decimal strings of the FC byte (e.g. "5" for 0x05 DIRECT_OPERATE).
@@ -1675,16 +1738,23 @@ impl Dnp3Analyzer {
             .collect();
 
         // BC-2.15.020 postcondition 1: control_operation_counts — per-flow direct_operate_count.
-        // Keys are the flow index (0-based) as string. We sort entries by FlowKey
-        // (which derives Ord via lexicographic (lower_ip, lower_port, upper_ip, upper_port))
-        // BEFORE enumerate so that index→value is deterministic across process runs,
-        // independent of HashMap's per-process randomized iteration order.
-        let mut sorted_flows: Vec<(&FlowKey, &Dnp3FlowState)> = self.flows.iter().collect();
-        sorted_flows.sort_by_key(|(k, _)| *k);
-        let control_operation_counts: BTreeMap<String, u64> = sorted_flows
+        // Keys are the flow index (0-based) as string. We sort ALL entries (closed + open)
+        // by FlowKey (which derives Ord via lexicographic (lower_ip, lower_port, upper_ip,
+        // upper_port)) BEFORE enumerate so that index→value is deterministic across process
+        // runs, independent of HashMap's per-process randomized iteration order.
+        //
+        // SEC-006 / issue #342: merge closed-flow entries (from closed_flow_direct_operates)
+        // with still-open flows so that purging a flow at close time does not lose its
+        // direct_operate_count from the output.
+        let mut all_flow_entries: Vec<(FlowKey, u32)> = self.closed_flow_direct_operates.to_vec();
+        for (k, flow) in &self.flows {
+            all_flow_entries.push((k.clone(), flow.direct_operate_count));
+        }
+        all_flow_entries.sort_by_key(|(k, _)| k.clone());
+        let control_operation_counts: BTreeMap<String, u64> = all_flow_entries
             .iter()
             .enumerate()
-            .map(|(i, (_, flow))| (i.to_string(), flow.direct_operate_count as u64))
+            .map(|(i, (_, count))| (i.to_string(), *count as u64))
             .collect();
 
         let mut detail = BTreeMap::new();

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -446,14 +446,20 @@ impl StreamHandler for StreamDispatcher {
                 }
             }
             Some(DispatchTarget::Dnp3) => {
-                // BC-2.15.021: route on_flow_close to Dnp3Analyzer (no-op if disabled).
-                // Dnp3Analyzer does not implement StreamHandler; no forwarding needed.
+                // BC-2.15.021 / SEC-006 / issue #342: forward on_flow_close to Dnp3Analyzer
+                // to purge per-flow state and fold metrics into aggregates.
                 let _ = reason;
+                if let Some(ref mut dnp3) = self.dnp3 {
+                    dnp3.on_flow_close(flow_key.clone());
+                }
             }
             Some(DispatchTarget::Enip) => {
-                // BC-2.17.019: route on_flow_close to EnipAnalyzer (no-op if disabled).
-                // EnipAnalyzer does not implement StreamHandler; no forwarding needed.
+                // BC-2.17.019 / SEC-005 / issue #342: forward on_flow_close to EnipAnalyzer
+                // to purge per-flow state and fold metrics into aggregates.
                 let _ = reason;
+                if let Some(ref mut enip) = self.enip {
+                    enip.on_flow_close(flow_key.clone());
+                }
             }
             Some(DispatchTarget::None) | None => {
                 // BC-2.14.025 §P3: unclassified_flows guard extended with modbus + dnp3 + enip.

--- a/tests/issue_342_flow_leak_regression_tests.rs
+++ b/tests/issue_342_flow_leak_regression_tests.rs
@@ -1,0 +1,304 @@
+//! Regression tests for GitHub issue #342 — DNP3 / ENIP analyzers leak per-flow
+//! state because `StreamDispatcher::on_flow_close` stubs out the DNP3 and ENIP
+//! forwarding arms instead of calling the analyzers' own `on_flow_close` / purge
+//! logic.
+//!
+//! ## Bug summary (issue #342)
+//!
+//! Finding SEC-005 (ENIP): `StreamDispatcher::on_flow_close` — `Some(DispatchTarget::Enip)`
+//! arm — executes `let _ = reason;` and returns without calling
+//! `EnipAnalyzer::on_flow_close`.  `EnipAnalyzer::on_flow_close` exists and correctly
+//! removes the per-flow entry from `self.flows`, but it is never called via the
+//! dispatcher path, so `flows` grows without bound as flows are opened and closed.
+//!
+//! Finding SEC-006 (DNP3): `StreamDispatcher::on_flow_close` — `Some(DispatchTarget::Dnp3)`
+//! arm — executes `let _ = reason;` and returns without purging per-flow state.
+//! `Dnp3Analyzer` has no `on_flow_close` method at all; its `flows` HashMap is
+//! never pruned on flow close, growing without bound.
+//!
+//! ## TDD role
+//!
+//! These tests are written FIRST (Red Gate).  They MUST FAIL on the current
+//! (buggy) code and MUST PASS once the implementer:
+//!   1. Wires `EnipAnalyzer::on_flow_close` into the dispatcher's ENIP arm.
+//!   2. Adds `Dnp3Analyzer::on_flow_close` (purges the flow entry from `self.flows`)
+//!      and wires it into the dispatcher's DNP3 arm.
+//!
+//! ## Test seam
+//!
+//! Both `EnipAnalyzer::flows` and `Dnp3Analyzer::flows` are declared `pub`.
+//! No additional test-only accessor is required — `analyzer.flows.len()` is the
+//! observable.  This mirrors the existing ENIP unit-test convention used in
+//! `tests/enip_analyzer_tests.rs` (e.g. `analyzer.flows.contains_key(&key)` in
+//! `test_flow_close_removes_state`).
+
+#![allow(non_snake_case)]
+
+use std::net::IpAddr;
+
+use wirerust::analyzer::dnp3::Dnp3Analyzer;
+use wirerust::analyzer::enip::EnipAnalyzer;
+use wirerust::dispatcher::StreamDispatcher;
+use wirerust::reassembly::flow::FlowKey;
+use wirerust::reassembly::handler::{CloseReason, Direction, StreamHandler};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn flow_key(src_port: u16, dst_port: u16) -> FlowKey {
+    FlowKey::new(
+        "10.0.0.1".parse::<IpAddr>().unwrap(),
+        src_port,
+        "10.0.0.2".parse::<IpAddr>().unwrap(),
+        dst_port,
+    )
+}
+
+/// Minimal 24-byte EtherNet/IP frame: command = 0x0065 (RegisterSession), length = 0.
+///
+/// 24 bytes is the fixed ENIP encapsulation header size.  `length` field (bytes 2–3,
+/// LE) = 0 means no payload, which is the smallest valid RegisterSession request.
+/// `EnipAnalyzer::on_data` lazily creates a per-flow entry on the first call, so
+/// even a minimal frame is sufficient to seed `self.flows`.
+fn minimal_enip_frame() -> Vec<u8> {
+    let mut frame = vec![0u8; 24];
+    // command = 0x0065 (RegisterSession), LE
+    frame[0] = 0x65;
+    frame[1] = 0x00;
+    // length = 0 (no payload), LE — bytes 2–3 already 0
+    frame
+}
+
+/// Minimal DNP3 link-layer frame (10 bytes — header only, no user data).
+///
+/// Sync=0x05 0x64, LENGTH=0x05 (minimum), CONTROL=0x44 (DIR=0, PRM=1, FC=4
+/// UNCONFIRMED_USER_DATA), DEST=0x0003 (LE), SRC=0x0001 (LE), CRC=0x9A 0xC5.
+///
+/// `Dnp3Analyzer::on_data` creates a per-flow entry via `flows.entry(…).or_default()`
+/// on every call, so even a minimal (parse-failing) frame seeds `self.flows`.
+fn minimal_dnp3_frame() -> Vec<u8> {
+    vec![
+        0x05, 0x64, // sync
+        0x05, // LENGTH = 5
+        0x44, // CONTROL
+        0x03, 0x00, // DEST = 3, LE
+        0x01, 0x00, // SRC = 1, LE
+        0x9A, 0xC5, // CRC (pre-computed for these header bytes)
+    ]
+}
+
+// ---------------------------------------------------------------------------
+// SEC-005 (ENIP): dispatcher must forward on_flow_close to EnipAnalyzer
+// ---------------------------------------------------------------------------
+
+/// Regression test for SEC-005 / issue #342.
+///
+/// After opening an ENIP flow (feeding one ENIP frame through the dispatcher
+/// on port 44818) and then closing it via `dispatcher.on_flow_close`, the
+/// `EnipAnalyzer`'s live per-flow entry count must drop to 0.
+///
+/// FAILS on current code because `StreamDispatcher::on_flow_close` stubs the
+/// `DispatchTarget::Enip` arm (`let _ = reason; // no forwarding needed`),
+/// so `EnipAnalyzer::on_flow_close` is never called and `self.flows` retains
+/// the entry forever.
+///
+/// Traces: SEC-005, issue #342, BC-2.17.019 §P3 (implicit: flow-close forwarding
+/// must mirror the on_data forwarding path).
+#[test]
+fn test_SEC_005_enip_flow_state_purged_on_dispatcher_flow_close() {
+    let enip = EnipAnalyzer::new(50, 5);
+    let mut dispatcher = StreamDispatcher::new(None, None, None, None, Some(enip));
+
+    let fk = flow_key(60001, 44818); // port 44818 → DispatchTarget::Enip
+
+    // Feed one ENIP frame to create per-flow state in EnipAnalyzer::flows.
+    dispatcher.on_data(
+        &fk,
+        Direction::ClientToServer,
+        &minimal_enip_frame(),
+        0,
+        1_700_000_000,
+    );
+
+    // Pre-condition: the flow entry was created.
+    {
+        let enip = dispatcher
+            .enip_analyzer()
+            .expect("ENIP analyzer configured");
+        assert_eq!(
+            enip.flows.len(),
+            1,
+            "SEC-005 pre-condition: EnipAnalyzer must have 1 per-flow entry after on_data"
+        );
+    }
+
+    // Signal flow close through the dispatcher — this is the path under test.
+    // On current (buggy) code this is a no-op for the Enip arm; the implementer
+    // must wire it to EnipAnalyzer::on_flow_close.
+    dispatcher.on_flow_close(&fk, CloseReason::Fin);
+
+    // Post-condition: EnipAnalyzer must have 0 live per-flow entries.
+    // FAILS TODAY: flows.len() == 1 because on_flow_close was never forwarded.
+    let enip = dispatcher
+        .enip_analyzer()
+        .expect("ENIP analyzer configured");
+    assert_eq!(
+        enip.flows.len(),
+        0,
+        "SEC-005 / issue #342: EnipAnalyzer::flows must be empty after dispatcher \
+         on_flow_close — per-flow state was leaked (dispatcher never called \
+         EnipAnalyzer::on_flow_close)"
+    );
+}
+
+/// Bounded-retention invariant for ENIP (SEC-005 / issue #342).
+///
+/// Open and close N distinct ENIP flows sequentially through the dispatcher.
+/// After all flows are closed, the live per-flow entry count must be 0 (not N).
+///
+/// FAILS on current code because the dispatcher never forwards close events to
+/// EnipAnalyzer, so `flows` accumulates one entry per open flow and is never pruned.
+///
+/// N = 50: small enough to run quickly, large enough to prove unbounded growth.
+#[test]
+fn test_SEC_005_enip_flow_state_bounded_retention_after_n_flows() {
+    const N: u16 = 50;
+
+    let enip = EnipAnalyzer::new(50, 5);
+    let mut dispatcher = StreamDispatcher::new(None, None, None, None, Some(enip));
+
+    for i in 0..N {
+        let fk = flow_key(50000 + i, 44818);
+        dispatcher.on_data(
+            &fk,
+            Direction::ClientToServer,
+            &minimal_enip_frame(),
+            0,
+            1_700_000_000,
+        );
+        dispatcher.on_flow_close(&fk, CloseReason::Fin);
+    }
+
+    // Post-condition: retained flow-state count must be 0, not N.
+    // FAILS TODAY: flows.len() == 50 (each close was a no-op).
+    let enip = dispatcher
+        .enip_analyzer()
+        .expect("ENIP analyzer configured");
+    assert_eq!(
+        enip.flows.len(),
+        0,
+        "SEC-005 / issue #342: after opening+closing {N} ENIP flows, \
+         EnipAnalyzer::flows must contain 0 live entries (bounded retention). \
+         Non-zero count means per-flow state is leaking — dispatcher never \
+         forwarded on_flow_close to the analyzer."
+    );
+}
+
+// ---------------------------------------------------------------------------
+// SEC-006 (DNP3): dispatcher must purge Dnp3Analyzer per-flow state on close
+// ---------------------------------------------------------------------------
+
+/// Regression test for SEC-006 / issue #342.
+///
+/// After opening a DNP3 flow (feeding one DNP3 frame through the dispatcher
+/// on port 20000) and then closing it via `dispatcher.on_flow_close`, the
+/// `Dnp3Analyzer`'s live per-flow entry count must drop to 0.
+///
+/// FAILS on current code because `StreamDispatcher::on_flow_close` stubs the
+/// `DispatchTarget::Dnp3` arm (`let _ = reason; // no forwarding needed`), and
+/// `Dnp3Analyzer` has NO `on_flow_close` method at all — so `self.flows` is
+/// never pruned on flow close.
+///
+/// Traces: SEC-006, issue #342, BC-2.15.021 §P3 (implicit: flow-close forwarding
+/// must mirror the on_data forwarding path, matching Modbus behaviour).
+#[test]
+fn test_SEC_006_dnp3_flow_state_purged_on_dispatcher_flow_close() {
+    let dnp3 = Dnp3Analyzer::new(10);
+    let mut dispatcher = StreamDispatcher::new(None, None, None, Some(dnp3), None);
+
+    let fk = flow_key(60002, 20000); // port 20000 → DispatchTarget::Dnp3
+
+    // Feed one DNP3 frame to create per-flow state in Dnp3Analyzer::flows.
+    dispatcher.on_data(
+        &fk,
+        Direction::ClientToServer,
+        &minimal_dnp3_frame(),
+        0,
+        1_700_000_000,
+    );
+
+    // Pre-condition: the flow entry was created.
+    {
+        let dnp3 = dispatcher
+            .dnp3_analyzer()
+            .expect("DNP3 analyzer configured");
+        assert_eq!(
+            dnp3.flows.len(),
+            1,
+            "SEC-006 pre-condition: Dnp3Analyzer must have 1 per-flow entry after on_data"
+        );
+    }
+
+    // Signal flow close through the dispatcher — this is the path under test.
+    // On current (buggy) code this is a no-op for the Dnp3 arm; the implementer
+    // must add Dnp3Analyzer::on_flow_close and wire it here.
+    dispatcher.on_flow_close(&fk, CloseReason::Fin);
+
+    // Post-condition: Dnp3Analyzer must have 0 live per-flow entries.
+    // FAILS TODAY: flows.len() == 1 because on_flow_close was never forwarded and
+    // Dnp3Analyzer has no purge path at all.
+    let dnp3 = dispatcher
+        .dnp3_analyzer()
+        .expect("DNP3 analyzer configured");
+    assert_eq!(
+        dnp3.flows.len(),
+        0,
+        "SEC-006 / issue #342: Dnp3Analyzer::flows must be empty after dispatcher \
+         on_flow_close — per-flow state was leaked (dispatcher never purged the \
+         DNP3 flow entry; Dnp3Analyzer has no on_flow_close method)"
+    );
+}
+
+/// Bounded-retention invariant for DNP3 (SEC-006 / issue #342).
+///
+/// Open and close N distinct DNP3 flows sequentially through the dispatcher.
+/// After all flows are closed, the live per-flow entry count must be 0 (not N).
+///
+/// FAILS on current code because the dispatcher never purges DNP3 flow state
+/// and `Dnp3Analyzer` has no `on_flow_close` — so `flows` grows monotonically.
+///
+/// N = 50: matches the ENIP bounded-retention test for consistency.
+#[test]
+fn test_SEC_006_dnp3_flow_state_bounded_retention_after_n_flows() {
+    const N: u16 = 50;
+
+    let dnp3 = Dnp3Analyzer::new(10);
+    let mut dispatcher = StreamDispatcher::new(None, None, None, Some(dnp3), None);
+
+    for i in 0..N {
+        let fk = flow_key(50000 + i, 20000);
+        dispatcher.on_data(
+            &fk,
+            Direction::ClientToServer,
+            &minimal_dnp3_frame(),
+            0,
+            1_700_000_000,
+        );
+        dispatcher.on_flow_close(&fk, CloseReason::Fin);
+    }
+
+    // Post-condition: retained flow-state count must be 0, not N.
+    // FAILS TODAY: flows.len() == 50 (each close was a no-op; no purge path exists).
+    let dnp3 = dispatcher
+        .dnp3_analyzer()
+        .expect("DNP3 analyzer configured");
+    assert_eq!(
+        dnp3.flows.len(),
+        0,
+        "SEC-006 / issue #342: after opening+closing {N} DNP3 flows, \
+         Dnp3Analyzer::flows must contain 0 live entries (bounded retention). \
+         Non-zero count means per-flow state is leaking — dispatcher never \
+         purges DNP3 flow state and Dnp3Analyzer has no on_flow_close method."
+    );
+}


### PR DESCRIPTION
## Release v0.11.3

This is a gitflow `release/0.11.3` → `main` PR.

### What's in this release

**Security fix:** Unbounded per-flow memory growth in DNP3 and EtherNet/IP (ENIP) analyzers (issue #342, CWE-401/CWE-770).

The stream dispatcher now purges DNP3/ENIP per-flow state on flow close, mirroring the existing behaviour for Modbus/HTTP/TLS analyzers. Closed-flow state is folded into aggregates so findings and summary output are unchanged. Memory is now bounded to live flows only.

- PR: #362
- Severity: HIGH (unbounded heap growth under sustained traffic)
- Binary smoke test: 37/37 clean, #342 fix confirmed, RSS bounded
- All CI gates pass on `develop`

### Changes
- `Cargo.toml`: 0.11.2 → 0.11.3
- `Cargo.lock`: updated
- `CHANGELOG.md`: [0.11.3] section added
- `src/dispatcher.rs`: purge DNP3/ENIP state on `on_close`
- `src/analyzer/dnp3.rs`: flow-close hook added
- `tests/issue_342_flow_leak_regression_tests.rs`: regression tests

### Merge strategy
Merge commit (matches v0.11.1 and v0.11.2 precedent for release → main).