### PR TITLE
chore: release v0.11.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,43 @@ Version numbers follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.11.4] - 2026-07-06
+
+### Added
+
+- **Four observability counters surfacing previously silent analyzer state (PR #365, BC-INDEX
+  v2.18).** The silent-limit observability audit is now closed. Four counter fields are newly
+  emitted in `summarize()` JSON output and terminal output across four analyzers:
+
+  - **`bindings_evicted`** (ARP summary) — cumulative count of LRU-evicted ARP binding-table
+    entries since analysis start. The ARP analyzer's binding table is capped at 65 536 entries;
+    this counter exposes how many entries have been silently dropped when the cap is reached.
+    ARP summary key count: 11 → 13 (also adds `storm_counters_evicted`).
+
+  - **`storm_counters_evicted`** (ARP summary) — cumulative count of LRU-evicted ARP
+    storm-counter entries since analysis start. The storm-counter LRU table is capped at 4 096
+    entries; this counter exposes how many entries have been silently dropped.
+
+  - **`dropped_transactions`** (Modbus summary) — cumulative count of Modbus pending-transaction
+    map entries dropped when the per-flow cap is reached. Previously the cap silently discarded
+    new pending entries; the counter makes the drop event visible in output. Modbus summary key
+    count: 6 → 7.
+
+  - **`dropped_map_entries`** (TLS summary and HTTP summary) — cumulative count of entries
+    dropped from the TLS SNI/fingerprint maps and the HTTP host/path maps when per-map caps are
+    reached. Previously cap-triggered drops were silent; the counter makes them visible. HTTP
+    summary key count: 9 → 10; TLS summary gains one additional field.
+
+### Tests / Internal
+
+- **Negative regression tests for eviction/drop no-Finding invariants + HTTP existing-key
+  AC-008 (PR #366).** Test module `bc_silent_resource_caps_tests` adds negative regression
+  coverage asserting that ARP binding-table and storm-counter eviction, and Modbus
+  dropped-transaction-map overflows, do not emit spurious Findings — the counters increment
+  but the finding list remains clean. HTTP AC-008 coverage (existing-key update does not
+  create a duplicate map entry) is also covered. Includes a cosmetic refactor of the ARP
+  analyzer's `insert_binding_lru` path for clarity.
+
 ## [0.11.3] - 2026-07-06
 
 ### Security
@@ -863,7 +900,8 @@ Downstream consumers of wirerust JSON or CSV output must update for this release
 - Output sanitization in the terminal reporter guards against C1 control bytes
   in packet-derived strings.
 
-[Unreleased]: https://github.com/Zious11/wirerust/compare/v0.11.3...HEAD
+[Unreleased]: https://github.com/Zious11/wirerust/compare/v0.11.4...HEAD
+[0.11.4]: https://github.com/Zious11/wirerust/compare/v0.11.3...v0.11.4
 [0.11.3]: https://github.com/Zious11/wirerust/compare/v0.11.2...v0.11.3
 [0.11.2]: https://github.com/Zious11/wirerust/compare/v0.11.1...v0.11.2
 [0.11.1]: https://github.com/Zious11/wirerust/compare/v0.11.0...v0.11.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ Version numbers follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.11.3] - 2026-07-06
+
+### Security
+
+- **Fixed unbounded per-flow memory growth in the DNP3 and EtherNet/IP (ENIP) analyzers
+  (issue #342, CWE-401/CWE-770).** The stream dispatcher now purges DNP3/ENIP per-flow
+  state on flow close (mirroring Modbus/HTTP/TLS), bounding analyzer memory to live flows;
+  closed-flow state is folded into aggregates so findings/summary output are unchanged.
+  (PR #362)
+
 ## [0.11.2] - 2026-07-05
 
 ### Added
@@ -853,7 +863,8 @@ Downstream consumers of wirerust JSON or CSV output must update for this release
 - Output sanitization in the terminal reporter guards against C1 control bytes
   in packet-derived strings.
 
-[Unreleased]: https://github.com/Zious11/wirerust/compare/v0.11.2...HEAD
+[Unreleased]: https://github.com/Zious11/wirerust/compare/v0.11.3...HEAD
+[0.11.3]: https://github.com/Zious11/wirerust/compare/v0.11.2...v0.11.3
 [0.11.2]: https://github.com/Zious11/wirerust/compare/v0.11.1...v0.11.2
 [0.11.1]: https://github.com/Zious11/wirerust/compare/v0.11.0...v0.11.1
 [0.11.0]: https://github.com/Zious11/wirerust/compare/v0.10.0...v0.11.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1637,7 +1637,7 @@ dependencies = [
 
 [[package]]
 name = "wirerust"
-version = "0.11.3"
+version = "0.11.4"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1637,7 +1637,7 @@ dependencies = [
 
 [[package]]
 name = "wirerust"
-version = "0.11.2"
+version = "0.11.3"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wirerust"
-version = "0.11.3"
+version = "0.11.4"
 edition = "2024"
 rust-version = "1.91"
 description = "Fast PCAP forensics and network triage CLI tool"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wirerust"
-version = "0.11.2"
+version = "0.11.3"
 edition = "2024"
 rust-version = "1.91"
 description = "Fast PCAP forensics and network triage CLI tool"

--- a/src/analyzer/arp.rs
+++ b/src/analyzer/arp.rs
@@ -382,6 +382,16 @@ pub struct ArpAnalyzer {
     pub malformed_findings: u64,
     /// Total malformed ARP frames counted (always incremented, even without `--arp`).
     pub malformed_frames: u64,
+    /// Count of LRU evictions from the binding table (MAX_ARP_BINDINGS=65_536).
+    ///
+    /// Incremented each time `insert_binding_lru` evicts an entry (new IP at cap).
+    /// Monotonic, saturating. BC-2.16.008 v2.0 / BC-2.16.010 v1.9.
+    pub bindings_evicted: u64,
+    /// Count of LRU evictions from the storm-counter table (MAX_STORM_COUNTERS=4_096).
+    ///
+    /// Incremented each time `insert_storm_counter_lru` evicts an entry (new MAC at cap).
+    /// Monotonic, saturating. BC-2.16.008 v2.0 / BC-2.16.010 v1.9.
+    pub storm_counters_evicted: u64,
 }
 
 impl ArpAnalyzer {
@@ -414,6 +424,8 @@ impl ArpAnalyzer {
             mismatch_findings: 0,
             malformed_findings: 0,
             malformed_frames: 0,
+            bindings_evicted: 0,
+            storm_counters_evicted: 0,
         }
     }
 
@@ -600,6 +612,9 @@ impl ArpAnalyzer {
                 // New IP via GARP (no conflict means either no entry or same MAC).
                 // Insert/update binding and set last_seen_ts.
                 if !self.bindings.contains_key(&sender_ip) {
+                    if self.bindings.len() >= MAX_ARP_BINDINGS {
+                        self.bindings_evicted = self.bindings_evicted.saturating_add(1);
+                    }
                     insert_binding_lru(&mut self.bindings, sender_ip, sender_mac, MAX_ARP_BINDINGS);
                 }
                 if let Some(entry) = self.bindings.get_mut(&sender_ip) {
@@ -644,6 +659,9 @@ impl ArpAnalyzer {
             }
         } else {
             // New IP: call insert_binding_lru (handles eviction), then set last_seen_ts.
+            if self.bindings.len() >= MAX_ARP_BINDINGS {
+                self.bindings_evicted = self.bindings_evicted.saturating_add(1);
+            }
             insert_binding_lru(&mut self.bindings, sender_ip, sender_mac, MAX_ARP_BINDINGS);
             if let Some(entry) = self.bindings.get_mut(&sender_ip) {
                 entry.last_seen_ts = timestamp_secs;
@@ -766,6 +784,14 @@ impl ArpAnalyzer {
         detail.insert(
             "malformed_frames".to_string(),
             serde_json::json!(self.malformed_frames),
+        );
+        detail.insert(
+            "bindings_evicted".to_string(),
+            serde_json::json!(self.bindings_evicted),
+        );
+        detail.insert(
+            "storm_counters_evicted".to_string(),
+            serde_json::json!(self.storm_counters_evicted),
         );
 
         AnalysisSummary {
@@ -941,6 +967,7 @@ impl ArpAnalyzer {
             if let Some(k) = oldest_mac {
                 self.storm_counters.remove(&k);
             }
+            self.storm_counters_evicted = self.storm_counters_evicted.saturating_add(1);
         }
         self.storm_counters.insert(
             source_mac,
@@ -2024,16 +2051,21 @@ mod tests {
         let analyzer = ArpAnalyzer::new_for_test();
         let summary = analyzer.summarize();
 
-        // All eleven canonical keys must be present and equal 0 (BC-2.16.010 EC-001)
+        // All thirteen canonical keys must be present and equal 0 (BC-2.16.010 v1.9 EC-001).
+        // Updated 11→13 for BC-2.16.008 v2.0 / BC-2.16.010 v1.9: adds `bindings_evicted`
+        // and `storm_counters_evicted` (silent-limit audit, surface-silent-resource-caps).
+        // RED GATE: these two new keys are absent from the current summarize() implementation.
         const EXPECTED_KEYS: &[&str] = &[
             "frames_analyzed",
             "request_count",
             "reply_count",
             "other_opcode_count",
             "bindings_tracked",
+            "bindings_evicted",
             "spoof_findings",
             "garp_findings",
             "storm_findings",
+            "storm_counters_evicted",
             "mismatch_findings",
             "malformed_findings",
             "malformed_frames",
@@ -2055,23 +2087,29 @@ mod tests {
         }
     }
 
-    /// AC-013b (BC-2.16.010 Invariant 1): exactly eleven keys in detail — no extras, no fewer.
+    /// AC-013b (BC-2.16.010 v1.9 Invariant 1): exactly thirteen keys in detail — no extras, no fewer.
+    ///
+    /// Updated 11→13 for BC-2.16.008 v2.0 / BC-2.16.010 v1.9: adds `bindings_evicted`
+    /// and `storm_counters_evicted` (silent-limit audit, surface-silent-resource-caps).
+    /// RED GATE: these two new keys are absent from the current summarize() implementation.
     #[test]
     #[allow(non_snake_case)]
     fn test_BC_2_16_010_summarize_key_names_exact() {
         let analyzer = ArpAnalyzer::new_for_test();
         let summary = analyzer.summarize();
 
-        // Exact eleven key names per BC-2.16.010 PC1 (authority over any story body wording)
+        // Exact thirteen key names per BC-2.16.010 v1.9 PC1.
         let mut expected: std::collections::BTreeSet<&str> = [
             "frames_analyzed",
             "request_count",
             "reply_count",
             "other_opcode_count",
             "bindings_tracked",
+            "bindings_evicted",
             "spoof_findings",
             "garp_findings",
             "storm_findings",
+            "storm_counters_evicted",
             "mismatch_findings",
             "malformed_findings",
             "malformed_frames",
@@ -2085,8 +2123,8 @@ mod tests {
 
         assert_eq!(
             actual.len(),
-            11,
-            "AC-013 / BC-2.16.010 Invariant 1: summarize() must return exactly 11 \
+            13,
+            "AC-013 / BC-2.16.010 v1.9 Invariant 1: summarize() must return exactly 13 \
              keys. Got {}. Keys present: {actual:?}",
             actual.len()
         );
@@ -2094,7 +2132,7 @@ mod tests {
         for key in &expected {
             assert!(
                 actual.contains(key),
-                "AC-013 / BC-2.16.010 PC1: required key '{key}' is MISSING from summarize() \
+                "AC-013 / BC-2.16.010 v1.9 PC1: required key '{key}' is MISSING from summarize() \
                  output. Actual keys: {actual:?}"
             );
         }
@@ -2115,9 +2153,11 @@ mod tests {
                     "reply_count",
                     "other_opcode_count",
                     "bindings_tracked",
+                    "bindings_evicted",
                     "spoof_findings",
                     "garp_findings",
                     "storm_findings",
+                    "storm_counters_evicted",
                     "mismatch_findings",
                     "malformed_findings",
                     "malformed_frames",
@@ -2127,7 +2167,7 @@ mod tests {
             .collect();
         assert!(
             extras.is_empty(),
-            "AC-013 / BC-2.16.010 Invariant 1: summarize() must contain EXACTLY 11 keys. \
+            "AC-013 / BC-2.16.010 v1.9 Invariant 1: summarize() must contain EXACTLY 13 keys. \
              Unexpected extra keys found: {extras:?}"
         );
     }

--- a/src/analyzer/arp.rs
+++ b/src/analyzer/arp.rs
@@ -168,6 +168,10 @@ pub fn is_gratuitous_arp(frame: &ArpFrame) -> bool {
 /// the entry with the minimum `last_seen_ts` before inserting. If `ip` is
 /// already present, the entry is updated in-place (last-write-wins per BC-2.16.005).
 ///
+/// Returns `true` when an LRU eviction occurred (new IP at cap), `false`
+/// otherwise (update-in-place or insert below cap). Callers that track an
+/// eviction counter should increment it when this returns `true`.
+///
 /// **Architecture Compliance Rule 1:** This function has NO `ts` parameter.
 /// `last_seen_ts` is written into the entry by `process_arp` before this
 /// function is called; the eviction scan reads it from the stored entries.
@@ -178,16 +182,16 @@ pub fn insert_binding_lru(
     ip: [u8; 4],
     mac: [u8; 6],
     cap: usize,
-) {
+) -> bool {
     if bindings.contains_key(&ip) {
         // Update existing entry in-place (last-write-wins, last_seen_ts already set by caller).
         if let Some(entry) = bindings.get_mut(&ip) {
             entry.mac = mac;
         }
-        return;
+        return false;
     }
     // New IP — evict the entry with the minimum last_seen_ts if at capacity.
-    if bindings.len() >= cap {
+    let evicted = if bindings.len() >= cap {
         let oldest_ip = bindings
             .iter()
             .min_by_key(|(_, e)| e.last_seen_ts)
@@ -195,7 +199,10 @@ pub fn insert_binding_lru(
         if let Some(k) = oldest_ip {
             bindings.remove(&k);
         }
-    }
+        true
+    } else {
+        false
+    };
     bindings.insert(
         ip,
         BindingEntry {
@@ -206,6 +213,7 @@ pub fn insert_binding_lru(
             last_seen_ts: 0,
         },
     );
+    evicted
 }
 
 /// BTreeMap surrogate of `insert_binding_lru` for VP-024 Sub-D Kani harness.
@@ -611,11 +619,15 @@ impl ArpAnalyzer {
 
                 // New IP via GARP (no conflict means either no entry or same MAC).
                 // Insert/update binding and set last_seen_ts.
-                if !self.bindings.contains_key(&sender_ip) {
-                    if self.bindings.len() >= MAX_ARP_BINDINGS {
-                        self.bindings_evicted = self.bindings_evicted.saturating_add(1);
-                    }
-                    insert_binding_lru(&mut self.bindings, sender_ip, sender_mac, MAX_ARP_BINDINGS);
+                if !self.bindings.contains_key(&sender_ip)
+                    && insert_binding_lru(
+                        &mut self.bindings,
+                        sender_ip,
+                        sender_mac,
+                        MAX_ARP_BINDINGS,
+                    )
+                {
+                    self.bindings_evicted = self.bindings_evicted.saturating_add(1);
                 }
                 if let Some(entry) = self.bindings.get_mut(&sender_ip) {
                     entry.last_seen_ts = timestamp_secs;
@@ -659,10 +671,9 @@ impl ArpAnalyzer {
             }
         } else {
             // New IP: call insert_binding_lru (handles eviction), then set last_seen_ts.
-            if self.bindings.len() >= MAX_ARP_BINDINGS {
+            if insert_binding_lru(&mut self.bindings, sender_ip, sender_mac, MAX_ARP_BINDINGS) {
                 self.bindings_evicted = self.bindings_evicted.saturating_add(1);
             }
-            insert_binding_lru(&mut self.bindings, sender_ip, sender_mac, MAX_ARP_BINDINGS);
             if let Some(entry) = self.bindings.get_mut(&sender_ip) {
                 entry.last_seen_ts = timestamp_secs;
             }

--- a/src/analyzer/http.rs
+++ b/src/analyzer/http.rs
@@ -131,6 +131,11 @@ pub struct HttpAnalyzer {
     parse_errors: u64,
     non_http_flows: u64,
     poisoned_bytes_skipped: u64,
+    /// Count of new-key insertions refused across all distribution maps (methods, hosts,
+    /// user_agents) because the map was at MAX_MAP_ENTRIES=50_000. Monotonic, saturating.
+    /// Existing-key hits do NOT increment this counter (BC-2.06.024 AC-008).
+    /// BC-2.06.023 v1.6 / BC-2.06.024 v1.4.
+    dropped_map_entries: u64,
 }
 
 impl Default for HttpAnalyzer {
@@ -153,6 +158,7 @@ impl HttpAnalyzer {
             parse_errors: 0,
             non_http_flows: 0,
             poisoned_bytes_skipped: 0,
+            dropped_map_entries: 0,
         }
     }
 
@@ -391,17 +397,24 @@ impl HttpAnalyzer {
                         || self.methods.contains_key(&parsed.method)
                     {
                         *self.methods.entry(parsed.method.clone()).or_insert(0) += 1;
+                    } else {
+                        self.dropped_map_entries = self.dropped_map_entries.saturating_add(1);
                     }
-                    if let Some(ref h) = parsed.host
-                        && (self.hosts.len() < MAX_MAP_ENTRIES || self.hosts.contains_key(h))
-                    {
-                        *self.hosts.entry(h.clone()).or_insert(0) += 1;
+                    if let Some(ref h) = parsed.host {
+                        if self.hosts.len() < MAX_MAP_ENTRIES || self.hosts.contains_key(h) {
+                            *self.hosts.entry(h.clone()).or_insert(0) += 1;
+                        } else {
+                            self.dropped_map_entries = self.dropped_map_entries.saturating_add(1);
+                        }
                     }
-                    if let Some(ref ua) = parsed.user_agent
-                        && (self.user_agents.len() < MAX_MAP_ENTRIES
-                            || self.user_agents.contains_key(ua))
-                    {
-                        *self.user_agents.entry(ua.clone()).or_insert(0) += 1;
+                    if let Some(ref ua) = parsed.user_agent {
+                        if self.user_agents.len() < MAX_MAP_ENTRIES
+                            || self.user_agents.contains_key(ua)
+                        {
+                            *self.user_agents.entry(ua.clone()).or_insert(0) += 1;
+                        } else {
+                            self.dropped_map_entries = self.dropped_map_entries.saturating_add(1);
+                        }
                     }
                     if self.uris.len() < MAX_URIS {
                         self.uris.push(parsed.uri.clone());
@@ -624,6 +637,12 @@ impl StreamAnalyzer for HttpAnalyzer {
         detail.insert(
             "poisoned_bytes_skipped".to_string(),
             serde_json::json!(self.poisoned_bytes_skipped),
+        );
+        // BC-2.06.023 v1.6: surface refused new-key insertions across all distribution maps.
+        // Key ALWAYS present even when count==0 (silent-limit audit).
+        detail.insert(
+            "dropped_map_entries".to_string(),
+            serde_json::json!(self.dropped_map_entries),
         );
 
         AnalysisSummary {

--- a/src/analyzer/modbus.rs
+++ b/src/analyzer/modbus.rs
@@ -285,6 +285,10 @@ pub struct ModbusAnalyzer {
     pub all_findings: Vec<Finding>,
     /// Count of findings silently dropped after MAX_FINDINGS cap was reached (BC-2.14.022).
     pub dropped_findings: u64,
+    /// Count of new unique (txn_id, unit_id) requests silently dropped because the pending
+    /// table was at MAX_PENDING_TRANSACTIONS=256 (drop-not-evict per BC-2.14.012).
+    /// Monotonic, saturating. BC-2.14.012 v1.1 / BC-2.14.021 v1.2.
+    pub dropped_transactions: u64,
     /// Monotonic counter: incremented once per flow on first PDU insertion (BC-2.14.021).
     /// NOT derived from a flow map length (flows removed on close would give wrong count).
     pub total_flows_analyzed: u64,
@@ -307,6 +311,7 @@ impl ModbusAnalyzer {
             fn_code_counts: HashMap::new(),
             all_findings: Vec::new(),
             dropped_findings: 0,
+            dropped_transactions: 0,
             total_flows_analyzed: 0,
             flows: HashMap::new(),
         }
@@ -500,6 +505,13 @@ impl ModbusAnalyzer {
                 // REQUEST path
                 // --- Insert into pending table (BC-2.14.009) ---
                 if fc_class != FunctionCodeClass::Exception {
+                    let key = (header.transaction_id, header.unit_id);
+                    if !flow.pending.contains_key(&key)
+                        && flow.pending.len() >= MAX_PENDING_TRANSACTIONS
+                    {
+                        // New unique key dropped at cap (drop-not-evict, BC-2.14.012).
+                        self.dropped_transactions = self.dropped_transactions.saturating_add(1);
+                    }
                     let overwrite =
                         flow.insert_request(header.transaction_id, header.unit_id, fc, timestamp);
                     if overwrite.is_some() {
@@ -960,6 +972,10 @@ impl ModbusAnalyzer {
         detail.insert(
             "dropped_findings".to_string(),
             serde_json::json!(self.dropped_findings),
+        );
+        detail.insert(
+            "dropped_transactions".to_string(),
+            serde_json::json!(self.dropped_transactions),
         );
 
         // function_code_distribution: "0x{FC:02X}" → count (zero-count suppressed).

--- a/src/analyzer/tls.rs
+++ b/src/analyzer/tls.rs
@@ -357,6 +357,11 @@ pub struct TlsAnalyzer {
     /// aggregate counter pattern.
     /// AC-146-001 / BC-2.07.043 Invariants 1–3.
     buffer_saturation_drops: u64,
+    /// Count of new-key insertions refused across all distribution maps
+    /// (sni_counts, ja3_counts, ja3s_counts, cipher_counts, version_counts) because the
+    /// map was at MAX_MAP_ENTRIES=50_000. Monotonic, saturating.
+    /// BC-2.07.031 v1.5 / BC-2.07.028 v1.4.
+    dropped_map_entries: u64,
     all_findings: Vec<Finding>,
 }
 
@@ -380,6 +385,7 @@ impl TlsAnalyzer {
             truncated_records: 0,
             handshake_reassembly_overflows: 0,
             buffer_saturation_drops: 0,
+            dropped_map_entries: 0,
             all_findings: Vec::new(),
         }
     }
@@ -418,9 +424,16 @@ impl TlsAnalyzer {
 
     // ── internal helpers ──────────────────────────────────────────────────
 
-    fn increment<K: Eq + std::hash::Hash>(map: &mut HashMap<K, u64>, key: K, limit: usize) {
+    fn increment<K: Eq + std::hash::Hash>(
+        map: &mut HashMap<K, u64>,
+        key: K,
+        limit: usize,
+        dropped: &mut u64,
+    ) {
         if map.len() < limit || map.contains_key(&key) {
             *map.entry(key).or_insert(0) += 1;
+        } else {
+            *dropped = dropped.saturating_add(1);
         }
     }
 
@@ -437,7 +450,12 @@ impl TlsAnalyzer {
         self.handshakes_seen += 1;
 
         let version = ch.version.0;
-        Self::increment(&mut self.version_counts, version, MAX_MAP_ENTRIES);
+        Self::increment(
+            &mut self.version_counts,
+            version,
+            MAX_MAP_ENTRIES,
+            &mut self.dropped_map_entries,
+        );
 
         // Parse extensions (compute partial JA3 with empty fields on failure)
         let exts: Vec<TlsExtension<'_>> = match ch.ext {
@@ -466,7 +484,12 @@ impl TlsAnalyzer {
                 SniValue::NonAsciiUtf8 { hostname, .. } => hostname.clone(),
                 SniValue::NonUtf8 { hex, .. } => format!("<non-utf8:{hex}>"),
             };
-            Self::increment(&mut self.sni_counts, key, MAX_MAP_ENTRIES);
+            Self::increment(
+                &mut self.sni_counts,
+                key,
+                MAX_MAP_ENTRIES,
+                &mut self.dropped_map_entries,
+            );
 
             // SNI encoding violations (control chars, non-ASCII UTF-8,
             // non-UTF-8 bytes) map to MITRE T1027 (Obfuscated Files or
@@ -559,7 +582,12 @@ impl TlsAnalyzer {
 
         // JA3
         let (ja3_hash, _ja3_str) = compute_ja3(version, &ch.ciphers, &exts);
-        Self::increment(&mut self.ja3_counts, ja3_hash, MAX_MAP_ENTRIES);
+        Self::increment(
+            &mut self.ja3_counts,
+            ja3_hash,
+            MAX_MAP_ENTRIES,
+            &mut self.dropped_map_entries,
+        );
 
         // Weak cipher detection
         //
@@ -632,7 +660,12 @@ impl TlsAnalyzer {
         last_ts: u32,
     ) {
         let version = sh.version.0;
-        Self::increment(&mut self.version_counts, version, MAX_MAP_ENTRIES);
+        Self::increment(
+            &mut self.version_counts,
+            version,
+            MAX_MAP_ENTRIES,
+            &mut self.dropped_map_entries,
+        );
 
         let exts: Vec<TlsExtension<'_>> = match sh.ext {
             Some(raw) => match parse_tls_extensions(raw) {
@@ -647,11 +680,21 @@ impl TlsAnalyzer {
 
         // JA3S
         let ja3s_hash = compute_ja3s(version, sh.cipher, &exts);
-        Self::increment(&mut self.ja3s_counts, ja3s_hash, MAX_MAP_ENTRIES);
+        Self::increment(
+            &mut self.ja3s_counts,
+            ja3s_hash,
+            MAX_MAP_ENTRIES,
+            &mut self.dropped_map_entries,
+        );
 
         // Cipher tracking
         let name = cipher_name(sh.cipher);
-        Self::increment(&mut self.cipher_counts, name.clone(), MAX_MAP_ENTRIES);
+        Self::increment(
+            &mut self.cipher_counts,
+            name.clone(),
+            MAX_MAP_ENTRIES,
+            &mut self.dropped_map_entries,
+        );
 
         if is_weak_server_cipher(sh.cipher) {
             self.all_findings.push(Finding {
@@ -1236,6 +1279,12 @@ impl StreamAnalyzer for TlsAnalyzer {
         detail.insert(
             "buffer_saturation_drops".to_string(),
             serde_json::json!(self.buffer_saturation_drops),
+        );
+        // BC-2.07.031 v1.5: surface refused new-key insertions across all distribution maps.
+        // Key ALWAYS present even when count==0 (silent-limit audit).
+        detail.insert(
+            "dropped_map_entries".to_string(),
+            serde_json::json!(self.dropped_map_entries),
         );
 
         AnalysisSummary {

--- a/tests/bc_2_16_story113_arp_tests.rs
+++ b/tests/bc_2_16_story113_arp_tests.rs
@@ -152,13 +152,16 @@ mod story_113_cli {
                  the \"analyzers\" array when --arp flag is active. No 'ARP' entry found.",
             );
 
-        // BC-2.16.010 PC1: the ARP summary must contain all eleven canonical keys.
+        // BC-2.16.010 v1.9 PC1: the ARP summary must contain all thirteen canonical keys.
+        // Updated 11→13 for BC-2.16.008 v2.0 / BC-2.16.010 v1.9: adds `bindings_evicted`
+        // and `storm_counters_evicted` (silent-limit audit, surface-silent-resource-caps).
+        // RED GATE: these two new keys are absent from the current summarize() implementation.
         let detail = arp_summary
             .get("detail")
             .and_then(|d| d.as_object())
             .expect(
-                "AC-016 / BC-2.16.010 PC1: ARP AnalysisSummary must have a 'detail' \
-                 object containing the eleven canonical keys.",
+                "AC-016 / BC-2.16.010 v1.9 PC1: ARP AnalysisSummary must have a 'detail' \
+                 object containing the thirteen canonical keys.",
             );
 
         const REQUIRED_KEYS: &[&str] = &[
@@ -167,9 +170,11 @@ mod story_113_cli {
             "reply_count",
             "other_opcode_count",
             "bindings_tracked",
+            "bindings_evicted",
             "spoof_findings",
             "garp_findings",
             "storm_findings",
+            "storm_counters_evicted",
             "mismatch_findings",
             "malformed_findings",
             "malformed_frames",
@@ -178,7 +183,7 @@ mod story_113_cli {
         for key in REQUIRED_KEYS {
             assert!(
                 detail.contains_key(*key),
-                "AC-016 / BC-2.16.010 PC1: ARP summary 'detail' must contain key '{}'. \
+                "AC-016 / BC-2.16.010 v1.9 PC1: ARP summary 'detail' must contain key '{}'. \
                  Keys present: {:?}",
                 key,
                 detail.keys().collect::<Vec<_>>()
@@ -187,9 +192,9 @@ mod story_113_cli {
 
         assert_eq!(
             detail.len(),
-            11,
-            "AC-016 / BC-2.16.010 Invariant 1: ARP summary 'detail' must contain \
-             exactly 11 keys. Got {}. Keys: {:?}",
+            13,
+            "AC-016 / BC-2.16.010 v1.9 Invariant 1: ARP summary 'detail' must contain \
+             exactly 13 keys. Got {}. Keys: {:?}",
             detail.len(),
             detail.keys().collect::<Vec<_>>()
         );

--- a/tests/bc_silent_resource_caps_tests.rs
+++ b/tests/bc_silent_resource_caps_tests.rs
@@ -1,0 +1,675 @@
+//! TDD red-gate tests for four new observability counters that surface silently-dropped /
+//! evicted analyzer state (silent-limit audit, fix/surface-silent-resource-caps).
+//!
+//! Behavioral contracts:
+//!   BC-2.16.010 v1.9 — ArpAnalyzer summarize() now 13 keys
+//!   BC-2.16.008 v2.0 — `bindings_evicted` (MAX_ARP_BINDINGS=65536 LRU eviction)
+//!                       `storm_counters_evicted` (MAX_STORM_COUNTERS=4096 LRU eviction)
+//!   BC-2.14.012 v1.1 — `dropped_transactions` (MAX_PENDING_TRANSACTIONS=256 drop-not-evict)
+//!   BC-2.14.021 v1.2 — ModbusAnalyzer summarize() now 7 keys (adds `dropped_transactions`)
+//!   BC-2.07.031 v1.5 — TlsAnalyzer summarize() `dropped_map_entries` (MAX_MAP_ENTRIES=50000)
+//!   BC-2.06.023 v1.6 — HttpAnalyzer summarize() `dropped_map_entries` (MAX_MAP_ENTRIES=50000)
+//!
+//! These tests are the RED GATE: they MUST FAIL on the current codebase (the new fields /
+//! keys do not exist yet). The implementer's job is to make each test pass with minimum code.
+//!
+//! Strategy: all assertions are against summarize().detail map keys so the tests COMPILE
+//! even before the struct fields are added. A missing key causes a runtime assertion failure,
+//! which is the correct red-gate failure mode — not a compile error.
+//!
+//! DF-TEST-NAMESPACE-001: all tests wrapped in `mod silent_resource_caps`.
+
+#![allow(non_snake_case)]
+
+mod silent_resource_caps {
+    use std::net::IpAddr;
+    use wirerust::analyzer::arp::ArpAnalyzer;
+    use wirerust::analyzer::modbus::{MAX_PENDING_TRANSACTIONS, ModbusAnalyzer};
+    use wirerust::decoder::ArpFrame;
+    use wirerust::reassembly::flow::FlowKey;
+    use wirerust::reassembly::handler::{Direction, StreamAnalyzer, StreamHandler};
+
+    // -----------------------------------------------------------------------
+    // Shared helpers
+    // -----------------------------------------------------------------------
+
+    fn modbus_flow_key() -> FlowKey {
+        FlowKey::new(
+            "10.0.0.1".parse::<IpAddr>().unwrap(),
+            12345,
+            "10.0.0.2".parse::<IpAddr>().unwrap(),
+            502,
+        )
+    }
+
+    /// Build a minimal valid Modbus TCP ADU (FC=0x03 Read Holding Registers request).
+    ///
+    /// MBAP layout: [txn_hi, txn_lo, proto_hi=0, proto_lo=0, len_hi=0, len_lo=6,
+    ///               unit_id, fc=0x03, addr_hi=0, addr_lo=0, qty_hi=0, qty_lo=1]
+    /// Length=6 covers unit_id (1) + FC (1) + 4 data bytes.
+    fn modbus_read_request(txn_id: u16, unit_id: u8) -> [u8; 12] {
+        let [hi, lo] = txn_id.to_be_bytes();
+        [
+            hi, lo, 0x00, 0x00, 0x00, 0x06, unit_id, 0x03, 0x00, 0x00, 0x00, 0x01,
+        ]
+    }
+
+    // -----------------------------------------------------------------------
+    // KEY-PRESENCE tests — assert new keys appear in summarize() with value 0
+    // on a freshly constructed (zero-input) analyzer.
+    // All four tests FAIL on current code: key absent → panic via .unwrap() /
+    // explicit assert.
+    // -----------------------------------------------------------------------
+
+    /// BC-2.16.010 v1.9 / BC-2.16.008 v2.0: `bindings_evicted` must be present in
+    /// ArpAnalyzer summarize() detail with value 0 when no frames have been processed.
+    ///
+    /// RED GATE: `bindings_evicted` is not yet a field on ArpAnalyzer and is not yet
+    /// inserted into the detail map by summarize().
+    #[test]
+    fn test_BC_2_16_008_bindings_evicted_key_present_zero_on_fresh_analyzer() {
+        let analyzer = ArpAnalyzer::new(3, 50);
+        let summary = analyzer.summarize();
+        let val = summary.detail.get("bindings_evicted").unwrap_or_else(|| {
+            panic!(
+                "BC-2.16.010 v1.9 / BC-2.16.008 v2.0 PC: ArpAnalyzer summarize() must \
+                 contain key 'bindings_evicted' (u64, always-present, 0 when no evictions). \
+                 Key is MISSING — red gate expected on current code. \
+                 Keys present: {:?}",
+                summary.detail.keys().collect::<Vec<_>>()
+            )
+        });
+        assert_eq!(
+            val.as_u64(),
+            Some(0),
+            "BC-2.16.008 v2.0: 'bindings_evicted' must be 0 on a fresh analyzer, got: {val}"
+        );
+    }
+
+    /// BC-2.16.010 v1.9 / BC-2.16.008 v2.0: `storm_counters_evicted` must be present in
+    /// ArpAnalyzer summarize() detail with value 0 when no frames have been processed.
+    ///
+    /// RED GATE: `storm_counters_evicted` is not yet a field on ArpAnalyzer and is not yet
+    /// inserted into the detail map by summarize().
+    #[test]
+    fn test_BC_2_16_008_storm_counters_evicted_key_present_zero_on_fresh_analyzer() {
+        let analyzer = ArpAnalyzer::new(3, 50);
+        let summary = analyzer.summarize();
+        let val = summary
+            .detail
+            .get("storm_counters_evicted")
+            .unwrap_or_else(|| {
+                panic!(
+                    "BC-2.16.010 v1.9 / BC-2.16.008 v2.0 PC: ArpAnalyzer summarize() must \
+                 contain key 'storm_counters_evicted' (u64, always-present, 0 when no \
+                 evictions). Key is MISSING — red gate expected on current code. \
+                 Keys present: {:?}",
+                    summary.detail.keys().collect::<Vec<_>>()
+                )
+            });
+        assert_eq!(
+            val.as_u64(),
+            Some(0),
+            "BC-2.16.008 v2.0: 'storm_counters_evicted' must be 0 on a fresh analyzer, got: {val}"
+        );
+    }
+
+    /// BC-2.14.021 v1.2 / BC-2.14.012 v1.1: `dropped_transactions` must be present in
+    /// ModbusAnalyzer summarize() detail with value 0 when no PDUs have been processed.
+    ///
+    /// RED GATE: `dropped_transactions` is not yet a field on ModbusAnalyzer and is not yet
+    /// inserted into the detail map by summarize().
+    #[test]
+    fn test_BC_2_14_012_dropped_transactions_key_present_zero_on_fresh_analyzer() {
+        let analyzer = ModbusAnalyzer::new(20, 10);
+        let summary = analyzer.summarize();
+        let val = summary
+            .detail
+            .get("dropped_transactions")
+            .unwrap_or_else(|| {
+                panic!(
+                    "BC-2.14.021 v1.2 / BC-2.14.012 v1.1 PC: ModbusAnalyzer summarize() must \
+                 contain key 'dropped_transactions' (u64, always-present, 0 when no drops). \
+                 Key is MISSING — red gate expected on current code. \
+                 Keys present: {:?}",
+                    summary.detail.keys().collect::<Vec<_>>()
+                )
+            });
+        assert_eq!(
+            val.as_u64(),
+            Some(0),
+            "BC-2.14.012 v1.1: 'dropped_transactions' must be 0 on a fresh analyzer, got: {val}"
+        );
+    }
+
+    /// BC-2.14.021 v1.2: summarize() must return exactly 7 keys (was 6 before this BC amendment).
+    ///
+    /// RED GATE: `dropped_transactions` not yet in detail map → actual len == 6, not 7.
+    #[test]
+    fn test_BC_2_14_021_summarize_seven_keys_exact() {
+        let analyzer = ModbusAnalyzer::new(20, 10);
+        let summary = analyzer.summarize();
+        let detail = &summary.detail;
+        let required_keys = [
+            "dropped_transactions",
+            "dropped_findings",
+            "exception_count",
+            "function_code_distribution",
+            "parse_errors",
+            "pdu_count",
+            "write_count",
+        ];
+        for key in &required_keys {
+            assert!(
+                detail.contains_key(*key),
+                "BC-2.14.021 v1.2: ModbusAnalyzer summarize() must contain key '{key}'. \
+                 Key is MISSING — red gate expected on current code. \
+                 Keys present: {:?}",
+                detail.keys().collect::<Vec<_>>()
+            );
+        }
+        assert_eq!(
+            detail.len(),
+            7,
+            "BC-2.14.021 v1.2: ModbusAnalyzer summarize() must return exactly 7 keys \
+             (was 6 before BC-2.14.021 v1.2 amendment). Got {}. Keys: {:?}",
+            detail.len(),
+            detail.keys().collect::<Vec<_>>()
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // INCREMENT-ON-EVENT tests
+    // -----------------------------------------------------------------------
+
+    /// BC-2.14.012 v1.1: `dropped_transactions` increments when a new unique request
+    /// is dropped because the pending table is at MAX_PENDING_TRANSACTIONS=256.
+    ///
+    /// Mechanism: feed 257 distinct (txn_id, unit_id) requests to one flow via
+    /// `on_data` (ClientToServer). The 257th request is a new key at a full table →
+    /// `dropped_transactions` must be >= 1.
+    ///
+    /// This test drives `ModbusAnalyzer` via its public `on_data` interface, building
+    /// minimal valid Modbus TCP ADUs (FC=0x03, length=6). 257 iterations completes in
+    /// well under 100 ms.
+    ///
+    /// RED GATE: `dropped_transactions` field does not exist on ModbusAnalyzer;
+    /// summarize() does not emit it → key absent, test panics on `unwrap_or_else`.
+    #[test]
+    fn test_BC_2_14_012_dropped_transactions_increments_at_cap() {
+        let mut analyzer = ModbusAnalyzer::new(20, 10);
+        let fk = modbus_flow_key();
+
+        // Feed MAX_PENDING_TRANSACTIONS + 1 = 257 distinct requests to one flow.
+        // txn_id runs 0..=256 (u16), unit_id fixed at 0x01 so all keys are distinct.
+        // The 257th request (txn_id=256, unit_id=0x01) is a new key while the table
+        // is full → insert_request drops it → dropped_transactions must be incremented.
+        for txn_id in 0u16..=(MAX_PENDING_TRANSACTIONS as u16) {
+            let adu = modbus_read_request(txn_id, 0x01);
+            analyzer.on_data(&fk, Direction::ClientToServer, &adu, 0, txn_id as u32);
+        }
+
+        let summary = analyzer.summarize();
+        let dropped = summary
+            .detail
+            .get("dropped_transactions")
+            .unwrap_or_else(|| {
+                panic!(
+                    "BC-2.14.012 v1.1: summarize() must contain 'dropped_transactions' key \
+                     after exceeding MAX_PENDING_TRANSACTIONS={}. \
+                     Key is MISSING — red gate expected on current code. \
+                     Keys present: {:?}",
+                    MAX_PENDING_TRANSACTIONS,
+                    summary.detail.keys().collect::<Vec<_>>()
+                )
+            })
+            .as_u64()
+            .expect("dropped_transactions must be a u64");
+
+        assert!(
+            dropped >= 1,
+            "BC-2.14.012 v1.1: 'dropped_transactions' must be >= 1 after feeding \
+             {} requests to a single flow (cap = {}). Got 0.",
+            MAX_PENDING_TRANSACTIONS + 1,
+            MAX_PENDING_TRANSACTIONS
+        );
+    }
+
+    /// BC-2.16.008 v2.0: `bindings_evicted` increments when the binding table LRU-evicts
+    /// at MAX_ARP_BINDINGS=65_536.
+    ///
+    /// At 65_536 distinct IPs the table is full; the 65_537th insert must evict one entry
+    /// and increment `bindings_evicted`. Filling 65_536 + 1 distinct ARP entries requires
+    /// driving 65_537 frames which takes several seconds on most machines and is too slow
+    /// for a default-run test suite.
+    ///
+    /// Therefore this test is `#[ignore]` by default. It is included so the implementer
+    /// has a concrete live test for the eviction path, and can be run explicitly:
+    ///   cargo test test_BC_2_16_008_bindings_evicted_increments_at_cap -- --ignored
+    ///
+    /// The key-presence test `test_BC_2_16_008_bindings_evicted_key_present_zero_on_fresh_analyzer`
+    /// provides the red-gate assertion at zero cost. Code review validates the LRU eviction
+    /// path increments the counter.
+    ///
+    /// Justification for #[ignore]: MAX_ARP_BINDINGS=65_536 distinct ARP frames at ~1 µs
+    /// each ≈ 65 ms minimum, but typically 0.5–2 s with frame construction overhead.
+    /// Acceptable for a one-off run; unacceptable as a default CI test on every commit.
+    #[test]
+    #[ignore = "BC-2.16.008 v2.0 eviction increment test; MAX_ARP_BINDINGS=65536 frames takes \
+                ~0.5-2s. Run with: cargo test test_BC_2_16_008_bindings_evicted_increments -- \
+                --ignored. Key-presence red-gate covered by \
+                test_BC_2_16_008_bindings_evicted_key_present_zero_on_fresh_analyzer."]
+    fn test_BC_2_16_008_bindings_evicted_increments_at_cap() {
+        use wirerust::analyzer::arp::MAX_ARP_BINDINGS;
+
+        let mut analyzer = ArpAnalyzer::new(3, 50);
+
+        // Fill the binding table to exactly MAX_ARP_BINDINGS distinct sender IPs.
+        // Use unique sender_mac per IP to avoid spoof findings (which require a MAC change
+        // on an existing IP). Target IP = 192.168.0.1 (irrelevant).
+        let make_frame = |i: u32| -> ArpFrame {
+            let ip = (i + 1).to_be_bytes(); // avoid 0.0.0.0
+            let mac_lo = ((i + 1) & 0xFF) as u8;
+            let mac_hi = (((i + 1) >> 8) & 0xFF) as u8;
+            ArpFrame {
+                operation: 1,
+                sender_mac: [0xAA, 0xBB, 0xCC, 0xDD, mac_hi, mac_lo],
+                sender_ip: ip,
+                target_mac: [0u8; 6],
+                target_ip: [192, 168, 0, 1],
+                outer_src_mac: Some([0xAA, 0xBB, 0xCC, 0xDD, mac_hi, mac_lo]),
+                packet_len: 42,
+            }
+        };
+
+        // Fill to cap (65_536 distinct IPs).
+        for i in 0u32..MAX_ARP_BINDINGS as u32 {
+            let frame = make_frame(i);
+            let _ = analyzer.process_arp(&frame, 0);
+        }
+
+        let before = analyzer
+            .summarize()
+            .detail
+            .get("bindings_evicted")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(u64::MAX);
+        assert_eq!(
+            before, 0,
+            "BC-2.16.008 v2.0: 'bindings_evicted' must be 0 before the 65537th distinct IP"
+        );
+
+        // Insert one more distinct IP — must trigger LRU eviction.
+        let eviction_frame = make_frame(MAX_ARP_BINDINGS as u32 + 1);
+        let _ = analyzer.process_arp(&eviction_frame, 1);
+
+        let after = analyzer
+            .summarize()
+            .detail
+            .get("bindings_evicted")
+            .and_then(|v| v.as_u64())
+            .expect("'bindings_evicted' key must be present after eviction");
+        assert!(
+            after >= 1,
+            "BC-2.16.008 v2.0: 'bindings_evicted' must be >= 1 after inserting \
+             MAX_ARP_BINDINGS+1={} distinct sender IPs. Got 0.",
+            MAX_ARP_BINDINGS + 1
+        );
+    }
+
+    /// BC-2.16.008 v2.0: `storm_counters_evicted` increments when the storm-counter table
+    /// LRU-evicts at MAX_STORM_COUNTERS=4096.
+    ///
+    /// At 4096 distinct source MACs the storm-counter table is full; the 4097th distinct MAC
+    /// must evict one entry and increment `storm_counters_evicted`. Filling 4096 distinct ARP
+    /// request frames (each with a unique sender MAC) at storm rate (same timestamp) is fast
+    /// in practice (~4 ms), but may be slow in coverage or sanitizer builds.
+    ///
+    /// This test is `#[ignore]` by default because MAX_STORM_COUNTERS=4096 frames may take
+    /// >1s in slow CI environments.
+    ///
+    /// Run explicitly:
+    ///   cargo test test_BC_2_16_008_storm_counters_evicted_increments -- --ignored
+    ///
+    /// Key-presence red-gate:
+    ///   test_BC_2_16_008_storm_counters_evicted_key_present_zero_on_fresh_analyzer
+    #[test]
+    #[ignore = "BC-2.16.008 v2.0 storm eviction increment test; MAX_STORM_COUNTERS=4096 frames \
+                may be slow in coverage/sanitizer builds. Run with: cargo test \
+                test_BC_2_16_008_storm_counters_evicted_increments -- --ignored. \
+                Key-presence red-gate covered by \
+                test_BC_2_16_008_storm_counters_evicted_key_present_zero_on_fresh_analyzer."]
+    fn test_BC_2_16_008_storm_counters_evicted_increments_at_cap() {
+        use wirerust::analyzer::arp::MAX_STORM_COUNTERS;
+
+        let mut analyzer = ArpAnalyzer::new(3, 50);
+
+        // Fill to exactly MAX_STORM_COUNTERS (4096) distinct source MACs.
+        // All frames have the same timestamp (ts=1) so the storm-counter window
+        // accumulates without resetting, maximising the chance that all MACs are
+        // tracked. Unique sender_mac and sender_ip per iteration.
+        let make_frame = |i: u32| -> ArpFrame {
+            let mac_lo = (i & 0xFF) as u8;
+            let mac_hi = ((i >> 8) & 0xFF) as u8;
+            let ip = [0x0A, mac_hi, mac_lo, 0x01]; // 10.x.x.1 (unique per i)
+            ArpFrame {
+                operation: 1,
+                sender_mac: [0x00, 0x00, mac_hi, mac_lo, 0x00, 0x01],
+                sender_ip: ip,
+                target_mac: [0u8; 6],
+                target_ip: [192, 168, 0, 1],
+                outer_src_mac: Some([0x00, 0x00, mac_hi, mac_lo, 0x00, 0x01]),
+                packet_len: 42,
+            }
+        };
+
+        for i in 0u32..MAX_STORM_COUNTERS as u32 {
+            let frame = make_frame(i);
+            let _ = analyzer.process_arp(&frame, 1);
+        }
+
+        let before = analyzer
+            .summarize()
+            .detail
+            .get("storm_counters_evicted")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(u64::MAX);
+        assert_eq!(
+            before, 0,
+            "BC-2.16.008 v2.0: 'storm_counters_evicted' must be 0 before the 4097th distinct MAC"
+        );
+
+        // Insert one more distinct MAC — must trigger LRU eviction.
+        let eviction_frame = make_frame(MAX_STORM_COUNTERS as u32 + 1);
+        let _ = analyzer.process_arp(&eviction_frame, 1);
+
+        let after = analyzer
+            .summarize()
+            .detail
+            .get("storm_counters_evicted")
+            .and_then(|v| v.as_u64())
+            .expect("'storm_counters_evicted' key must be present after eviction");
+        assert!(
+            after >= 1,
+            "BC-2.16.008 v2.0: 'storm_counters_evicted' must be >= 1 after inserting \
+             MAX_STORM_COUNTERS+1={} distinct source MACs. Got 0.",
+            MAX_STORM_COUNTERS + 1
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // TLS / HTTP dropped_map_entries — key-presence tests
+    // (increment tests are #[ignore]'d: cap is 50_000, filling it is too slow
+    // for a default test run)
+    // -----------------------------------------------------------------------
+
+    /// BC-2.07.031 v1.5: `dropped_map_entries` must be present in TlsAnalyzer
+    /// summarize() detail with value 0 on a freshly constructed analyzer.
+    ///
+    /// RED GATE: `dropped_map_entries` not yet a field on TlsAnalyzer; summarize()
+    /// does not emit it.
+    #[test]
+    fn test_BC_2_07_031_tls_dropped_map_entries_key_present_zero_on_fresh_analyzer() {
+        use wirerust::analyzer::tls::TlsAnalyzer;
+        let analyzer = TlsAnalyzer::new();
+        let summary = analyzer.summarize();
+        let val = summary
+            .detail
+            .get("dropped_map_entries")
+            .unwrap_or_else(|| {
+                panic!(
+                    "BC-2.07.031 v1.5 PC: TlsAnalyzer summarize() must contain key \
+                 'dropped_map_entries' (u64, always-present, 0 when no drops). \
+                 Key is MISSING — red gate expected on current code. \
+                 Keys present: {:?}",
+                    summary.detail.keys().collect::<Vec<_>>()
+                )
+            });
+        assert_eq!(
+            val.as_u64(),
+            Some(0),
+            "BC-2.07.031 v1.5: 'dropped_map_entries' must be 0 on a fresh TLS analyzer, got: {val}"
+        );
+    }
+
+    /// BC-2.06.023 v1.6: `dropped_map_entries` must be present in HttpAnalyzer
+    /// summarize() detail with value 0 on a freshly constructed analyzer.
+    ///
+    /// RED GATE: `dropped_map_entries` not yet a field on HttpAnalyzer; summarize()
+    /// does not emit it.
+    #[test]
+    fn test_BC_2_06_023_http_dropped_map_entries_key_present_zero_on_fresh_analyzer() {
+        use wirerust::analyzer::http::HttpAnalyzer;
+        let analyzer = HttpAnalyzer::new();
+        let summary = analyzer.summarize();
+        let val = summary
+            .detail
+            .get("dropped_map_entries")
+            .unwrap_or_else(|| {
+                panic!(
+                    "BC-2.06.023 v1.6 PC: HttpAnalyzer summarize() must contain key \
+                 'dropped_map_entries' (u64, always-present, 0 when no drops). \
+                 Key is MISSING — red gate expected on current code. \
+                 Keys present: {:?}",
+                    summary.detail.keys().collect::<Vec<_>>()
+                )
+            });
+        assert_eq!(
+            val.as_u64(),
+            Some(0),
+            "BC-2.06.023 v1.6: 'dropped_map_entries' must be 0 on a fresh HTTP analyzer, got: {val}"
+        );
+    }
+
+    /// BC-2.07.031 v1.5: `dropped_map_entries` increments when a distribution map
+    /// (sni_counts, ja3_counts, ja3s_counts, cipher_counts, version_counts) drops a
+    /// new key at MAX_MAP_ENTRIES=50_000.
+    ///
+    /// Filling 50_001 distinct keys requires constructing at minimum 50_001 TLS
+    /// ClientHello messages with unique SNIs. Even with minimal frames this takes
+    /// several seconds and is not acceptable for a default CI run.
+    ///
+    /// Therefore this test is `#[ignore]` by default. The key-presence test provides
+    /// the red-gate assertion at zero cost.
+    ///
+    /// Run explicitly:
+    ///   cargo test test_BC_2_07_031_tls_dropped_map_entries_increments -- --ignored
+    #[test]
+    #[ignore = "BC-2.07.031 v1.5 TLS dropped_map_entries increment test; requires 50_001 \
+                distinct SNI/JA3/cipher entries (MAX_MAP_ENTRIES=50000). Too slow for default \
+                CI run. Run explicitly with --ignored. Key-presence red-gate covered by \
+                test_BC_2_07_031_tls_dropped_map_entries_key_present_zero_on_fresh_analyzer."]
+    fn test_BC_2_07_031_tls_dropped_map_entries_increments_at_cap() {
+        use wirerust::analyzer::tls::TlsAnalyzer;
+        use wirerust::reassembly::handler::Direction;
+
+        const MAX_MAP_ENTRIES: usize = 50_000;
+
+        let mut analyzer = TlsAnalyzer::new();
+        // Build a minimal TLS 1.2 ClientHello record with an SNI extension.
+        // Wire format: TLS record (0x16, ver, len) + Handshake header + ClientHello body.
+        let build_ch = |sni: &str| -> Vec<u8> {
+            let sni_bytes = sni.as_bytes();
+            let sni_name_len = sni_bytes.len() as u16;
+            // SNI entry: NameType(1) + NameLen(2) + Name
+            let sni_entry_len = 1u16 + 2u16 + sni_name_len;
+            // SNI ext data: ServerNameListLength(2) + entry
+            let sni_ext_data_len = 2u16 + sni_entry_len;
+            // Extensions block: ext_type(2) + ext_data_len(2) + sni_ext_data_len
+            let _ext_total_len = 2u16 + 2u16 + sni_ext_data_len;
+
+            let mut extensions = Vec::new();
+            extensions.extend_from_slice(&[0x00, 0x00]); // SNI ext type
+            extensions.extend_from_slice(&sni_ext_data_len.to_be_bytes());
+            extensions.extend_from_slice(&sni_entry_len.to_be_bytes());
+            extensions.push(0x00); // NameType: host_name
+            extensions.extend_from_slice(&sni_name_len.to_be_bytes());
+            extensions.extend_from_slice(sni_bytes);
+            // Supported groups (required by some parsers)
+            extensions
+                .extend_from_slice(&[0x00, 0x0a, 0x00, 0x06, 0x00, 0x04, 0x00, 0x1d, 0x00, 0x17]);
+            // EC point formats
+            extensions.extend_from_slice(&[0x00, 0x0b, 0x00, 0x02, 0x01, 0x00]);
+
+            let actual_ext_total = extensions.len() as u16;
+
+            let mut ch_body = Vec::new();
+            ch_body.extend_from_slice(&[0x03, 0x03]); // TLS 1.2
+            ch_body.extend_from_slice(&[0u8; 32]); // random
+            ch_body.push(0x00); // session_id len
+            ch_body.extend_from_slice(&[0x00, 0x02]); // cipher suites len: 1 suite
+            ch_body.extend_from_slice(&[0x13, 0x01]); // TLS_AES_128_GCM_SHA256
+            ch_body.push(0x01); // compression methods len
+            ch_body.push(0x00); // null compression
+            ch_body.extend_from_slice(&actual_ext_total.to_be_bytes()); // extensions len
+            ch_body.extend_from_slice(&extensions);
+
+            let ch_len = ch_body.len() as u32;
+            let mut handshake = vec![
+                0x01, // ClientHello
+                (ch_len >> 16) as u8,
+                (ch_len >> 8) as u8,
+                ch_len as u8,
+            ];
+            handshake.extend_from_slice(&ch_body);
+
+            let hs_len = handshake.len() as u16;
+            let mut record = vec![0x16]; // handshake record
+            record.extend_from_slice(&[0x03, 0x01]); // record version TLS 1.0
+            record.extend_from_slice(&hs_len.to_be_bytes());
+            record.extend_from_slice(&handshake);
+            record
+        };
+
+        // Fill sni_counts to exactly MAX_MAP_ENTRIES with unique hostnames.
+        // Each frame uses a new flow key to avoid the "one handshake per flow" limit.
+        for i in 0u32..MAX_MAP_ENTRIES as u32 {
+            let sni = format!("h{i}.example.test");
+            let record = build_ch(&sni);
+            let flow_key = FlowKey::new(
+                "10.0.0.1".parse::<IpAddr>().unwrap(),
+                (i as u16).wrapping_add(1),
+                "10.0.0.2".parse::<IpAddr>().unwrap(),
+                443,
+            );
+            analyzer.on_data(&flow_key, Direction::ClientToServer, &record, 0, 0);
+        }
+
+        let before = analyzer
+            .summarize()
+            .detail
+            .get("dropped_map_entries")
+            .and_then(|v| v.as_u64())
+            .expect("dropped_map_entries key must be present");
+        assert_eq!(
+            before, 0,
+            "BC-2.07.031 v1.5: dropped_map_entries must be 0 before the 50_001st distinct SNI"
+        );
+
+        // Insert one more distinct SNI — must be dropped and increment the counter.
+        let overflow_sni = "overflow.example.test";
+        let overflow_record = build_ch(overflow_sni);
+        let overflow_fk = FlowKey::new(
+            "10.0.0.1".parse::<IpAddr>().unwrap(),
+            65535,
+            "10.0.0.2".parse::<IpAddr>().unwrap(),
+            443,
+        );
+        analyzer.on_data(
+            &overflow_fk,
+            Direction::ClientToServer,
+            &overflow_record,
+            0,
+            0,
+        );
+
+        let after = analyzer
+            .summarize()
+            .detail
+            .get("dropped_map_entries")
+            .and_then(|v| v.as_u64())
+            .expect("dropped_map_entries key must be present after overflow");
+        assert!(
+            after >= 1,
+            "BC-2.07.031 v1.5: dropped_map_entries must be >= 1 after inserting \
+             MAX_MAP_ENTRIES+1={} distinct SNIs. Got 0.",
+            MAX_MAP_ENTRIES + 1
+        );
+    }
+
+    /// BC-2.06.023 v1.6: `dropped_map_entries` increments when a distribution map
+    /// (methods, hosts, user_agents) drops a new key at MAX_MAP_ENTRIES=50_000.
+    ///
+    /// As with TLS, filling 50_001 distinct host values requires constructing 50_001
+    /// HTTP request/response pairs and is too slow for a default CI run.
+    ///
+    /// Run explicitly:
+    ///   cargo test test_BC_2_06_023_http_dropped_map_entries_increments -- --ignored
+    #[test]
+    #[ignore = "BC-2.06.023 v1.6 HTTP dropped_map_entries increment test; requires 50_001 \
+                distinct Host header values (MAX_MAP_ENTRIES=50000). Too slow for default CI run. \
+                Run explicitly with --ignored. Key-presence red-gate covered by \
+                test_BC_2_06_023_http_dropped_map_entries_key_present_zero_on_fresh_analyzer."]
+    fn test_BC_2_06_023_http_dropped_map_entries_increments_at_cap() {
+        use wirerust::analyzer::http::HttpAnalyzer;
+        use wirerust::reassembly::handler::Direction;
+
+        const MAX_MAP_ENTRIES: usize = 50_000;
+
+        let mut analyzer = HttpAnalyzer::new();
+
+        // Fill hosts map to exactly MAX_MAP_ENTRIES distinct Host values.
+        // Each request uses a unique Host header on a unique flow to avoid
+        // flow-level parsing state interfering across requests.
+        for i in 0u32..MAX_MAP_ENTRIES as u32 {
+            let fk = FlowKey::new(
+                "10.0.0.1".parse::<IpAddr>().unwrap(),
+                (i as u16).wrapping_add(1),
+                "10.0.0.2".parse::<IpAddr>().unwrap(),
+                80,
+            );
+            let request = format!("GET / HTTP/1.1\r\nHost: h{i}.example.test\r\n\r\n");
+            analyzer.on_data(&fk, Direction::ClientToServer, request.as_bytes(), 0, 0);
+        }
+
+        let before = analyzer
+            .summarize()
+            .detail
+            .get("dropped_map_entries")
+            .and_then(|v| v.as_u64())
+            .expect("dropped_map_entries key must be present");
+        assert_eq!(
+            before, 0,
+            "BC-2.06.023 v1.6: dropped_map_entries must be 0 before the 50_001st distinct host"
+        );
+
+        // Insert one more distinct host — must be dropped and increment the counter.
+        let overflow_fk = FlowKey::new(
+            "10.0.0.1".parse::<IpAddr>().unwrap(),
+            65535,
+            "10.0.0.2".parse::<IpAddr>().unwrap(),
+            80,
+        );
+        let overflow_request = "GET / HTTP/1.1\r\nHost: overflow.example.test\r\n\r\n";
+        analyzer.on_data(
+            &overflow_fk,
+            Direction::ClientToServer,
+            overflow_request.as_bytes(),
+            0,
+            0,
+        );
+
+        let after = analyzer
+            .summarize()
+            .detail
+            .get("dropped_map_entries")
+            .and_then(|v| v.as_u64())
+            .expect("dropped_map_entries key must be present after overflow");
+        assert!(
+            after >= 1,
+            "BC-2.06.023 v1.6: dropped_map_entries must be >= 1 after inserting \
+             MAX_MAP_ENTRIES+1={} distinct Host values. Got 0.",
+            MAX_MAP_ENTRIES + 1
+        );
+    }
+} // mod silent_resource_caps

--- a/tests/bc_silent_resource_caps_tests.rs
+++ b/tests/bc_silent_resource_caps_tests.rs
@@ -672,4 +672,254 @@ mod silent_resource_caps {
             MAX_MAP_ENTRIES + 1
         );
     }
+
+    // -----------------------------------------------------------------------
+    // NEGATIVE REGRESSION TESTS (PR #365 reviewer follow-ups)
+    // These guard ALREADY-SHIPPED, already-correct behavior.  They MUST PASS
+    // on current code.  If either fails, that reveals a real bug — STOP.
+    // -----------------------------------------------------------------------
+
+    /// HTTP-AC008-NEG-TEST-001 / BC-2.06.024 AC-008 (negative):
+    /// Hitting an EXISTING key in the HttpAnalyzer distribution maps must NOT
+    /// increment `dropped_map_entries`.
+    ///
+    /// Invariant: `dropped_map_entries` is incremented ONLY when a NEW key is
+    /// refused because the map is at MAX_MAP_ENTRIES=50_000 capacity.  Repeated
+    /// requests that reuse already-inserted Host / User-Agent values are
+    /// existing-key updates and must never touch the counter, regardless of
+    /// how many times the same keys are seen.
+    ///
+    /// Mechanism: send several HTTP requests that all use the same Host and
+    /// User-Agent, well below the 50k cap.  The maps stay tiny; the keys are
+    /// inserted on the first request and updated (not refused) on every
+    /// subsequent one.  Assert `dropped_map_entries == 0` throughout.
+    ///
+    /// This is a live (non-`#[ignore]`) test — it runs in under 1 ms.
+    #[test]
+    fn test_HTTP_AC008_NEG_TEST_001_existing_key_increment_does_not_raise_dropped_map_entries() {
+        use wirerust::analyzer::http::HttpAnalyzer;
+        use wirerust::reassembly::handler::Direction;
+
+        let mut analyzer = HttpAnalyzer::new();
+
+        // Use two distinct flow keys so the HTTP parser does not see the
+        // repeated requests as a single pipelined stream and mangle them.
+        // Even if they share a flow, the Host/User-Agent keys are already
+        // present after the first parse, so the insert guard returns early.
+        let fk_a = FlowKey::new(
+            "10.10.0.1".parse::<IpAddr>().unwrap(),
+            51000,
+            "10.10.0.2".parse::<IpAddr>().unwrap(),
+            80,
+        );
+        let fk_b = FlowKey::new(
+            "10.10.0.3".parse::<IpAddr>().unwrap(),
+            51001,
+            "10.10.0.4".parse::<IpAddr>().unwrap(),
+            80,
+        );
+
+        // 10 repetitions of the same Host + User-Agent on alternating flow keys.
+        // The first request on each flow seeds the maps; subsequent ones reuse
+        // the EXISTING key → must NOT increment dropped_map_entries.
+        for i in 0u32..10 {
+            let fk = if i % 2 == 0 { &fk_a } else { &fk_b };
+            let req =
+                b"GET /path HTTP/1.1\r\nHost: existing.example.test\r\nUser-Agent: TestBot/1.0\r\n\r\n";
+            analyzer.on_data(fk, Direction::ClientToServer, req, 0, i);
+        }
+
+        let summary = analyzer.summarize();
+        let dropped = summary
+            .detail
+            .get("dropped_map_entries")
+            .and_then(|v| v.as_u64())
+            .expect(
+                "HTTP-AC008-NEG-TEST-001: 'dropped_map_entries' key must be present in \
+                 HttpAnalyzer summarize(). Key missing — regression in BC-2.06.023.",
+            );
+
+        assert_eq!(
+            dropped, 0,
+            "HTTP-AC008-NEG-TEST-001 / BC-2.06.024 AC-008 (negative): \
+             `dropped_map_entries` must be 0 when only EXISTING keys are hit \
+             (same Host/User-Agent repeated below the 50k cap). \
+             Got {dropped} — existing-key increment is incorrectly bumping the drop counter."
+        );
+    }
+
+    /// EVICTION-NO-FINDING-NEG-TEST-001 / BC-2.16.006 Inv3 / BC-2.16.008 Inv5 /
+    /// BC-2.16.010 Inv7 / BC-2.14.012 v1.1 (negative):
+    /// Eviction / pending-drop events are COUNTER-ONLY: they must not produce
+    /// any Finding.
+    ///
+    /// Part A — Modbus pending-drop (fast: 257 requests).
+    ///   After saturating the 256-slot pending table, additional new requests
+    ///   are silently dropped.  The `dropped_transactions` counter increments;
+    ///   `all_findings` must gain NO new Finding for the drop event itself.
+    ///
+    /// Part B — ARP binding eviction (slow: requires 65537 distinct IPs).
+    ///   Marked `#[ignore]` because filling MAX_ARP_BINDINGS=65536 distinct
+    ///   entries takes ~0.5–2 s.  Justification: the invariant is structurally
+    ///   enforced — `process_arp` only pushes findings before the eviction
+    ///   branch and returns the `findings` vec which never includes an eviction
+    ///   entry.  Part A provides the fast guard; Part B is an exhaustive check
+    ///   runnable on-demand.
+    ///
+    /// Run Part B explicitly:
+    ///   cargo test EVICTION_NO_FINDING_NEG_TEST_001_arp -- --ignored
+    #[test]
+    fn test_EVICTION_NO_FINDING_NEG_TEST_001_modbus_pending_drop_emits_no_finding() {
+        let mut analyzer = ModbusAnalyzer::new(20, 10);
+        let fk = modbus_flow_key();
+
+        // Feed MAX_PENDING_TRANSACTIONS = 256 requests to fill the table.
+        // All use FC=0x03 (read holding registers) — non-write, non-exception
+        // → they produce no findings regardless of cap state.
+        for txn_id in 0u16..MAX_PENDING_TRANSACTIONS as u16 {
+            let adu = modbus_read_request(txn_id, 0x01);
+            analyzer.on_data(&fk, Direction::ClientToServer, &adu, 0, txn_id as u32);
+        }
+
+        // Snapshot findings length immediately before the overflow request.
+        let findings_at_cap = analyzer.all_findings.len();
+
+        // The 257th request (txn_id=256, unit_id=0x01) is a NEW key at a FULL table →
+        // `dropped_transactions` must increment and NO finding must be emitted.
+        let overflow_txn_id = MAX_PENDING_TRANSACTIONS as u16;
+        let overflow_adu = modbus_read_request(overflow_txn_id, 0x01);
+        analyzer.on_data(
+            &fk,
+            Direction::ClientToServer,
+            &overflow_adu,
+            0,
+            overflow_txn_id as u32,
+        );
+
+        // `dropped_transactions` must be at least 1 (proving the cap was hit).
+        let summary = analyzer.summarize();
+        let dropped = summary
+            .detail
+            .get("dropped_transactions")
+            .and_then(|v| v.as_u64())
+            .expect(
+                "EVICTION-NO-FINDING-NEG-TEST-001: 'dropped_transactions' key must be present \
+                 in ModbusAnalyzer summarize().",
+            );
+        assert!(
+            dropped >= 1,
+            "EVICTION-NO-FINDING-NEG-TEST-001: expected dropped_transactions >= 1 after \
+             feeding {} requests (cap={}). Got 0 — test precondition not met.",
+            MAX_PENDING_TRANSACTIONS + 1,
+            MAX_PENDING_TRANSACTIONS
+        );
+
+        // `all_findings` must not have grown due to the drop event.
+        // FC=0x03 (read holding registers) is non-write, non-exception → zero findings.
+        // The drop path only increments `dropped_transactions`; it must never emit a Finding.
+        let findings_after_overflow = analyzer.all_findings.len();
+        assert_eq!(
+            findings_after_overflow, findings_at_cap,
+            "EVICTION-NO-FINDING-NEG-TEST-001 / BC-2.14.012 (negative): \
+             `all_findings` must not grow due to a pending-table drop event. \
+             At cap ({MAX_PENDING_TRANSACTIONS} requests): {findings_at_cap} finding(s). \
+             After overflow request: {findings_after_overflow} finding(s). \
+             A drop event is a COUNTER-ONLY event (BC-2.16.006 Inv3 / BC-2.14.012)."
+        );
+    }
+
+    /// EVICTION-NO-FINDING-NEG-TEST-001 — Part B (ARP binding eviction, slow path).
+    ///
+    /// Fills MAX_ARP_BINDINGS=65536 distinct sender IPs into ArpAnalyzer, then
+    /// inserts one more to trigger LRU eviction.  Asserts the eviction-triggering
+    /// frame returns ZERO findings (the eviction branch runs only after `findings`
+    /// is fully constructed and returned; no eviction Finding is ever appended).
+    ///
+    /// Marked `#[ignore]` because filling 65537 distinct ARP frames takes
+    /// approximately 0.5–2 s.  Part A (Modbus, above) provides the fast guard.
+    ///
+    /// Run explicitly:
+    ///   cargo test test_EVICTION_NO_FINDING_NEG_TEST_001_arp_eviction_emits_no_finding -- --ignored
+    #[test]
+    #[ignore = "EVICTION-NO-FINDING-NEG-TEST-001 ARP Part B: MAX_ARP_BINDINGS=65536 frames \
+                takes ~0.5-2s. Run with: cargo test \
+                test_EVICTION_NO_FINDING_NEG_TEST_001_arp_eviction_emits_no_finding -- --ignored. \
+                Fast guard: test_EVICTION_NO_FINDING_NEG_TEST_001_modbus_pending_drop_emits_no_finding."]
+    fn test_EVICTION_NO_FINDING_NEG_TEST_001_arp_eviction_emits_no_finding() {
+        use wirerust::analyzer::arp::MAX_ARP_BINDINGS;
+
+        let mut analyzer = ArpAnalyzer::new(3, 50);
+
+        // Fill to exactly MAX_ARP_BINDINGS distinct sender IPs.
+        // Unique sender_mac per IP prevents rebind (D1) findings.
+        // outer_src_mac == sender_mac prevents mismatch (D12) findings.
+        // Non-GARP (target_ip != sender_ip) prevents D2 findings.
+        // Unique IPs prevent storm (D3) from firing on repeated MACs.
+        let make_normal_frame = |i: u32| -> ArpFrame {
+            let ip = (i + 1).to_be_bytes(); // avoid 0.0.0.0
+            let mac_lo = ((i + 1) & 0xFF) as u8;
+            let mac_hi = (((i + 1) >> 8) & 0xFF) as u8;
+            ArpFrame {
+                operation: 1,
+                sender_mac: [0xAA, 0xBB, 0xCC, 0xDD, mac_hi, mac_lo],
+                sender_ip: ip,
+                target_mac: [0u8; 6],
+                target_ip: [192, 168, 0, 1], // different from sender_ip → non-GARP
+                outer_src_mac: Some([0xAA, 0xBB, 0xCC, 0xDD, mac_hi, mac_lo]),
+                packet_len: 42,
+            }
+        };
+
+        // Fill to cap.
+        for i in 0u32..MAX_ARP_BINDINGS as u32 {
+            let frame = make_normal_frame(i);
+            let _ = analyzer.process_arp(&frame, 0);
+        }
+
+        // Verify cap is reached: bindings_evicted still 0 before the +1 insert.
+        let before_evict = analyzer
+            .summarize()
+            .detail
+            .get("bindings_evicted")
+            .and_then(|v| v.as_u64())
+            .expect("bindings_evicted key must be present");
+        assert_eq!(
+            before_evict,
+            0,
+            "EVICTION-NO-FINDING-NEG-TEST-001 (ARP Part B): bindings_evicted must be 0 \
+             before the {}-th distinct IP insert.",
+            MAX_ARP_BINDINGS + 1
+        );
+
+        // Insert one more distinct IP — triggers LRU eviction of the oldest entry.
+        let eviction_frame = make_normal_frame(MAX_ARP_BINDINGS as u32 + 1);
+        let eviction_findings = analyzer.process_arp(&eviction_frame, 1);
+
+        // The eviction-triggering frame must return ZERO findings
+        // (BC-2.16.006 Inv3 / BC-2.16.008 Inv5 / BC-2.16.010 Inv7:
+        // eviction is COUNTER-ONLY, never a Finding).
+        assert_eq!(
+            eviction_findings.len(),
+            0,
+            "EVICTION-NO-FINDING-NEG-TEST-001 / BC-2.16.006 Inv3 (negative, ARP): \
+             LRU eviction of a binding table entry must return ZERO findings. \
+             Got {} finding(s). Eviction must be a COUNTER-ONLY event.",
+            eviction_findings.len()
+        );
+
+        // Also confirm eviction counter incremented (proves the eviction path was hit).
+        let after_evict = analyzer
+            .summarize()
+            .detail
+            .get("bindings_evicted")
+            .and_then(|v| v.as_u64())
+            .expect("bindings_evicted key must be present after eviction");
+        assert!(
+            after_evict >= 1,
+            "EVICTION-NO-FINDING-NEG-TEST-001 (ARP Part B): bindings_evicted must be >= 1 \
+             after inserting MAX_ARP_BINDINGS+1={} distinct IPs. Got 0 — eviction path \
+             was not exercised.",
+            MAX_ARP_BINDINGS + 1
+        );
+    }
 } // mod silent_resource_caps

--- a/tests/http_analyzer_tests.rs
+++ b/tests/http_analyzer_tests.rs
@@ -268,8 +268,12 @@ fn test_summarize_produces_complete_output() {
 
     let detail = &summary.detail;
 
-    // AC-002: exact 9-key set — no extras, no missing.
+    // AC-002: exact 10-key set — no extras, no missing.
+    // Updated 9→10 for BC-2.06.023 v1.6: adds `dropped_map_entries`
+    // (silent-limit audit, surface-silent-resource-caps; key always present even when count==0).
+    // RED GATE: `dropped_map_entries` is absent from the current summarize() implementation.
     let expected_keys: std::collections::BTreeSet<&str> = [
+        "dropped_map_entries",
         "methods",
         "non_http_flows",
         "parse_errors",
@@ -286,7 +290,7 @@ fn test_summarize_produces_complete_output() {
     let actual_keys: std::collections::BTreeSet<&str> = detail.keys().map(|k| k.as_str()).collect();
     assert_eq!(
         actual_keys, expected_keys,
-        "BC-2.06.023 postcondition 1 detail map keys: must contain exactly these 9 keys"
+        "BC-2.06.023 v1.6 postcondition 1 detail map keys: must contain exactly these 10 keys"
     );
 
     // Spot-check values to confirm the map is populated correctly.
@@ -6119,8 +6123,10 @@ mod bc_2_06_023_formalization {
              return identical detail maps"
         );
 
-        // Spot-check: alphabetical order for the 9 required keys.
+        // Spot-check: alphabetical order for the 10 required keys.
+        // Updated 9→10 for BC-2.06.023 v1.6: `dropped_map_entries` added before `methods`.
         let expected_order = [
+            "dropped_map_entries",
             "methods",
             "non_http_flows",
             "parse_errors",
@@ -6133,7 +6139,7 @@ mod bc_2_06_023_formalization {
         ];
         assert_eq!(
             keys1, expected_order,
-            "BC-2.06.023 invariant 1: keys must appear in strict alphabetical order"
+            "BC-2.06.023 v1.6 invariant 1: keys must appear in strict alphabetical order"
         );
     }
 

--- a/tests/modbus_detection_tests.rs
+++ b/tests/modbus_detection_tests.rs
@@ -1271,15 +1271,16 @@ mod story_104 {
     }
 
     // ---------------------------------------------------------------------------
-    // BC-2.14.021 — summarize() returns exactly six keys
+    // BC-2.14.021 — summarize() returns exactly seven keys (updated from 6 for BC-2.14.021 v1.2)
     // AC-010
     // ---------------------------------------------------------------------------
 
     /// test_BC_2_14_021_summarize_returns_six_keys
     ///
-    /// Process a mix of ADUs, then call `summarize()`. Assert all six required keys
+    /// Process a mix of ADUs, then call `summarize()`. Assert all seven required keys
     /// are present in `detail`: pdu_count, write_count, exception_count, parse_errors,
-    /// function_code_distribution, dropped_findings.
+    /// function_code_distribution, dropped_findings, dropped_transactions.
+    /// Updated 6→7 for BC-2.14.021 v1.2 / BC-2.14.012 v1.1 (silent-limit audit).
     /// Traces to: BC-2.14.021 post.1, STORY-104 AC-010.
     #[test]
     fn test_BC_2_14_021_summarize_returns_six_keys() {
@@ -1308,7 +1309,7 @@ mod story_104 {
         let summary = az.summarize();
         let detail = &summary.detail;
 
-        // All six keys must be present
+        // All seven keys must be present (updated 6→7 for BC-2.14.021 v1.2).
         assert!(detail.contains_key("pdu_count"), "missing key: pdu_count");
         assert!(
             detail.contains_key("write_count"),
@@ -1330,10 +1331,14 @@ mod story_104 {
             detail.contains_key("dropped_findings"),
             "missing key: dropped_findings"
         );
+        assert!(
+            detail.contains_key("dropped_transactions"),
+            "missing key: dropped_transactions (BC-2.14.021 v1.2)"
+        );
         assert_eq!(
             detail.len(),
-            6,
-            "must have EXACTLY six keys (not more, not fewer)"
+            7,
+            "must have EXACTLY seven keys (not more, not fewer) — updated for BC-2.14.021 v1.2"
         );
     }
 

--- a/tests/tls_analyzer_tests.rs
+++ b/tests/tls_analyzer_tests.rs
@@ -929,15 +929,19 @@ fn test_summarize_output() {
 
     let detail = &summary.detail;
 
-    // AC-009 / BC-2.07.031 postconditions 3-9 + AC-144-003 + AC-146-005:
-    // EXACT 9-key set — no more, no fewer (BTreeMap ordering enforced below).
+    // AC-009 / BC-2.07.031 postconditions 3-9 + AC-144-003 + AC-146-005 + BC-2.07.031 v1.5:
+    // EXACT 10-key set — no more, no fewer (BTreeMap ordering enforced below).
     // Updated from 7→8 in STORY-144 to include `handshake_reassembly_overflows`
     // (BC-2.07.039 Postcondition 7 / AC-144-003).
     // Updated from 8→9 in STORY-146 to include `buffer_saturation_drops`
     // (BC-2.07.043 Postcondition 4 / AC-146-005; key always present even when count==0).
+    // Updated from 9→10 for BC-2.07.031 v1.5: adds `dropped_map_entries`
+    // (silent-limit audit, surface-silent-resource-caps; key always present even when count==0).
+    // RED GATE: `dropped_map_entries` is absent from the current summarize() implementation.
     let required_keys = [
         "buffer_saturation_drops",
         "cipher_suites",
+        "dropped_map_entries",
         "handshake_reassembly_overflows",
         "ja3_hashes",
         "ja3s_hashes",
@@ -949,13 +953,13 @@ fn test_summarize_output() {
     for key in &required_keys {
         assert!(
             detail.contains_key(*key),
-            "AC-009 (BC-2.07.031 pc3-9): detail must contain key \"{key}\""
+            "AC-009 (BC-2.07.031 v1.5 pc3-10): detail must contain key \"{key}\""
         );
     }
     assert_eq!(
         detail.len(),
-        9,
-        "AC-009 (BC-2.07.031 pc3-9 + AC-144-003 + AC-146-005): detail must have EXACTLY 9 keys, \
+        10,
+        "AC-009 (BC-2.07.031 v1.5 + AC-144-003 + AC-146-005): detail must have EXACTLY 10 keys, \
          got: {:?}",
         detail.keys().collect::<Vec<_>>()
     );


### PR DESCRIPTION
## Release v0.11.4 — Gitflow release/ → main

This is a standard gitflow release PR merging `release/0.11.4` into `main`.

### What ships in v0.11.4

**Four observability counters surfacing previously silent analyzer state (PR #365)**

Four counter fields are newly emitted in `summarize()` JSON output and terminal output across four analyzers, closing the silent-limit observability audit (BC-INDEX v2.18):

- `bindings_evicted` (ARP) — cumulative LRU-evicted ARP binding-table entries (cap: 65,536)
- `storm_counters_evicted` (ARP) — cumulative LRU-evicted ARP storm-counter entries (cap: 4,096)
- `dropped_transactions` (Modbus) — cumulative dropped pending-transaction map entries at per-flow cap
- `dropped_map_entries` (TLS + HTTP) — cumulative entries dropped from SNI/fingerprint/host/path maps at per-map cap

**Negative regression tests + ARP refactor (PR #366)**

Test module `bc_silent_resource_caps_tests` adds negative regression coverage asserting that eviction/drop events do not emit spurious Findings. Also covers HTTP AC-008 (existing-key update does not create a duplicate map entry). Includes cosmetic refactor of ARP `insert_binding_lru` for clarity.

### Branches

- Head: `release/0.11.4` (commit `114a22c`)
- Base: `main` (currently v0.11.3, commit `6785716`)

### Checklist

- [x] `Cargo.toml` version bumped 0.11.3 → 0.11.4
- [x] `Cargo.lock` updated
- [x] `CHANGELOG.md` `[0.11.4]` section present
- [x] All changes reviewed on `develop` (PRs #365, #366)
- [x] CI passed on `develop`