### PR TITLE
feat(dnp3): surface silently-dropped state via observability counters

### DIFF
--- a/src/analyzer/dnp3.rs
+++ b/src/analyzer/dnp3.rs
@@ -307,6 +307,14 @@ pub struct Dnp3Analyzer {
     pub fn_code_counts: HashMap<u8, u64>,
     /// Accumulated findings — capped at MAX_FINDINGS (BC-2.15.022).
     pub all_findings: Vec<Finding>,
+    /// Count of findings silently dropped after MAX_FINDINGS cap was reached (BC-2.15.022).
+    pub dropped_findings: u64,
+    /// Count of unique master source addresses silently ignored at MAX_MASTER_ADDRS=64 cap
+    /// (BC-2.15.016 v2.1 PC-6).
+    pub master_addrs_dropped: u64,
+    /// Count of pending-request entries evicted via LRU at MAX_PENDING_REQUESTS=256 cap
+    /// (BC-2.15.016 v2.1 PC-10).
+    pub pending_requests_evicted: u64,
 
     // ---- on_flow_close aggregate fields (issue #342 / SEC-006) ----
     // These fields accumulate per-flow metrics from flows removed at close time
@@ -339,6 +347,9 @@ impl Dnp3Analyzer {
             direct_operate_threshold,
             fn_code_counts: HashMap::new(),
             all_findings: Vec::new(),
+            dropped_findings: 0,
+            master_addrs_dropped: 0,
+            pending_requests_evicted: 0,
             closed_flows_count: 0,
             total_frames_closed: 0,
             parse_errors_closed: 0,
@@ -444,7 +455,14 @@ impl Dnp3Analyzer {
         // Scan pending_requests for entries that have not received a RESPONSE within
         // BLOCK_CMD_TIMEOUT_SECS.  Must run BEFORE the frame-walk so that newly-arriving
         // frames at ts=T can observe timeouts from requests at ts=T-11.
-        Self::scan_block_timeouts(flow, &mut self.all_findings, ts, &flow_key, direction);
+        Self::scan_block_timeouts(
+            flow,
+            &mut self.all_findings,
+            &mut self.dropped_findings,
+            ts,
+            &flow_key,
+            direction,
+        );
 
         // --- Step 2: accumulate into carry with the 292-byte cap (AC-001 / EC-003) --
         // BC-2.15.016 postconditions 1–2: append incoming bytes; if the carry would
@@ -494,7 +512,14 @@ impl Dnp3Analyzer {
                     active_carry!(flow, direction).clear();
                 }
             }
-            Self::check_malformed_anomaly(flow, &mut self.all_findings, ts, &flow_key, direction);
+            Self::check_malformed_anomaly(
+                flow,
+                &mut self.all_findings,
+                &mut self.dropped_findings,
+                ts,
+                &flow_key,
+                direction,
+            );
             // Fall through to frame-walk. Do NOT return early.
             // The frame-walk will find a valid head frame (if preserved) or
             // carry.len() < 3 → break immediately (empty carry). Both are correct.
@@ -554,6 +579,7 @@ impl Dnp3Analyzer {
                         Self::check_malformed_anomaly(
                             flow,
                             &mut self.all_findings,
+                            &mut self.dropped_findings,
                             ts,
                             &flow_key,
                             direction,
@@ -586,6 +612,7 @@ impl Dnp3Analyzer {
                             Self::check_malformed_anomaly(
                                 flow,
                                 &mut self.all_findings,
+                                &mut self.dropped_findings,
                                 ts,
                                 &flow_key,
                                 direction,
@@ -636,6 +663,7 @@ impl Dnp3Analyzer {
                 Self::check_malformed_anomaly(
                     flow,
                     &mut self.all_findings,
+                    &mut self.dropped_findings,
                     ts,
                     &flow_key,
                     direction,
@@ -697,6 +725,7 @@ impl Dnp3Analyzer {
                     Self::check_malformed_anomaly(
                         flow,
                         &mut self.all_findings,
+                        &mut self.dropped_findings,
                         ts,
                         &flow_key,
                         direction,
@@ -724,6 +753,7 @@ impl Dnp3Analyzer {
                     Self::check_malformed_anomaly(
                         flow,
                         &mut self.all_findings,
+                        &mut self.dropped_findings,
                         ts,
                         &flow_key,
                         direction,
@@ -747,11 +777,14 @@ impl Dnp3Analyzer {
 
             // BC-2.15.016 PC5–6: master-direction (DIR=1) frame → record its source
             // address in master_addrs_seen, deduplicated and capped at MAX_MASTER_ADDRS.
-            if is_master_frame(header.control)
-                && !flow.master_addrs_seen.contains(&header.source)
-                && flow.master_addrs_seen.len() < MAX_MASTER_ADDRS
-            {
-                flow.master_addrs_seen.push(header.source);
+            // BC-2.15.016 v2.1 PC-6: increment master_addrs_dropped when a NEW unique
+            // master address is silently ignored because the cap is already full.
+            if is_master_frame(header.control) && !flow.master_addrs_seen.contains(&header.source) {
+                if flow.master_addrs_seen.len() < MAX_MASTER_ADDRS {
+                    flow.master_addrs_seen.push(header.source);
+                } else {
+                    self.master_addrs_dropped += 1;
+                }
             }
 
             // BC-2.15.008 FIR=1 + user-data gate: extract the application FC only from
@@ -781,6 +814,7 @@ impl Dnp3Analyzer {
                         Self::detect_unsolicited_control(
                             flow,
                             &mut self.all_findings,
+                            &mut self.dropped_findings,
                             app_fc,
                             dest,
                             src,
@@ -798,6 +832,7 @@ impl Dnp3Analyzer {
                                 Self::detect_broadcast_anomaly(
                                     flow,
                                     &mut self.all_findings,
+                                    &mut self.dropped_findings,
                                     app_fc,
                                     dest,
                                     src,
@@ -821,6 +856,7 @@ impl Dnp3Analyzer {
                                 Self::detect_unexpected_source_split(
                                     flow,
                                     &mut self.all_findings,
+                                    &mut self.dropped_findings,
                                     app_fc,
                                     dest,
                                     src,
@@ -836,13 +872,16 @@ impl Dnp3Analyzer {
                             // STORY-109: 0x06 is excluded from pending_requests.
                             if app_fc != 0x06 {
                                 let app_seq = active_carry!(flow, direction)[11] & 0x0F;
-                                Self::insert_pending_request(flow, (dest, app_seq), ts);
+                                if Self::insert_pending_request(flow, (dest, app_seq), ts) {
+                                    self.pending_requests_evicted += 1;
+                                }
                             }
 
                             // Detection burst branch (also increments direct_operate_count).
                             Self::detect_control_class_burst_split(
                                 flow,
                                 &mut self.all_findings,
+                                &mut self.dropped_findings,
                                 self.direct_operate_threshold,
                                 app_fc,
                                 ts,
@@ -858,6 +897,7 @@ impl Dnp3Analyzer {
                             Self::detect_restart_split(
                                 flow,
                                 &mut self.all_findings,
+                                &mut self.dropped_findings,
                                 app_fc,
                                 dest,
                                 src,
@@ -869,6 +909,7 @@ impl Dnp3Analyzer {
                             Self::maybe_emit_t0827(
                                 flow,
                                 &mut self.all_findings,
+                                &mut self.dropped_findings,
                                 ts,
                                 dest,
                                 &flow_key,
@@ -878,6 +919,7 @@ impl Dnp3Analyzer {
                         Dnp3FcClass::Write => {
                             Self::detect_write_split(
                                 &mut self.all_findings,
+                                &mut self.dropped_findings,
                                 dest,
                                 src,
                                 ts,
@@ -895,6 +937,7 @@ impl Dnp3Analyzer {
                             Self::detect_unsolicited_anomaly(
                                 flow,
                                 &mut self.all_findings,
+                                &mut self.dropped_findings,
                                 app_fc,
                                 app_ctrl,
                                 dest,
@@ -951,6 +994,7 @@ impl Dnp3Analyzer {
     fn detect_control_class_burst_split(
         flow: &mut Dnp3FlowState,
         findings: &mut Vec<Finding>,
+        dropped_findings: &mut u64,
         direct_operate_threshold: u32,
         app_fc: u8,
         now_ts: u32,
@@ -984,37 +1028,40 @@ impl Dnp3Analyzer {
         if flow.direct_operate_count > direct_operate_threshold
             && !flow.direct_operate_emitted
             && now_ts.saturating_sub(flow.window_start_ts) <= DETECTION_WINDOW_SECS
-            && findings.len() < MAX_FINDINGS
         {
-            let count = flow.direct_operate_count;
-            let elapsed = now_ts.saturating_sub(flow.window_start_ts);
-            let threshold = direct_operate_threshold;
-            // BC-2.15.010 PC3: resolve master endpoint from FlowKey using direction.
-            // STORY-140 AC-140-002: replace port-heuristic with direction-based resolution.
-            let (client_ip, server_ip) = if flow_key.lower_port() == 20000 {
-                (flow_key.upper_ip(), flow_key.lower_ip())
+            if findings.len() < MAX_FINDINGS {
+                let count = flow.direct_operate_count;
+                let elapsed = now_ts.saturating_sub(flow.window_start_ts);
+                let threshold = direct_operate_threshold;
+                // BC-2.15.010 PC3: resolve master endpoint from FlowKey using direction.
+                // STORY-140 AC-140-002: replace port-heuristic with direction-based resolution.
+                let (client_ip, server_ip) = if flow_key.lower_port() == 20000 {
+                    (flow_key.upper_ip(), flow_key.lower_ip())
+                } else {
+                    (flow_key.lower_ip(), flow_key.upper_ip())
+                };
+                let master_ip = match direction {
+                    Direction::ClientToServer => client_ip,
+                    Direction::ServerToClient => server_ip,
+                };
+                findings.push(Finding {
+                    category: crate::findings::ThreatCategory::Execution,
+                    verdict: crate::findings::Verdict::Likely,
+                    confidence: crate::findings::Confidence::Medium,
+                    summary: format!(
+                        "DNP3 unauthorized control command burst: {count} control FCs \
+                         in {elapsed}s window (threshold {threshold})"
+                    ),
+                    evidence: vec![format!("FC=0x{app_fc:02X} dest={dest:#06X} src={src:#06X}")],
+                    mitre_techniques: vec!["T1692.001".to_string()],
+                    source_ip: Some(master_ip),
+                    timestamp: chrono::DateTime::from_timestamp(now_ts as i64, 0),
+                    direction: None,
+                });
+                flow.direct_operate_emitted = true;
             } else {
-                (flow_key.lower_ip(), flow_key.upper_ip())
-            };
-            let master_ip = match direction {
-                Direction::ClientToServer => client_ip,
-                Direction::ServerToClient => server_ip,
-            };
-            findings.push(Finding {
-                category: crate::findings::ThreatCategory::Execution,
-                verdict: crate::findings::Verdict::Likely,
-                confidence: crate::findings::Confidence::Medium,
-                summary: format!(
-                    "DNP3 unauthorized control command burst: {count} control FCs \
-                     in {elapsed}s window (threshold {threshold})"
-                ),
-                evidence: vec![format!("FC=0x{app_fc:02X} dest={dest:#06X} src={src:#06X}")],
-                mitre_techniques: vec!["T1692.001".to_string()],
-                source_ip: Some(master_ip),
-                timestamp: chrono::DateTime::from_timestamp(now_ts as i64, 0),
-                direction: None,
-            });
-            flow.direct_operate_emitted = true;
+                *dropped_findings += 1;
+            }
         }
     }
 
@@ -1029,6 +1076,7 @@ impl Dnp3Analyzer {
     fn detect_restart_split(
         flow: &mut Dnp3FlowState,
         findings: &mut Vec<Finding>,
+        dropped_findings: &mut u64,
         app_fc: u8,
         dest: u16,
         src: u16,
@@ -1067,6 +1115,8 @@ impl Dnp3Analyzer {
                 timestamp: chrono::DateTime::from_timestamp(now_ts as i64, 0),
                 direction: None,
             });
+        } else {
+            *dropped_findings += 1;
         }
 
         // BC-2.15.011 postcondition 2 / Architecture Compliance Rule 3:
@@ -1084,6 +1134,7 @@ impl Dnp3Analyzer {
     /// Cap check: `findings.len() < MAX_FINDINGS` evaluated before push.
     fn detect_write_split(
         findings: &mut Vec<Finding>,
+        dropped_findings: &mut u64,
         dest: u16,
         src: u16,
         now_ts: u32,
@@ -1115,6 +1166,8 @@ impl Dnp3Analyzer {
                 timestamp: chrono::DateTime::from_timestamp(now_ts as i64, 0),
                 direction: None,
             });
+        } else {
+            *dropped_findings += 1;
         }
     }
 
@@ -1137,6 +1190,7 @@ impl Dnp3Analyzer {
     fn scan_block_timeouts(
         flow: &mut Dnp3FlowState,
         findings: &mut Vec<Finding>,
+        dropped_findings: &mut u64,
         now_ts: u32,
         flow_key: &FlowKey,
         direction: Direction,
@@ -1166,38 +1220,40 @@ impl Dnp3Analyzer {
             flow.block_event_count += 1;
         }
         // BC-2.15.014 PC3: emit T1691.001 when threshold reached, guard clear, in-window.
-        if flow.block_event_count >= BLOCK_CMD_THRESHOLD
-            && !flow.block_finding_emitted_this_window
-            && findings.len() < MAX_FINDINGS
+        if flow.block_event_count >= BLOCK_CMD_THRESHOLD && !flow.block_finding_emitted_this_window
         {
-            let (client_ip, server_ip) = if flow_key.lower_port() == 20000 {
-                (flow_key.upper_ip(), flow_key.lower_ip())
+            if findings.len() < MAX_FINDINGS {
+                let (client_ip, server_ip) = if flow_key.lower_port() == 20000 {
+                    (flow_key.upper_ip(), flow_key.lower_ip())
+                } else {
+                    (flow_key.lower_ip(), flow_key.upper_ip())
+                };
+                let master_ip = match direction {
+                    Direction::ClientToServer => client_ip,
+                    Direction::ServerToClient => server_ip,
+                };
+                findings.push(Finding {
+                    category: crate::findings::ThreatCategory::Execution,
+                    verdict: crate::findings::Verdict::Possible,
+                    confidence: crate::findings::Confidence::Low,
+                    summary: format!(
+                        "DNP3 inferred blocked command: {} requests without response \
+                         within {}s (dest={:#06X})",
+                        flow.block_event_count, BLOCK_CMD_TIMEOUT_SECS, min_timedout_dest
+                    ),
+                    evidence: vec![format!(
+                        "block_event_count={} in correlation window; threshold={}",
+                        flow.block_event_count, BLOCK_CMD_THRESHOLD
+                    )],
+                    mitre_techniques: vec!["T1691.001".to_string()],
+                    source_ip: Some(master_ip),
+                    timestamp: chrono::DateTime::from_timestamp(now_ts as i64, 0),
+                    direction: None,
+                });
+                flow.block_finding_emitted_this_window = true;
             } else {
-                (flow_key.lower_ip(), flow_key.upper_ip())
-            };
-            let master_ip = match direction {
-                Direction::ClientToServer => client_ip,
-                Direction::ServerToClient => server_ip,
-            };
-            findings.push(Finding {
-                category: crate::findings::ThreatCategory::Execution,
-                verdict: crate::findings::Verdict::Possible,
-                confidence: crate::findings::Confidence::Low,
-                summary: format!(
-                    "DNP3 inferred blocked command: {} requests without response \
-                     within {}s (dest={:#06X})",
-                    flow.block_event_count, BLOCK_CMD_TIMEOUT_SECS, min_timedout_dest
-                ),
-                evidence: vec![format!(
-                    "block_event_count={} in correlation window; threshold={}",
-                    flow.block_event_count, BLOCK_CMD_THRESHOLD
-                )],
-                mitre_techniques: vec!["T1691.001".to_string()],
-                source_ip: Some(master_ip),
-                timestamp: chrono::DateTime::from_timestamp(now_ts as i64, 0),
-                direction: None,
-            });
-            flow.block_finding_emitted_this_window = true;
+                *dropped_findings += 1;
+            }
         }
 
         // BC-2.15.015 PC5 / EC-002: T0827 must fire in the same on_data call that crosses
@@ -1214,6 +1270,7 @@ impl Dnp3Analyzer {
             Self::maybe_emit_t0827(
                 flow,
                 findings,
+                dropped_findings,
                 now_ts,
                 min_timedout_dest,
                 flow_key,
@@ -1281,50 +1338,52 @@ impl Dnp3Analyzer {
     fn maybe_emit_t0827(
         flow: &mut Dnp3FlowState,
         findings: &mut Vec<Finding>,
+        dropped_findings: &mut u64,
         now_ts: u32,
         dest: u16,
         flow_key: &FlowKey,
         direction: Direction,
     ) {
         let combined = flow.restart_event_count + flow.block_event_count;
-        if combined >= T0827_THRESHOLD
-            && !flow.loss_of_control_emitted
-            && findings.len() < MAX_FINDINGS
-        {
-            let (client_ip, server_ip) = if flow_key.lower_port() == 20000 {
-                (flow_key.upper_ip(), flow_key.lower_ip())
+        if combined >= T0827_THRESHOLD && !flow.loss_of_control_emitted {
+            if findings.len() < MAX_FINDINGS {
+                let (client_ip, server_ip) = if flow_key.lower_port() == 20000 {
+                    (flow_key.upper_ip(), flow_key.lower_ip())
+                } else {
+                    (flow_key.lower_ip(), flow_key.upper_ip())
+                };
+                let master_ip = match direction {
+                    Direction::ClientToServer => client_ip,
+                    Direction::ServerToClient => server_ip,
+                };
+                let elapsed = now_ts.saturating_sub(flow.correlation_window_start_ts);
+                let restart_count = flow.restart_event_count;
+                let block_count = flow.block_event_count;
+                findings.push(Finding {
+                    category: crate::findings::ThreatCategory::Impact,
+                    verdict: crate::findings::Verdict::Likely,
+                    confidence: crate::findings::Confidence::Medium,
+                    // BC-2.15.015 PC1 exact format:
+                    // "DNP3 sustained loss-of-control pattern: {restart_count} restart events +
+                    //  {block_count} blocked commands within {elapsed}s on flow (dest={dest:#06X})"
+                    summary: format!(
+                        "DNP3 sustained loss-of-control pattern: \
+                         {restart_count} restart events + {block_count} blocked commands \
+                         within {elapsed}s on flow (dest={dest:#06X})"
+                    ),
+                    evidence: vec![format!(
+                        "restart_event_count={restart_count} block_event_count={block_count} \
+                         threshold={T0827_THRESHOLD}"
+                    )],
+                    mitre_techniques: vec!["T0827".to_string()],
+                    source_ip: Some(master_ip),
+                    timestamp: chrono::DateTime::from_timestamp(now_ts as i64, 0),
+                    direction: None,
+                });
+                flow.loss_of_control_emitted = true;
             } else {
-                (flow_key.lower_ip(), flow_key.upper_ip())
-            };
-            let master_ip = match direction {
-                Direction::ClientToServer => client_ip,
-                Direction::ServerToClient => server_ip,
-            };
-            let elapsed = now_ts.saturating_sub(flow.correlation_window_start_ts);
-            let restart_count = flow.restart_event_count;
-            let block_count = flow.block_event_count;
-            findings.push(Finding {
-                category: crate::findings::ThreatCategory::Impact,
-                verdict: crate::findings::Verdict::Likely,
-                confidence: crate::findings::Confidence::Medium,
-                // BC-2.15.015 PC1 exact format:
-                // "DNP3 sustained loss-of-control pattern: {restart_count} restart events +
-                //  {block_count} blocked commands within {elapsed}s on flow (dest={dest:#06X})"
-                summary: format!(
-                    "DNP3 sustained loss-of-control pattern: \
-                     {restart_count} restart events + {block_count} blocked commands \
-                     within {elapsed}s on flow (dest={dest:#06X})"
-                ),
-                evidence: vec![format!(
-                    "restart_event_count={restart_count} block_event_count={block_count} \
-                     threshold={T0827_THRESHOLD}"
-                )],
-                mitre_techniques: vec!["T0827".to_string()],
-                source_ip: Some(master_ip),
-                timestamp: chrono::DateTime::from_timestamp(now_ts as i64, 0),
-                direction: None,
-            });
-            flow.loss_of_control_emitted = true;
+                *dropped_findings += 1;
+            }
         }
     }
 
@@ -1343,6 +1402,7 @@ impl Dnp3Analyzer {
     fn detect_broadcast_anomaly(
         _flow: &mut Dnp3FlowState,
         findings: &mut Vec<Finding>,
+        dropped_findings: &mut u64,
         app_fc: u8,
         dest: u16,
         src: u16,
@@ -1381,6 +1441,8 @@ impl Dnp3Analyzer {
                 timestamp: chrono::DateTime::from_timestamp(now_ts as i64, 0),
                 direction: None,
             });
+        } else {
+            *dropped_findings += 1;
         }
         // BC-2.15.018 PC2: direct_operate_count incremented so burst threshold can fire.
         // The burst detection (detect_control_class_burst_split) runs after this in on_data
@@ -1406,6 +1468,7 @@ impl Dnp3Analyzer {
     fn detect_unexpected_source_split(
         flow: &mut Dnp3FlowState,
         findings: &mut Vec<Finding>,
+        dropped_findings: &mut u64,
         app_fc: u8,
         dest: u16,
         src: u16,
@@ -1413,7 +1476,11 @@ impl Dnp3Analyzer {
         flow_key: &FlowKey,
         direction: Direction,
     ) {
-        if flow.unexpected_source_emitted || findings.len() >= MAX_FINDINGS {
+        if flow.unexpected_source_emitted {
+            return;
+        }
+        if findings.len() >= MAX_FINDINGS {
+            *dropped_findings += 1;
             return;
         }
         // Build the expected master set string from master_addrs_seen, EXCLUDING `src`.
@@ -1477,6 +1544,7 @@ impl Dnp3Analyzer {
     fn detect_unsolicited_anomaly(
         flow: &mut Dnp3FlowState,
         findings: &mut Vec<Finding>,
+        dropped_findings: &mut u64,
         app_fc: u8,
         app_ctrl: u8,
         dest: u16,
@@ -1497,44 +1565,47 @@ impl Dnp3Analyzer {
             if !flow.enable_unsolicited_seen
                 && !flow.response_seen
                 && !flow.unsolicited_anomaly_emitted
-                && findings.len() < MAX_FINDINGS
             {
-                // UNS bit is bit 4 (0x10) of the application control byte
-                // (IEEE Std 1815-2012 §7.2.3); included in BC-2.15.019 PC1 evidence.
-                let uns_bit = (app_ctrl & 0x10) != 0;
-                let (client_ip, server_ip) = if flow_key.lower_port() == 20000 {
-                    (flow_key.upper_ip(), flow_key.lower_ip())
+                if findings.len() < MAX_FINDINGS {
+                    // UNS bit is bit 4 (0x10) of the application control byte
+                    // (IEEE Std 1815-2012 §7.2.3); included in BC-2.15.019 PC1 evidence.
+                    let uns_bit = (app_ctrl & 0x10) != 0;
+                    let (client_ip, server_ip) = if flow_key.lower_port() == 20000 {
+                        (flow_key.upper_ip(), flow_key.lower_ip())
+                    } else {
+                        (flow_key.lower_ip(), flow_key.upper_ip())
+                    };
+                    let master_ip = match direction {
+                        Direction::ClientToServer => client_ip,
+                        Direction::ServerToClient => server_ip,
+                    };
+                    findings.push(Finding {
+                        category: crate::findings::ThreatCategory::Suspicious,
+                        verdict: crate::findings::Verdict::Possible,
+                        confidence: crate::findings::Confidence::Low,
+                        // BC-2.15.019 PC1 exact summary format:
+                        // "DNP3 unexpected unsolicited response: UNSOLICITED_RESPONSE from
+                        //  src={src:#06X} with no prior ENABLE_UNSOLICITED or solicited
+                        //  exchange on this flow"
+                        summary: format!(
+                            "DNP3 unexpected unsolicited response: \
+                             UNSOLICITED_RESPONSE from src={src:#06X} \
+                             with no prior ENABLE_UNSOLICITED or solicited exchange on this flow"
+                        ),
+                        // BC-2.15.019 PC1 exact evidence format:
+                        // "FC=0x82 src={src:#06X} dest={dest:#06X} UNS_bit={uns_bit}"
+                        evidence: vec![format!(
+                            "FC=0x82 src={src:#06X} dest={dest:#06X} UNS_bit={uns_bit}"
+                        )],
+                        mitre_techniques: vec!["T0814".to_string()],
+                        source_ip: Some(master_ip),
+                        timestamp: chrono::DateTime::from_timestamp(now_ts as i64, 0),
+                        direction: None,
+                    });
+                    flow.unsolicited_anomaly_emitted = true;
                 } else {
-                    (flow_key.lower_ip(), flow_key.upper_ip())
-                };
-                let master_ip = match direction {
-                    Direction::ClientToServer => client_ip,
-                    Direction::ServerToClient => server_ip,
-                };
-                findings.push(Finding {
-                    category: crate::findings::ThreatCategory::Suspicious,
-                    verdict: crate::findings::Verdict::Possible,
-                    confidence: crate::findings::Confidence::Low,
-                    // BC-2.15.019 PC1 exact summary format:
-                    // "DNP3 unexpected unsolicited response: UNSOLICITED_RESPONSE from
-                    //  src={src:#06X} with no prior ENABLE_UNSOLICITED or solicited
-                    //  exchange on this flow"
-                    summary: format!(
-                        "DNP3 unexpected unsolicited response: \
-                         UNSOLICITED_RESPONSE from src={src:#06X} \
-                         with no prior ENABLE_UNSOLICITED or solicited exchange on this flow"
-                    ),
-                    // BC-2.15.019 PC1 exact evidence format:
-                    // "FC=0x82 src={src:#06X} dest={dest:#06X} UNS_bit={uns_bit}"
-                    evidence: vec![format!(
-                        "FC=0x82 src={src:#06X} dest={dest:#06X} UNS_bit={uns_bit}"
-                    )],
-                    mitre_techniques: vec!["T0814".to_string()],
-                    source_ip: Some(master_ip),
-                    timestamp: chrono::DateTime::from_timestamp(now_ts as i64, 0),
-                    direction: None,
-                });
-                flow.unsolicited_anomaly_emitted = true;
+                    *dropped_findings += 1;
+                }
             }
         }
     }
@@ -1555,6 +1626,7 @@ impl Dnp3Analyzer {
     fn detect_unsolicited_control(
         flow: &mut Dnp3FlowState,
         findings: &mut Vec<Finding>,
+        dropped_findings: &mut u64,
         app_fc: u8,
         dest: u16,
         src: u16,
@@ -1594,6 +1666,8 @@ impl Dnp3Analyzer {
                         timestamp: chrono::DateTime::from_timestamp(now_ts as i64, 0),
                         direction: None,
                     });
+                } else {
+                    *dropped_findings += 1;
                 }
             }
             0x14 => {
@@ -1631,6 +1705,8 @@ impl Dnp3Analyzer {
                         timestamp: chrono::DateTime::from_timestamp(now_ts as i64, 0),
                         direction: None,
                     });
+                } else {
+                    *dropped_findings += 1;
                 }
             }
             _ => {}
@@ -1650,6 +1726,7 @@ impl Dnp3Analyzer {
     fn check_malformed_anomaly(
         flow: &mut Dnp3FlowState,
         findings: &mut Vec<Finding>,
+        dropped_findings: &mut u64,
         now_ts: u32,
         flow_key: &FlowKey,
         direction: Direction,
@@ -1663,43 +1740,46 @@ impl Dnp3Analyzer {
         if flow.malformed_in_window >= MALFORMED_ANOMALY_THRESHOLD
             && !flow.malformed_anomaly_emitted
             && in_window
-            && findings.len() < MAX_FINDINGS
         {
-            let elapsed = now_ts.saturating_sub(flow.correlation_window_start_ts);
-            let count = flow.malformed_in_window;
-            let (client_ip, server_ip) = if flow_key.lower_port() == 20000 {
-                (flow_key.upper_ip(), flow_key.lower_ip())
+            if findings.len() < MAX_FINDINGS {
+                let elapsed = now_ts.saturating_sub(flow.correlation_window_start_ts);
+                let count = flow.malformed_in_window;
+                let (client_ip, server_ip) = if flow_key.lower_port() == 20000 {
+                    (flow_key.upper_ip(), flow_key.lower_ip())
+                } else {
+                    (flow_key.lower_ip(), flow_key.upper_ip())
+                };
+                let master_ip = match direction {
+                    Direction::ClientToServer => client_ip,
+                    Direction::ServerToClient => server_ip,
+                };
+                let src_ip = flow_key.lower_ip();
+                let dest_ip = flow_key.upper_ip();
+                findings.push(Finding {
+                    category: crate::findings::ThreatCategory::Anomaly,
+                    verdict: crate::findings::Verdict::Possible,
+                    confidence: crate::findings::Confidence::Low,
+                    summary: format!(
+                        "DNP3 structural anomaly: {count} malformed frames \
+                         in {elapsed}s window (flow {src_ip}\u{2192}{dest_ip}) \
+                         \u{2014} possible Crain-Sistrunk crash-probe"
+                    ),
+                    // BC-2.15.024 PC3 exact evidence format:
+                    // "malformed_in_window={count} in correlation window; threshold={threshold}"
+                    // (parse_errors field is NOT included)
+                    evidence: vec![format!(
+                        "malformed_in_window={count} in correlation window; \
+                         threshold={MALFORMED_ANOMALY_THRESHOLD}"
+                    )],
+                    mitre_techniques: vec!["T0814".to_string()],
+                    source_ip: Some(master_ip),
+                    timestamp: chrono::DateTime::from_timestamp(now_ts as i64, 0),
+                    direction: None,
+                });
+                flow.malformed_anomaly_emitted = true;
             } else {
-                (flow_key.lower_ip(), flow_key.upper_ip())
-            };
-            let master_ip = match direction {
-                Direction::ClientToServer => client_ip,
-                Direction::ServerToClient => server_ip,
-            };
-            let src_ip = flow_key.lower_ip();
-            let dest_ip = flow_key.upper_ip();
-            findings.push(Finding {
-                category: crate::findings::ThreatCategory::Anomaly,
-                verdict: crate::findings::Verdict::Possible,
-                confidence: crate::findings::Confidence::Low,
-                summary: format!(
-                    "DNP3 structural anomaly: {count} malformed frames \
-                     in {elapsed}s window (flow {src_ip}\u{2192}{dest_ip}) \
-                     \u{2014} possible Crain-Sistrunk crash-probe"
-                ),
-                // BC-2.15.024 PC3 exact evidence format:
-                // "malformed_in_window={count} in correlation window; threshold={threshold}"
-                // (parse_errors field is NOT included)
-                evidence: vec![format!(
-                    "malformed_in_window={count} in correlation window; \
-                     threshold={MALFORMED_ANOMALY_THRESHOLD}"
-                )],
-                mitre_techniques: vec!["T0814".to_string()],
-                source_ip: Some(master_ip),
-                timestamp: chrono::DateTime::from_timestamp(now_ts as i64, 0),
-                direction: None,
-            });
-            flow.malformed_anomaly_emitted = true;
+                *dropped_findings += 1;
+            }
         }
     }
 
@@ -1780,6 +1860,20 @@ impl Dnp3Analyzer {
             "flows_analyzed".to_string(),
             serde_json::Value::Number(flows_analyzed.into()),
         );
+        // BC-2.15.022 v1.5 / BC-2.15.020 v1.5: three observability counters.
+        // Always present, zero-defaulted when the cap/eviction event has never fired.
+        detail.insert(
+            "dropped_findings".to_string(),
+            serde_json::Value::Number(self.dropped_findings.into()),
+        );
+        detail.insert(
+            "master_addrs_dropped".to_string(),
+            serde_json::Value::Number(self.master_addrs_dropped.into()),
+        );
+        detail.insert(
+            "pending_requests_evicted".to_string(),
+            serde_json::Value::Number(self.pending_requests_evicted.into()),
+        );
 
         AnalysisSummary {
             analyzer_name: "DNP3".to_string(),
@@ -1796,7 +1890,10 @@ impl Dnp3Analyzer {
     /// (oldest) is evicted **before** the new entry is inserted (ties broken arbitrarily
     /// per PC9). The evicted entry is silently dropped — it generates NO T1691.001
     /// timeout event (PC10).
-    fn insert_pending_request(flow: &mut Dnp3FlowState, key: (u16, u8), request_ts: u32) {
+    ///
+    /// Returns `true` when an LRU eviction occurred (BC-2.15.016 v2.1 PC-10 counter site);
+    /// returns `false` on a normal insert or in-place overwrite.
+    fn insert_pending_request(flow: &mut Dnp3FlowState, key: (u16, u8), request_ts: u32) -> bool {
         // If the key already exists we are overwriting in place — no growth, no eviction.
         if flow.pending_requests.len() >= MAX_PENDING_REQUESTS
             && !flow.pending_requests.contains_key(&key)
@@ -1810,8 +1907,11 @@ impl Dnp3Analyzer {
             {
                 flow.pending_requests.remove(&oldest_key);
             }
+            flow.pending_requests.insert(key, request_ts);
+            return true;
         }
         flow.pending_requests.insert(key, request_ts);
+        false
     }
 }
 

--- a/src/analyzer/dnp3.rs
+++ b/src/analyzer/dnp3.rs
@@ -1061,6 +1061,9 @@ impl Dnp3Analyzer {
                 flow.direct_operate_emitted = true;
             } else {
                 *dropped_findings += 1;
+                // Prevent re-counting on the next on_data call: the logical finding was
+                // seen once, the cap blocked it once.  Guard mirrors the emit path.
+                flow.direct_operate_emitted = true;
             }
         }
     }
@@ -1253,6 +1256,8 @@ impl Dnp3Analyzer {
                 flow.block_finding_emitted_this_window = true;
             } else {
                 *dropped_findings += 1;
+                // Prevent re-counting: block-finding was observed once; cap blocked it once.
+                flow.block_finding_emitted_this_window = true;
             }
         }
 
@@ -1383,6 +1388,8 @@ impl Dnp3Analyzer {
                 flow.loss_of_control_emitted = true;
             } else {
                 *dropped_findings += 1;
+                // Prevent re-counting: T0827 was observed once; cap blocked it once.
+                flow.loss_of_control_emitted = true;
             }
         }
     }
@@ -1481,6 +1488,8 @@ impl Dnp3Analyzer {
         }
         if findings.len() >= MAX_FINDINGS {
             *dropped_findings += 1;
+            // Prevent re-counting: unexpected-source was observed once; cap blocked it once.
+            flow.unexpected_source_emitted = true;
             return;
         }
         // Build the expected master set string from master_addrs_seen, EXCLUDING `src`.
@@ -1605,6 +1614,8 @@ impl Dnp3Analyzer {
                     flow.unsolicited_anomaly_emitted = true;
                 } else {
                     *dropped_findings += 1;
+                    // Prevent re-counting: unsolicited anomaly was observed once; cap blocked it.
+                    flow.unsolicited_anomaly_emitted = true;
                 }
             }
         }
@@ -1779,6 +1790,8 @@ impl Dnp3Analyzer {
                 flow.malformed_anomaly_emitted = true;
             } else {
                 *dropped_findings += 1;
+                // Prevent re-counting: malformed anomaly was observed once; cap blocked it.
+                flow.malformed_anomaly_emitted = true;
             }
         }
     }

--- a/tests/bc_2_15_020_dnp3_observability_counters_tests.rs
+++ b/tests/bc_2_15_020_dnp3_observability_counters_tests.rs
@@ -29,7 +29,7 @@ mod bc_2_15_020_dnp3_observability_counters {
     use std::net::{IpAddr, Ipv4Addr};
 
     use wirerust::analyzer::dnp3::{
-        Dnp3Analyzer, BLOCK_CMD_TIMEOUT_SECS, MAX_FINDINGS, MAX_MASTER_ADDRS, MAX_PENDING_REQUESTS,
+        BLOCK_CMD_TIMEOUT_SECS, Dnp3Analyzer, MAX_FINDINGS, MAX_MASTER_ADDRS, MAX_PENDING_REQUESTS,
     };
     use wirerust::findings::{Confidence, Finding, ThreatCategory, Verdict};
     use wirerust::reassembly::flow::FlowKey;

--- a/tests/bc_2_15_020_dnp3_observability_counters_tests.rs
+++ b/tests/bc_2_15_020_dnp3_observability_counters_tests.rs
@@ -119,18 +119,15 @@ mod bc_2_15_020_dnp3_observability_counters {
     fn test_BC_2_15_020_dropped_findings_key_present_zero_on_fresh_analyzer() {
         let analyzer = Dnp3Analyzer::new(10);
         let summary = analyzer.summarize();
-        let val = summary
-            .detail
-            .get("dropped_findings")
-            .unwrap_or_else(|| {
-                panic!(
-                    "BC-2.15.020 v1.5 / BC-2.15.022 v1.5: Dnp3Analyzer summarize() must contain \
+        let val = summary.detail.get("dropped_findings").unwrap_or_else(|| {
+            panic!(
+                "BC-2.15.020 v1.5 / BC-2.15.022 v1.5: Dnp3Analyzer summarize() must contain \
                      key 'dropped_findings' (u64, always-present, 0 when cap never hit). \
                      Key is MISSING — red gate expected on current code. \
                      Keys present: {:?}",
-                    summary.detail.keys().collect::<Vec<_>>()
-                )
-            });
+                summary.detail.keys().collect::<Vec<_>>()
+            )
+        });
         assert_eq!(
             val.as_u64(),
             Some(0),
@@ -395,8 +392,7 @@ mod bc_2_15_020_dnp3_observability_counters {
             .expect("'master_addrs_dropped' key must still be present after re-visit");
 
         assert_eq!(
-            after,
-            before,
+            after, before,
             "BC-2.15.016 v2.1 NEG (negative): 'master_addrs_dropped' must NOT increment when \
              a KNOWN master address (src=0, already in master_addrs_seen) is re-seen while \
              master_addrs_seen is at MAX_MASTER_ADDRS={}. \
@@ -451,7 +447,12 @@ mod bc_2_15_020_dnp3_observability_counters {
         // After: oldest entry evicted, new entry inserted, map still at 256,
         //        `pending_requests_evicted` incremented by 1.
         let eviction_frame = build_dnp3_detection_frame(0x05, MAX_PENDING_REQUESTS as u16, 1u16);
-        analyzer.on_data(key.clone(), &eviction_frame, 1000, Direction::ClientToServer);
+        analyzer.on_data(
+            key.clone(),
+            &eviction_frame,
+            1000,
+            Direction::ClientToServer,
+        );
 
         let summary = analyzer.summarize();
         let evicted = summary
@@ -493,8 +494,8 @@ mod bc_2_15_020_dnp3_observability_counters {
     ///
     /// RED GATE: key absent → panic before the zero assertion.
     #[test]
-    fn test_BC_2_15_016_NEG_normal_request_response_completion_does_not_increment_pending_requests_evicted(
-    ) {
+    fn test_BC_2_15_016_NEG_normal_request_response_completion_does_not_increment_pending_requests_evicted()
+     {
         let mut analyzer = Dnp3Analyzer::new(1000);
         let key = dnp3_flow_key();
 
@@ -525,8 +526,7 @@ mod bc_2_15_020_dnp3_observability_counters {
             .expect("'pending_requests_evicted' must be a u64");
 
         assert_eq!(
-            evicted,
-            0,
+            evicted, 0,
             "BC-2.15.016 v2.1 (negative): 'pending_requests_evicted' must be 0 after a normal \
              DIRECT_OPERATE (FC=0x05) / RESPONSE (FC=0x81) completion. Normal pending_requests \
              removal is NOT an LRU eviction. Got {evicted}."
@@ -604,14 +604,12 @@ mod bc_2_15_020_dnp3_observability_counters {
             // Assert no new Finding from the master_addrs drop event itself.
             let findings_after_drop = analyzer.all_findings.len();
             assert_eq!(
-                findings_after_drop,
-                findings_before_drop,
+                findings_after_drop, findings_before_drop,
                 "DNP3-EVICTION-NO-FINDING-NEG-TEST-001 Part A / BC-2.15.016 v2.1 Inv-2 \
                  (negative): `all_findings` must not grow due to a master_addrs_dropped counter \
                  event. Before drop: {} finding(s). After drop: {} finding(s). \
                  A cap-triggered master-address ignore is COUNTER-ONLY — no Finding emitted.",
-                findings_before_drop,
-                findings_after_drop
+                findings_before_drop, findings_after_drop
             );
         }
 
@@ -630,7 +628,12 @@ mod bc_2_15_020_dnp3_observability_counters {
 
             let eviction_frame =
                 build_dnp3_detection_frame(0x05, MAX_PENDING_REQUESTS as u16, 1u16);
-            analyzer.on_data(key.clone(), &eviction_frame, 1000, Direction::ClientToServer);
+            analyzer.on_data(
+                key.clone(),
+                &eviction_frame,
+                1000,
+                Direction::ClientToServer,
+            );
 
             // Assert counter was incremented (RED GATE: panics on missing key).
             let summary = analyzer.summarize();
@@ -657,14 +660,12 @@ mod bc_2_15_020_dnp3_observability_counters {
             // Assert no new Finding from the LRU eviction event itself.
             let findings_after_evict = analyzer.all_findings.len();
             assert_eq!(
-                findings_after_evict,
-                findings_before_evict,
+                findings_after_evict, findings_before_evict,
                 "DNP3-EVICTION-NO-FINDING-NEG-TEST-001 Part B / BC-2.15.016 v2.1 Inv-5 \
                  (negative): `all_findings` must not grow due to a pending_requests LRU \
                  eviction. Before eviction: {} finding(s). After eviction: {} finding(s). \
                  LRU eviction is COUNTER-ONLY — no Finding, no T1691.001 timeout event.",
-                findings_before_evict,
-                findings_after_evict
+                findings_before_evict, findings_after_evict
             );
         }
 

--- a/tests/bc_2_15_020_dnp3_observability_counters_tests.rs
+++ b/tests/bc_2_15_020_dnp3_observability_counters_tests.rs
@@ -29,7 +29,7 @@ mod bc_2_15_020_dnp3_observability_counters {
     use std::net::{IpAddr, Ipv4Addr};
 
     use wirerust::analyzer::dnp3::{
-        Dnp3Analyzer, MAX_FINDINGS, MAX_MASTER_ADDRS, MAX_PENDING_REQUESTS,
+        Dnp3Analyzer, BLOCK_CMD_TIMEOUT_SECS, MAX_FINDINGS, MAX_MASTER_ADDRS, MAX_PENDING_REQUESTS,
     };
     use wirerust::findings::{Confidence, Finding, ThreatCategory, Verdict};
     use wirerust::reassembly::flow::FlowKey;
@@ -720,5 +720,66 @@ mod bc_2_15_020_dnp3_observability_counters {
                 analyzer.all_findings.len()
             );
         }
+    }
+
+    // -----------------------------------------------------------------------
+    // NEGATIVE: scan_block_timeouts age-out does NOT increment pending_requests_evicted
+    // (CR-002 finding follow-up; BC-2.15.016 v2.1 PC-10 negative path)
+    // -----------------------------------------------------------------------
+
+    /// BC-2.15.016 v2.1 NEG (age-out path):
+    ///
+    /// `scan_block_timeouts` removes timed-out entries from `pending_requests` directly via
+    /// `pending_requests.remove()`, bypassing `insert_pending_request`.  Therefore the
+    /// `pending_requests_evicted` counter must NOT increment when a pending request ages out
+    /// (i.e., exceeds BLOCK_CMD_TIMEOUT_SECS without receiving a matching RESPONSE).
+    ///
+    /// Sequence:
+    ///   1. Send DIRECT_OPERATE (FC=0x05) at ts=0 — inserts key (dest=3, app_seq=0).
+    ///   2. Send any frame at ts=BLOCK_CMD_TIMEOUT_SECS+1 — triggers scan_block_timeouts,
+    ///      which ages out and removes the request entry.
+    ///   3. Assert pending_requests_evicted == 0.
+    #[test]
+    fn test_BC_2_15_016_NEG_scan_block_timeouts_ageout_does_not_increment_pending_requests_evicted()
+    {
+        let mut analyzer = Dnp3Analyzer::new(1000);
+        let key = dnp3_flow_key();
+
+        // Step 1: DIRECT_OPERATE request at ts=0 — inserts (dest=3, app_seq=0) into pending.
+        let request_frame = build_dnp3_detection_frame(0x05, 3u16, 1u16);
+        analyzer.on_data(key.clone(), &request_frame, 0, Direction::ClientToServer);
+
+        // Step 2: Any frame at ts > BLOCK_CMD_TIMEOUT_SECS — triggers age-out in scan_block_timeouts.
+        let trigger_frame = build_dnp3_detection_frame(0x01, 3u16, 1u16);
+        analyzer.on_data(
+            key.clone(),
+            &trigger_frame,
+            BLOCK_CMD_TIMEOUT_SECS + 1,
+            Direction::ClientToServer,
+        );
+
+        // Step 3: pending_requests_evicted must be 0 — age-out is not an LRU eviction.
+        let summary = analyzer.summarize();
+        let evicted = summary
+            .detail
+            .get("pending_requests_evicted")
+            .unwrap_or_else(|| {
+                panic!(
+                    "BC-2.15.016 v2.1 NEG (age-out): 'pending_requests_evicted' key must be \
+                     present in summarize(). Key MISSING — implementation incomplete. \
+                     Keys present: {:?}",
+                    summary.detail.keys().collect::<Vec<_>>()
+                )
+            })
+            .as_u64()
+            .expect("'pending_requests_evicted' must be a u64");
+
+        assert_eq!(
+            evicted, 0,
+            "BC-2.15.016 v2.1 (negative / age-out): 'pending_requests_evicted' must be 0 when a \
+             pending request is removed by scan_block_timeouts age-out (BLOCK_CMD_TIMEOUT_SECS={}s). \
+             Age-out removal via pending_requests.remove() is NOT an LRU eviction. Got {evicted}.",
+            BLOCK_CMD_TIMEOUT_SECS
+        );
     }
 } // mod bc_2_15_020_dnp3_observability_counters

--- a/tests/bc_2_15_020_dnp3_observability_counters_tests.rs
+++ b/tests/bc_2_15_020_dnp3_observability_counters_tests.rs
@@ -8,8 +8,9 @@
 //!                       `pending_requests_evicted` incremented on MAX_PENDING_REQUESTS=256 LRU eviction
 //!   BC-2.15.022 v1.5 — `dropped_findings` incremented on MAX_FINDINGS=10_000 cap suppression
 //!
-//! RED GATE: all tests MUST FAIL on the current codebase.  The three counter fields do not
-//! yet exist on `Dnp3Analyzer`, and `summarize()` does not yet emit the three detail keys.
+//! GREEN: all 9 tests pass.  The three counter fields (`dropped_findings`,
+//! `master_addrs_dropped`, `pending_requests_evicted`) are present on `Dnp3Analyzer`, and
+//! `summarize()` emits the corresponding detail keys (maint-2026-07-06 FIX-B, commit 636c0d6).
 //!
 //! Assertion strategy: all assertions target `summarize().detail` map keys so tests
 //! COMPILE even before the struct fields exist.  A missing key causes a runtime panic via

--- a/tests/bc_2_15_020_dnp3_observability_counters_tests.rs
+++ b/tests/bc_2_15_020_dnp3_observability_counters_tests.rs
@@ -1,0 +1,722 @@
+//! Failing tests (Red Gate) for three new observability counters on `Dnp3Analyzer`
+//! (silent-limit audit, FIX-B maintenance run maint-2026-07-06).
+//!
+//! Behavioral contracts covered:
+//!   BC-2.15.020 v1.5 — `dropped_findings`, `master_addrs_dropped`,
+//!                       `pending_requests_evicted` present in `summarize()` detail map (8 keys)
+//!   BC-2.15.016 v2.1 — `master_addrs_dropped` incremented on MAX_MASTER_ADDRS=64 cap;
+//!                       `pending_requests_evicted` incremented on MAX_PENDING_REQUESTS=256 LRU eviction
+//!   BC-2.15.022 v1.5 — `dropped_findings` incremented on MAX_FINDINGS=10_000 cap suppression
+//!
+//! RED GATE: all tests MUST FAIL on the current codebase.  The three counter fields do not
+//! yet exist on `Dnp3Analyzer`, and `summarize()` does not yet emit the three detail keys.
+//!
+//! Assertion strategy: all assertions target `summarize().detail` map keys so tests
+//! COMPILE even before the struct fields exist.  A missing key causes a runtime panic via
+//! `.unwrap_or_else()` — not a compile error — which is the correct red-gate failure mode.
+//!
+//! Site references from df-validation-pc019-pc020-2026-07-06.md:
+//!   - master_addrs cap/silent-ignore: dnp3.rs:146, 750-755
+//!   - pending_requests LRU eviction helper: dnp3.rs:1799-1815
+//!   - MAX_FINDINGS cap guards (11 sites): dnp3.rs:201, 987,1040,1093,1171,1292,1353,1416,1500,1569,1603,1666
+//!
+//! DF-TEST-NAMESPACE-001: all tests are wrapped in `mod bc_2_15_020_dnp3_observability_counters`.
+
+#![allow(non_snake_case)]
+
+mod bc_2_15_020_dnp3_observability_counters {
+    use std::net::{IpAddr, Ipv4Addr};
+
+    use wirerust::analyzer::dnp3::{
+        Dnp3Analyzer, MAX_FINDINGS, MAX_MASTER_ADDRS, MAX_PENDING_REQUESTS,
+    };
+    use wirerust::findings::{Confidence, Finding, ThreatCategory, Verdict};
+    use wirerust::reassembly::flow::FlowKey;
+    use wirerust::reassembly::handler::Direction;
+
+    // -----------------------------------------------------------------------
+    // Shared helpers
+    // -----------------------------------------------------------------------
+
+    fn dnp3_flow_key() -> FlowKey {
+        FlowKey::new(
+            IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+            20000,
+            IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)),
+            20000,
+        )
+    }
+
+    /// Build a minimal valid DNP3 link frame (15 bytes) carrying one application FC.
+    ///
+    /// Layout (mirrors the helper in `dnp3_detection_tests.rs::story_108`):
+    ///   [0..1]   0x05 0x64              (sync word)
+    ///   [2]      0x08                   (LENGTH=8 → frame_len = 5+8+2×1 = 15)
+    ///   [3]      0xC4                   (CTRL: DIR=1(0x80), PRM=1(0x40), FC-nibble=UNCONFIRMED_USER_DATA; has_user_data=true)
+    ///   [4..5]   dest little-endian
+    ///   [6..7]   src  little-endian
+    ///   [8..9]   0x00 0x00              (header CRC placeholder)
+    ///   [10]     0xC0                   (transport: FIR=1(0x40)|FIN=1(0x80))
+    ///   [11]     0x00                   (app control; app_seq = 0x00 & 0x0F = 0)
+    ///   [12]     app_fc
+    ///   [13..14] 0x00 0x00              (data-block CRC placeholder)
+    ///
+    /// is_master_frame(0xC4) = (0xC4 & 0x80 != 0) = true — all frames are master-direction.
+    fn build_dnp3_detection_frame(app_fc: u8, dest: u16, src: u16) -> Vec<u8> {
+        let length_byte: u8 = 8;
+        let u_bytes = (length_byte as usize) - 5; // 3
+        let blocks = u_bytes.div_ceil(16); // 1
+        let frame_len = 5 + (length_byte as usize) + 2 * blocks; // 15
+
+        let mut frame = vec![0u8; frame_len];
+        frame[0] = 0x05;
+        frame[1] = 0x64;
+        frame[2] = length_byte;
+        frame[3] = 0xC4;
+        let [dl, dh] = dest.to_le_bytes();
+        frame[4] = dl;
+        frame[5] = dh;
+        let [sl, sh] = src.to_le_bytes();
+        frame[6] = sl;
+        frame[7] = sh;
+        frame[10] = 0xC0;
+        frame[11] = 0x00;
+        frame[12] = app_fc;
+        frame
+    }
+
+    /// Minimal dummy `Finding` for pre-filling `all_findings` without triggering logic.
+    fn dummy_finding() -> Finding {
+        Finding {
+            category: ThreatCategory::Anomaly,
+            verdict: Verdict::Unlikely,
+            confidence: Confidence::Low,
+            summary: "pre-fill dummy".to_string(),
+            evidence: vec![],
+            mitre_techniques: vec![],
+            source_ip: None,
+            timestamp: None,
+            direction: None,
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // KEY-PRESENCE tests (BC-2.15.020 v1.5 Postcondition 1, Invariant 1)
+    //
+    // Each of the three new counter keys must appear in `summarize().detail` with
+    // value 0 on a freshly constructed (zero-input) `Dnp3Analyzer`.
+    //
+    // RED GATE: none of the three keys is currently emitted by `summarize()`.
+    // Missing key → `.unwrap_or_else()` panics → test fails at runtime, not compile time.
+    // -----------------------------------------------------------------------
+
+    /// BC-2.15.020 v1.5 PC-1 / BC-2.15.022 v1.5 Inv-5:
+    /// `dropped_findings` must always be present in `Dnp3Analyzer::summarize()` detail
+    /// with value 0 when the MAX_FINDINGS cap has never been hit.
+    ///
+    /// RED GATE: key absent from current `summarize()` → panic on `.unwrap_or_else()`.
+    #[test]
+    fn test_BC_2_15_020_dropped_findings_key_present_zero_on_fresh_analyzer() {
+        let analyzer = Dnp3Analyzer::new(10);
+        let summary = analyzer.summarize();
+        let val = summary
+            .detail
+            .get("dropped_findings")
+            .unwrap_or_else(|| {
+                panic!(
+                    "BC-2.15.020 v1.5 / BC-2.15.022 v1.5: Dnp3Analyzer summarize() must contain \
+                     key 'dropped_findings' (u64, always-present, 0 when cap never hit). \
+                     Key is MISSING — red gate expected on current code. \
+                     Keys present: {:?}",
+                    summary.detail.keys().collect::<Vec<_>>()
+                )
+            });
+        assert_eq!(
+            val.as_u64(),
+            Some(0),
+            "BC-2.15.022 v1.5: 'dropped_findings' must be 0 on a fresh analyzer, got: {val}"
+        );
+    }
+
+    /// BC-2.15.020 v1.5 PC-1 / BC-2.15.016 v2.1 PC-6:
+    /// `master_addrs_dropped` must always be present in `Dnp3Analyzer::summarize()` detail
+    /// with value 0 when MAX_MASTER_ADDRS=64 has never been reached.
+    ///
+    /// RED GATE: key absent from current `summarize()` → panic on `.unwrap_or_else()`.
+    #[test]
+    fn test_BC_2_15_020_master_addrs_dropped_key_present_zero_on_fresh_analyzer() {
+        let analyzer = Dnp3Analyzer::new(10);
+        let summary = analyzer.summarize();
+        let val = summary
+            .detail
+            .get("master_addrs_dropped")
+            .unwrap_or_else(|| {
+                panic!(
+                    "BC-2.15.020 v1.5 / BC-2.15.016 v2.1 PC-6: Dnp3Analyzer summarize() must \
+                     contain key 'master_addrs_dropped' (u64, always-present, 0 when cap never \
+                     reached). Key is MISSING — red gate expected on current code. \
+                     Keys present: {:?}",
+                    summary.detail.keys().collect::<Vec<_>>()
+                )
+            });
+        assert_eq!(
+            val.as_u64(),
+            Some(0),
+            "BC-2.15.016 v2.1: 'master_addrs_dropped' must be 0 on a fresh analyzer, got: {val}"
+        );
+    }
+
+    /// BC-2.15.020 v1.5 PC-1 / BC-2.15.016 v2.1 PC-10:
+    /// `pending_requests_evicted` must always be present in `Dnp3Analyzer::summarize()` detail
+    /// with value 0 when MAX_PENDING_REQUESTS=256 has never been reached.
+    ///
+    /// RED GATE: key absent from current `summarize()` → panic on `.unwrap_or_else()`.
+    #[test]
+    fn test_BC_2_15_020_pending_requests_evicted_key_present_zero_on_fresh_analyzer() {
+        let analyzer = Dnp3Analyzer::new(10);
+        let summary = analyzer.summarize();
+        let val = summary
+            .detail
+            .get("pending_requests_evicted")
+            .unwrap_or_else(|| {
+                panic!(
+                    "BC-2.15.020 v1.5 / BC-2.15.016 v2.1 PC-10: Dnp3Analyzer summarize() must \
+                     contain key 'pending_requests_evicted' (u64, always-present, 0 when cap \
+                     never reached). Key is MISSING — red gate expected on current code. \
+                     Keys present: {:?}",
+                    summary.detail.keys().collect::<Vec<_>>()
+                )
+            });
+        assert_eq!(
+            val.as_u64(),
+            Some(0),
+            "BC-2.15.016 v2.1: 'pending_requests_evicted' must be 0 on a fresh analyzer, got: {val}"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // INCREMENT ON EVENT tests
+    // -----------------------------------------------------------------------
+
+    /// BC-2.15.022 v1.5 PC-5: `dropped_findings` increments by 1 for each finding
+    /// suppressed because `all_findings.len() == MAX_FINDINGS = 10_000`.
+    ///
+    /// Mechanism: pre-fill `all_findings` to exactly MAX_FINDINGS via the public field
+    /// (same pattern as `test_max_findings_cap_preserves_first_finding` in
+    /// `dnp3_detection_tests.rs`). Then deliver a COLD_RESTART (FC=0x0D) frame — the
+    /// detection logic would push a T0814 finding, but the cap is hit, so the push is
+    /// suppressed and `dropped_findings` must be incremented by 1.
+    ///
+    /// Mirrors BC-2.15.022 EC-001 canonical test vector; mirrors BC-2.14.022 (Modbus)
+    /// and BC-2.17.022 (ENIP) precedents.
+    ///
+    /// RED GATE: `dropped_findings` not yet a field on `Dnp3Analyzer`; `summarize()` does
+    /// not emit it → `.unwrap_or_else()` panics.
+    #[test]
+    fn test_BC_2_15_022_dropped_findings_increments_when_all_findings_cap_hit() {
+        let mut analyzer = Dnp3Analyzer::new(10);
+        let key = dnp3_flow_key();
+
+        // Pre-fill all_findings to MAX_FINDINGS using the public field.
+        for _ in 0..MAX_FINDINGS {
+            analyzer.all_findings.push(dummy_finding());
+        }
+        assert_eq!(
+            analyzer.all_findings.len(),
+            MAX_FINDINGS,
+            "pre-condition: all_findings must be at MAX_FINDINGS={} before test",
+            MAX_FINDINGS
+        );
+
+        // Seed the flow with a non-detection READ frame (no finding expected from READ).
+        let read_frame = build_dnp3_detection_frame(0x01, 0x0003, 0x0001);
+        analyzer.on_data(key.clone(), &read_frame, 0, Direction::ClientToServer);
+
+        // COLD_RESTART (FC=0x0D) — detection pushes T0814, but cap is at MAX_FINDINGS.
+        // Expectation: push suppressed, `dropped_findings` incremented by 1.
+        let cold_restart = build_dnp3_detection_frame(0x0D, 0x0003, 0x0001);
+        analyzer.on_data(key.clone(), &cold_restart, 100, Direction::ClientToServer);
+
+        let summary = analyzer.summarize();
+        let dropped = summary
+            .detail
+            .get("dropped_findings")
+            .unwrap_or_else(|| {
+                panic!(
+                    "BC-2.15.022 v1.5 PC-5: summarize() must contain 'dropped_findings' after a \
+                     cap-suppressed T0814 finding (all_findings was at MAX_FINDINGS={}). \
+                     Key is MISSING — red gate expected on current code. \
+                     Keys present: {:?}",
+                    MAX_FINDINGS,
+                    summary.detail.keys().collect::<Vec<_>>()
+                )
+            })
+            .as_u64()
+            .expect("'dropped_findings' must be a u64");
+
+        assert!(
+            dropped >= 1,
+            "BC-2.15.022 v1.5 PC-5: 'dropped_findings' must be >= 1 after a cap-suppressed \
+             COLD_RESTART T0814 finding (all_findings at MAX_FINDINGS={}). Got 0.",
+            MAX_FINDINGS
+        );
+    }
+
+    /// BC-2.15.016 v2.1 PC-6 / BC-2.15.020 v1.5:
+    /// `master_addrs_dropped` increments by 1 when the 65th unique master source address
+    /// arrives at a flow whose `master_addrs_seen` is already at MAX_MASTER_ADDRS=64.
+    ///
+    /// Mechanism: feed 64 READ (FC=0x01) frames with distinct source addresses (src=0..63),
+    /// each with CTRL=0xC4 (DIR=1 → master-direction). This fills `master_addrs_seen` to 64.
+    /// Then feed a 65th frame with src=64 — the cap gate prevents the push and
+    /// `master_addrs_dropped` must be incremented. Mirrors BC-2.15.016 EC-011.
+    ///
+    /// RED GATE: `master_addrs_dropped` not yet a field; key absent → panic.
+    #[test]
+    fn test_BC_2_15_016_master_addrs_dropped_increments_on_65th_unique_master_addr() {
+        // High threshold to suppress T1692.001 burst findings across 65 frames.
+        let mut analyzer = Dnp3Analyzer::new(1000);
+        let key = dnp3_flow_key();
+
+        // Feed MAX_MASTER_ADDRS=64 distinct master source addresses to one flow.
+        // CTRL=0xC4: is_master_frame(0xC4) = (0xC4 & 0x80 != 0) = true.
+        for i in 0u16..MAX_MASTER_ADDRS as u16 {
+            let frame = build_dnp3_detection_frame(0x01, 0x0003, i);
+            analyzer.on_data(key.clone(), &frame, i as u32, Direction::ClientToServer);
+        }
+
+        // Verify master_addrs_seen is exactly at cap before the overflow frame.
+        let flow = analyzer
+            .flows
+            .get(&key)
+            .expect("flow must exist after 64 frames");
+        assert_eq!(
+            flow.master_addrs_seen.len(),
+            MAX_MASTER_ADDRS,
+            "pre-condition: master_addrs_seen must be at MAX_MASTER_ADDRS={} before overflow",
+            MAX_MASTER_ADDRS
+        );
+
+        // 65th unique master address (src=64, not yet in master_addrs_seen) —
+        // cap gate fires: `len < MAX_MASTER_ADDRS` is false → push skipped.
+        // `master_addrs_dropped` must be incremented by 1 (EC-011, PC-6).
+        let overflow_frame = build_dnp3_detection_frame(0x01, 0x0003, MAX_MASTER_ADDRS as u16);
+        analyzer.on_data(
+            key.clone(),
+            &overflow_frame,
+            MAX_MASTER_ADDRS as u32,
+            Direction::ClientToServer,
+        );
+
+        let summary = analyzer.summarize();
+        let dropped = summary
+            .detail
+            .get("master_addrs_dropped")
+            .unwrap_or_else(|| {
+                panic!(
+                    "BC-2.15.016 v2.1 PC-6 / BC-2.15.020 v1.5: summarize() must contain \
+                     'master_addrs_dropped' after a 65th unique master address is silently \
+                     ignored at MAX_MASTER_ADDRS={}. \
+                     Key is MISSING — red gate expected on current code. \
+                     Keys present: {:?}",
+                    MAX_MASTER_ADDRS,
+                    summary.detail.keys().collect::<Vec<_>>()
+                )
+            })
+            .as_u64()
+            .expect("'master_addrs_dropped' must be a u64");
+
+        assert!(
+            dropped >= 1,
+            "BC-2.15.016 v2.1 EC-011: 'master_addrs_dropped' must be >= 1 after a 65th \
+             unique master address arrives at MAX_MASTER_ADDRS={}. Got 0.",
+            MAX_MASTER_ADDRS
+        );
+    }
+
+    /// BC-2.15.016 v2.1 PC-6 / BC-2.15.020 v1.5 Invariant 5 (NEGATIVE):
+    /// Re-seeing an already-known master source address when `master_addrs_seen` is at
+    /// MAX_MASTER_ADDRS=64 MUST NOT increment `master_addrs_dropped`.
+    ///
+    /// Rationale: the drop counter must only fire when a NEW address is silently ignored
+    /// due to cap pressure.  An address already in `master_addrs_seen` is a known address —
+    /// the `contains()` check in the push gate short-circuits before the `len < cap` gate,
+    /// so the counter is never reached (confirmed in df-validation-pc019-pc020-2026-07-06.md
+    /// §PC-016: "A full `master_addrs_seen` does NOT cause `contains(new_src)` to return
+    /// `true` — it returns `false` for any address not already present").
+    ///
+    /// Mirrors the HTTP-AC008-NEG-TEST-001 pattern (existing-key reuse must not bump counter).
+    ///
+    /// RED GATE: `master_addrs_dropped` key absent → panic before the no-increment assertion.
+    #[test]
+    fn test_BC_2_15_016_NEG_known_master_addr_at_cap_does_not_increment_master_addrs_dropped() {
+        let mut analyzer = Dnp3Analyzer::new(1000);
+        let key = dnp3_flow_key();
+
+        // Fill master_addrs_seen to exactly MAX_MASTER_ADDRS=64 with src=0..63.
+        for i in 0u16..MAX_MASTER_ADDRS as u16 {
+            let frame = build_dnp3_detection_frame(0x01, 0x0003, i);
+            analyzer.on_data(key.clone(), &frame, i as u32, Direction::ClientToServer);
+        }
+
+        // Snapshot counter before re-visiting a known address.
+        // If the key is absent, this step panics — red gate achieved.
+        let before_summary = analyzer.summarize();
+        let before = before_summary
+            .detail
+            .get("master_addrs_dropped")
+            .unwrap_or_else(|| {
+                panic!(
+                    "BC-2.15.016 v2.1 NEG: 'master_addrs_dropped' key must be present in \
+                     summarize() at the start of the negative assertion. \
+                     Key is MISSING — red gate expected on current code. \
+                     Keys present: {:?}",
+                    before_summary.detail.keys().collect::<Vec<_>>()
+                )
+            })
+            .as_u64()
+            .expect("'master_addrs_dropped' must be a u64");
+
+        // Re-visit src=0 (already in master_addrs_seen) when cap is full.
+        // contains(0) = true → the cap gate never fires → counter must NOT increment.
+        let repeat_frame = build_dnp3_detection_frame(0x01, 0x0003, 0u16);
+        analyzer.on_data(
+            key.clone(),
+            &repeat_frame,
+            MAX_MASTER_ADDRS as u32 + 1,
+            Direction::ClientToServer,
+        );
+
+        let after_summary = analyzer.summarize();
+        let after = after_summary
+            .detail
+            .get("master_addrs_dropped")
+            .and_then(|v| v.as_u64())
+            .expect("'master_addrs_dropped' key must still be present after re-visit");
+
+        assert_eq!(
+            after,
+            before,
+            "BC-2.15.016 v2.1 NEG (negative): 'master_addrs_dropped' must NOT increment when \
+             a KNOWN master address (src=0, already in master_addrs_seen) is re-seen while \
+             master_addrs_seen is at MAX_MASTER_ADDRS={}. \
+             Before re-visit: {before}, After re-visit: {after}.",
+            MAX_MASTER_ADDRS
+        );
+    }
+
+    /// BC-2.15.016 v2.1 PC-10 / BC-2.15.020 v1.5:
+    /// `pending_requests_evicted` increments by 1 on each LRU eviction from
+    /// `pending_requests` at MAX_PENDING_REQUESTS=256.
+    ///
+    /// Mechanism: feed 256 DIRECT_OPERATE (FC=0x05) frames with distinct dest=0..255 to one
+    /// flow (src=1 fixed, app_seq=0 from byte[11]=0x00). Each frame inserts key `(dest, 0)`
+    /// into `pending_requests`. At MAX_PENDING_REQUESTS=256 entries, the 257th unique key
+    /// (dest=256) triggers the LRU eviction in `insert_pending_request` — oldest entry is
+    /// evicted, new entry inserted, `pending_requests_evicted` incremented. Mirrors EC-008.
+    ///
+    /// RED GATE: `pending_requests_evicted` not yet a field; key absent → panic.
+    #[test]
+    fn test_BC_2_15_016_pending_requests_evicted_increments_on_lru_eviction() {
+        // High threshold to suppress T1692.001 burst findings across 257 frames.
+        let mut analyzer = Dnp3Analyzer::new(1000);
+        let key = dnp3_flow_key();
+
+        // Fill pending_requests to MAX_PENDING_REQUESTS=256 with distinct (dest, 0) keys.
+        // src=1 is fixed — it is added to master_addrs_seen on the first frame, so all
+        // subsequent frames from src=1 have src_was_known=true (no unexpected-source findings).
+        //
+        // All frames use ts=1000 so scan_block_timeouts never removes entries: the timeout
+        // check is `now_ts.saturating_sub(request_ts) > BLOCK_CMD_TIMEOUT_SECS (10s)`, which
+        // evaluates to `1000 - 1000 = 0 > 10 = false` on every call.  Using monotonically
+        // increasing timestamps (dest*2) would cause entries to time out once elapsed > 10s.
+        for dest in 0u16..MAX_PENDING_REQUESTS as u16 {
+            let frame = build_dnp3_detection_frame(0x05, dest, 1u16);
+            analyzer.on_data(key.clone(), &frame, 1000, Direction::ClientToServer);
+        }
+
+        // Verify pending_requests is at cap before the eviction frame.
+        let flow = analyzer
+            .flows
+            .get(&key)
+            .expect("flow must exist after 256 frames");
+        assert_eq!(
+            flow.pending_requests.len(),
+            MAX_PENDING_REQUESTS,
+            "pre-condition: pending_requests must be at MAX_PENDING_REQUESTS={} before overflow",
+            MAX_PENDING_REQUESTS
+        );
+
+        // 257th unique key (dest=256, not yet in pending_requests) — triggers LRU eviction.
+        // After: oldest entry evicted, new entry inserted, map still at 256,
+        //        `pending_requests_evicted` incremented by 1.
+        let eviction_frame = build_dnp3_detection_frame(0x05, MAX_PENDING_REQUESTS as u16, 1u16);
+        analyzer.on_data(key.clone(), &eviction_frame, 1000, Direction::ClientToServer);
+
+        let summary = analyzer.summarize();
+        let evicted = summary
+            .detail
+            .get("pending_requests_evicted")
+            .unwrap_or_else(|| {
+                panic!(
+                    "BC-2.15.016 v2.1 PC-10 / BC-2.15.020 v1.5: summarize() must contain \
+                     'pending_requests_evicted' after a 257th unique DIRECT_OPERATE request \
+                     triggers LRU eviction at MAX_PENDING_REQUESTS={}. \
+                     Key is MISSING — red gate expected on current code. \
+                     Keys present: {:?}",
+                    MAX_PENDING_REQUESTS,
+                    summary.detail.keys().collect::<Vec<_>>()
+                )
+            })
+            .as_u64()
+            .expect("'pending_requests_evicted' must be a u64");
+
+        assert!(
+            evicted >= 1,
+            "BC-2.15.016 v2.1 EC-008: 'pending_requests_evicted' must be >= 1 after a 257th \
+             unique Control-class request triggers LRU eviction at MAX_PENDING_REQUESTS={}. \
+             Got 0.",
+            MAX_PENDING_REQUESTS
+        );
+    }
+
+    /// BC-2.15.016 v2.1 PC-10 (NEGATIVE):
+    /// Normal request/response completion MUST NOT increment `pending_requests_evicted`.
+    ///
+    /// When a RESPONSE (FC=0x81) arrives and `pending_requests.remove(&(src, app_seq))`
+    /// succeeds, the entry is removed via normal completion — not LRU eviction.  The
+    /// `pending_requests_evicted` counter must remain 0.
+    ///
+    /// Scenario: DIRECT_OPERATE request (dest=3, src=1, app_seq=0) inserts key (3, 0).
+    /// Matching RESPONSE (src=3, dest=1, app_seq=0) removes (3, 0) via `pending_requests.remove`.
+    /// No eviction helper involved; pending_requests stays well below MAX_PENDING_REQUESTS.
+    ///
+    /// RED GATE: key absent → panic before the zero assertion.
+    #[test]
+    fn test_BC_2_15_016_NEG_normal_request_response_completion_does_not_increment_pending_requests_evicted(
+    ) {
+        let mut analyzer = Dnp3Analyzer::new(1000);
+        let key = dnp3_flow_key();
+
+        // DIRECT_OPERATE request: dest=3 (outstation), src=1 (master), app_seq=0.
+        // Inserts key (3, 0) into pending_requests.
+        let request_frame = build_dnp3_detection_frame(0x05, 3u16, 1u16);
+        analyzer.on_data(key.clone(), &request_frame, 100, Direction::ClientToServer);
+
+        // Matching RESPONSE: FC=0x81, src=3 (outstation), dest=1 (master), app_seq=0.
+        // Calls pending_requests.remove(&(3, 0)) — normal completion, not eviction.
+        let response_frame = build_dnp3_detection_frame(0x81, 1u16, 3u16);
+        analyzer.on_data(key.clone(), &response_frame, 105, Direction::ServerToClient);
+
+        let summary = analyzer.summarize();
+        let evicted = summary
+            .detail
+            .get("pending_requests_evicted")
+            .unwrap_or_else(|| {
+                panic!(
+                    "BC-2.15.016 v2.1 NEG: 'pending_requests_evicted' key must be present in \
+                     summarize() after a normal request/response completion. \
+                     Key is MISSING — red gate expected on current code. \
+                     Keys present: {:?}",
+                    summary.detail.keys().collect::<Vec<_>>()
+                )
+            })
+            .as_u64()
+            .expect("'pending_requests_evicted' must be a u64");
+
+        assert_eq!(
+            evicted,
+            0,
+            "BC-2.15.016 v2.1 (negative): 'pending_requests_evicted' must be 0 after a normal \
+             DIRECT_OPERATE (FC=0x05) / RESPONSE (FC=0x81) completion. Normal pending_requests \
+             removal is NOT an LRU eviction. Got {evicted}."
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // NEGATIVE: observability counter events must NOT emit any Finding
+    // (DNP3 counterpart of EVICTION-NO-FINDING-NEG-TEST-001 from
+    // bc_silent_resource_caps_tests.rs; precedent: BC-2.16.008 Inv-5,
+    // BC-2.14.012 v1.1, EVICTION-NO-FINDING-NEG-TEST-001)
+    // -----------------------------------------------------------------------
+
+    /// DNP3-EVICTION-NO-FINDING-NEG-TEST-001 / BC-2.15.016 v2.1 Inv-2,5 /
+    /// BC-2.15.022 v1.5 Inv-5 (NEGATIVE):
+    ///
+    /// All three observability counter events are COUNTER-ONLY — none must emit a Finding:
+    ///
+    /// Part A — `master_addrs_dropped` (65 frames):
+    ///   Fill master_addrs_seen to 64 via src=0..63, then send 65th new master address.
+    ///   Counter increments; `all_findings` must NOT grow due to the drop event.
+    ///
+    /// Part B — `pending_requests_evicted` (257 frames):
+    ///   Fill pending_requests to 256 via dest=0..255, then send 257th unique request.
+    ///   Counter increments; `all_findings` must NOT grow due to the eviction event.
+    ///
+    /// Part C — `dropped_findings` (pre-fill + 1 frame):
+    ///   Pre-fill all_findings to MAX_FINDINGS, then deliver COLD_RESTART.
+    ///   Counter increments; `all_findings.len()` must stay at MAX_FINDINGS.
+    ///
+    /// RED GATE: each Part first asserts its counter >= 1 (via `.unwrap_or_else` on the
+    /// missing key) — tests fail at that assertion before the no-Finding check runs.
+    #[test]
+    fn test_DNP3_EVICTION_NO_FINDING_NEG_TEST_001_observability_counters_emit_no_finding() {
+        // ---- Part A: master_addrs_dropped is COUNTER-ONLY ----
+        {
+            let mut analyzer = Dnp3Analyzer::new(1000);
+            let key = dnp3_flow_key();
+
+            for i in 0u16..MAX_MASTER_ADDRS as u16 {
+                let frame = build_dnp3_detection_frame(0x01, 0x0003, i);
+                analyzer.on_data(key.clone(), &frame, i as u32, Direction::ClientToServer);
+            }
+            let findings_before_drop = analyzer.all_findings.len();
+
+            let overflow_frame = build_dnp3_detection_frame(0x01, 0x0003, MAX_MASTER_ADDRS as u16);
+            analyzer.on_data(
+                key.clone(),
+                &overflow_frame,
+                MAX_MASTER_ADDRS as u32,
+                Direction::ClientToServer,
+            );
+
+            // Assert counter was incremented (RED GATE: panics on missing key).
+            let summary = analyzer.summarize();
+            let dropped_addrs = summary
+                .detail
+                .get("master_addrs_dropped")
+                .unwrap_or_else(|| {
+                    panic!(
+                        "DNP3-EVICTION-NO-FINDING-NEG-TEST-001 Part A: 'master_addrs_dropped' \
+                         must be present after 65th unique master address arrives. \
+                         Key MISSING — red gate expected. Keys: {:?}",
+                        summary.detail.keys().collect::<Vec<_>>()
+                    )
+                })
+                .as_u64()
+                .expect("'master_addrs_dropped' must be u64");
+            assert!(
+                dropped_addrs >= 1,
+                "Part A pre-condition: master_addrs_dropped must be >= 1 to confirm cap was hit. \
+                 Got 0 — cannot verify no-Finding invariant without a confirmed cap event."
+            );
+
+            // Assert no new Finding from the master_addrs drop event itself.
+            let findings_after_drop = analyzer.all_findings.len();
+            assert_eq!(
+                findings_after_drop,
+                findings_before_drop,
+                "DNP3-EVICTION-NO-FINDING-NEG-TEST-001 Part A / BC-2.15.016 v2.1 Inv-2 \
+                 (negative): `all_findings` must not grow due to a master_addrs_dropped counter \
+                 event. Before drop: {} finding(s). After drop: {} finding(s). \
+                 A cap-triggered master-address ignore is COUNTER-ONLY — no Finding emitted.",
+                findings_before_drop,
+                findings_after_drop
+            );
+        }
+
+        // ---- Part B: pending_requests_evicted is COUNTER-ONLY ----
+        {
+            let mut analyzer = Dnp3Analyzer::new(1000);
+            let key = dnp3_flow_key();
+
+            // ts=1000 fixed for all frames so scan_block_timeouts never removes entries:
+            // `1000.saturating_sub(1000) = 0 > BLOCK_CMD_TIMEOUT_SECS (10)` → false.
+            for dest in 0u16..MAX_PENDING_REQUESTS as u16 {
+                let frame = build_dnp3_detection_frame(0x05, dest, 1u16);
+                analyzer.on_data(key.clone(), &frame, 1000, Direction::ClientToServer);
+            }
+            let findings_before_evict = analyzer.all_findings.len();
+
+            let eviction_frame =
+                build_dnp3_detection_frame(0x05, MAX_PENDING_REQUESTS as u16, 1u16);
+            analyzer.on_data(key.clone(), &eviction_frame, 1000, Direction::ClientToServer);
+
+            // Assert counter was incremented (RED GATE: panics on missing key).
+            let summary = analyzer.summarize();
+            let evicted = summary
+                .detail
+                .get("pending_requests_evicted")
+                .unwrap_or_else(|| {
+                    panic!(
+                        "DNP3-EVICTION-NO-FINDING-NEG-TEST-001 Part B: 'pending_requests_evicted' \
+                         must be present after LRU eviction at MAX_PENDING_REQUESTS={}. \
+                         Key MISSING — red gate expected. Keys: {:?}",
+                        MAX_PENDING_REQUESTS,
+                        summary.detail.keys().collect::<Vec<_>>()
+                    )
+                })
+                .as_u64()
+                .expect("'pending_requests_evicted' must be u64");
+            assert!(
+                evicted >= 1,
+                "Part B pre-condition: pending_requests_evicted must be >= 1 to confirm eviction \
+                 fired. Got 0 — cannot verify no-Finding invariant without a confirmed eviction."
+            );
+
+            // Assert no new Finding from the LRU eviction event itself.
+            let findings_after_evict = analyzer.all_findings.len();
+            assert_eq!(
+                findings_after_evict,
+                findings_before_evict,
+                "DNP3-EVICTION-NO-FINDING-NEG-TEST-001 Part B / BC-2.15.016 v2.1 Inv-5 \
+                 (negative): `all_findings` must not grow due to a pending_requests LRU \
+                 eviction. Before eviction: {} finding(s). After eviction: {} finding(s). \
+                 LRU eviction is COUNTER-ONLY — no Finding, no T1691.001 timeout event.",
+                findings_before_evict,
+                findings_after_evict
+            );
+        }
+
+        // ---- Part C: dropped_findings cap-drop is COUNTER-ONLY ----
+        {
+            let mut analyzer = Dnp3Analyzer::new(10);
+            let key = dnp3_flow_key();
+
+            for _ in 0..MAX_FINDINGS {
+                analyzer.all_findings.push(dummy_finding());
+            }
+
+            let read_frame = build_dnp3_detection_frame(0x01, 0x0003, 0x0001);
+            analyzer.on_data(key.clone(), &read_frame, 0, Direction::ClientToServer);
+
+            // COLD_RESTART would push T0814 but cap hit → dropped_findings incremented.
+            let cold_restart = build_dnp3_detection_frame(0x0D, 0x0003, 0x0001);
+            analyzer.on_data(key.clone(), &cold_restart, 100, Direction::ClientToServer);
+
+            // Assert counter was incremented (RED GATE: panics on missing key).
+            let summary = analyzer.summarize();
+            let dropped_count = summary
+                .detail
+                .get("dropped_findings")
+                .unwrap_or_else(|| {
+                    panic!(
+                        "DNP3-EVICTION-NO-FINDING-NEG-TEST-001 Part C: 'dropped_findings' must \
+                         be present after cap-suppressed T0814 at MAX_FINDINGS={}. \
+                         Key MISSING — red gate expected. Keys: {:?}",
+                        MAX_FINDINGS,
+                        summary.detail.keys().collect::<Vec<_>>()
+                    )
+                })
+                .as_u64()
+                .expect("'dropped_findings' must be u64");
+            assert!(
+                dropped_count >= 1,
+                "Part C pre-condition: dropped_findings must be >= 1 to confirm cap was hit. \
+                 Got 0 — cannot verify no-growth invariant without a confirmed cap event."
+            );
+
+            // Assert all_findings did NOT grow beyond MAX_FINDINGS.
+            assert_eq!(
+                analyzer.all_findings.len(),
+                MAX_FINDINGS,
+                "DNP3-EVICTION-NO-FINDING-NEG-TEST-001 Part C / BC-2.15.022 v1.5 Inv-5 \
+                 (negative): `all_findings.len()` must stay at MAX_FINDINGS={} after a \
+                 cap-suppressed finding event. MAX_FINDINGS cap-drop is COUNTER-ONLY — \
+                 `all_findings` must NOT grow beyond the cap. Got {}.",
+                MAX_FINDINGS,
+                analyzer.all_findings.len()
+            );
+        }
+    }
+} // mod bc_2_15_020_dnp3_observability_counters


### PR DESCRIPTION
**Maintenance run:** maint-2026-07-06 FIX-B
**Mode:** maintenance / fix
**Convergence:** N/A — evaluated at wave gate

![Tests](https://img.shields.io/badge/tests-9%2F9%20new%20pass%2C%20453%20pre--existing%20green-brightgreen)
![Coverage](https://img.shields.io/badge/coverage-additive%20only-brightgreen)
![Holdout](https://img.shields.io/badge/holdout-pre--checked%20no%20scenario%20asserts%20exact%20DNP3%20key%20counts-blue)

This PR closes three genuine observability gaps identified by the maint-2026-07-06 pattern-consistency sweep (FIX-B). Three new monotonic counters surface DNP3 analyzer state that was previously silently dropped or evicted at hard resource caps. No behavior changes: detection logic, Finding emission, and all invariants are unchanged. Counters are purely additive — new keys appear in `summarize()` JSON output only.

**Direct precedent:** PR #365 / PR #366 (same counter pattern for ARP `bindings_evicted`/`storm_counters_evicted`, Modbus `dropped_transactions`, HTTP/TLS `dropped_map_entries`).

**Summary — new DNP3 counter keys after this PR:**

| Counter | Cap constant | Semantics |
|---------|-------------|-----------|
| `dropped_findings` | `MAX_FINDINGS = 10_000` | Incremented at each of 11 cap-check sites when a finding is suppressed; `&mut u64` threaded through 10 detection functions |
| `master_addrs_dropped` | `MAX_MASTER_ADDRS = 64` | Incremented only for new-unique master addresses silently ignored because the cap is full; existing-address hits do NOT increment (BC-2.15.016 v2.1 PC-6) |
| `pending_requests_evicted` | `MAX_PENDING_REQUESTS = 256` | Incremented when `insert_pending_request` LRU-evicts an entry; function now returns `bool` — consistent with the `insert_binding_lru`-returns-bool pattern from PR #366 (ARP) |

---

## Architecture Changes

```mermaid
graph TD
    Dnp3Analyzer["Dnp3Analyzer\n(src/analyzer/dnp3.rs)"] -->|"dropped_findings\nmaster_addrs_dropped\npending_requests_evicted"| Summarize["summarize() → JSON"]
    style Dnp3Analyzer fill:#90EE90
```

<details>
<summary><strong>Architecture Decision</strong></summary>

### ADR: Additive observability counters, no behavior change

**Context:** Three DNP3 resource caps silently drop or evict state without any observable signal. Operators could not distinguish "no cap pressure" from "high cap pressure" on `pending_requests`, `master_addrs_seen`, or the findings list.

**Decision:** Add one monotonic saturating counter per silent-drop/eviction site; expose each counter as a new key in `Dnp3Analyzer::summarize()` JSON detail map. Counters are always present (value=0 when no events occurred).

**Rationale:** Purely additive — zero risk of breaking existing consumers. No Finding is emitted on any eviction/drop event (observability-only). Consistent with v0.11.4 counter pattern established in PR #365.

**Implementation note — `dropped_findings` vs. `insert_pending_request`:** `dropped_findings` is threaded as `&mut u64` through the 10 detection functions that hold cap-check guards, mirroring the existing `&mut Vec<Finding>` pattern. `pending_requests_evicted` uses the `insert_pending_request`-returns-`bool` pattern (bool = eviction occurred), consistent with PR #366's `insert_binding_lru`-returns-bool for ARP. `master_addrs_dropped` increments directly in the frame-walk `else` branch (no helper function involved).

**Alternatives Considered:**
1. Emit a `Finding` on each eviction — rejected: violates BC-2.15.022 Invariant 1 (DoS cap), would inflate finding counts.
2. Log to stderr on eviction — rejected: not machine-readable.

</details>

---

## DF-VALIDATION-001 Evidence

**File:** `.factory/research/df-validation-pc019-pc020-2026-07-06.md`
**Policy enforced:** `DF-VALIDATION-001` (`.factory/policies.yaml`)

All three pattern-consistency findings were independently verified before this PR was filed:

| Canonical ID | Claim | Verdict |
|---|---|---|
| PC-016 (team-lead: PC-019) | `master_addrs_seen` silent-ignore has no counter | **CONFIRMED** (observability gap); T1692.001-masking mechanism **REFUTED** — the cap gates the push, not the membership check, so rogue-source detection still fires for any address not in the (full) set |
| PC-017 (team-lead: PC-020) | `pending_requests` LRU eviction has no counter | **CONFIRMED** — in-code doc comment at `dnp3.rs:1797` explicitly states the eviction produces no T1691.001 event; T1691.001 correlation degradation path confirmed |
| PC-003 | `dropped_findings` counter missing on 11 MAX_FINDINGS cap sites | **CONFIRMED** — Modbus and ENIP both carry equivalent counters; DNP3 was the sole omission |

**Important:** `master_addrs_dropped` counter is added for **observability parity** with the v0.11.4 pattern (ARP, Modbus, HTTP, TLS). The PR does NOT claim this counter restores T1692.001 detection capability — T1692.001 detection is not gated by the cap (validated per research file above).

---

## Spec Traceability

**BC-INDEX version: v2.19 Amendment 5.**

```mermaid
flowchart LR
    BC016["BC-2.15.016 v2.1\nPC-6: master_addrs cap\nPC-10: pending_requests LRU"] --> AC_MA["master_addrs_dropped\nkey in summarize()"]
    BC016 --> AC_PE["pending_requests_evicted\nkey in summarize()"]
    BC022["BC-2.15.022\nMAX_FINDINGS=10,000 cap"] --> AC_DF["dropped_findings\nkey in summarize()"]
    BC020["BC-2.15.020\nDNP3 observability counters"] --> AC_MA
    BC020 --> AC_PE
    BC020 --> AC_DF
    AC_MA --> T["tests/bc_2_15_020_dnp3_observability_counters_tests.rs"]
    AC_PE --> T
    AC_DF --> T
    T --> S["src/analyzer/dnp3.rs"]
```

| Behavioral Contract | Amendment | Counter | Status |
|--------------------|-----------|---------|--------|
| BC-2.15.016 v2.1 PC-6 | master_addrs cap | `master_addrs_dropped` | PASS |
| BC-2.15.016 v2.1 PC-10 | pending_requests LRU | `pending_requests_evicted` | PASS |
| BC-2.15.020 | DNP3 observability counters | all three | PASS |
| BC-2.15.022 | MAX_FINDINGS DoS cap | `dropped_findings` | PASS |

---

## Test Evidence (TDD — Red Gate First)

| Step | Commit | Details |
|------|--------|---------|
| Red gate | `4defc7b` | 9 new tests committed first; all 9 fail (keys absent from `summarize()`); all 453 pre-existing tests pass |
| Green gate | `636c0d6` | Implementation committed; 9/9 new tests pass; 453 pre-existing tests still green |

**Test file:** `tests/bc_2_15_020_dnp3_observability_counters_tests.rs` (722 lines, new file)

**Test coverage:**
- `dropped_findings`: verifies counter increments at MAX_FINDINGS boundary; verifies eviction counter does NOT fire on `scan_block_timeouts` age-out or on normal finding completion (negative tests)
- `master_addrs_dropped`: verifies counter increments only for new-unique addresses at cap; existing addresses do NOT increment counter
- `pending_requests_evicted`: verifies counter increments on LRU eviction; verifies counter does NOT fire on normal completion or `scan_block_timeouts` age-out
- Counters are observability-only: no `Finding` is emitted for any of the three counter increment paths

**Holdout pre-check:** No holdout scenario asserts exact DNP3 summary key counts — additive counter keys cannot break existing scenarios.

---

## Risk Assessment

- **Blast radius:** DNP3 `summarize()` JSON output only — new keys, zero behavior change
- **Risk level:** LOW (additive, no behavioral change, saturating arithmetic)
- **Memory delta:** +24 bytes per `Dnp3Analyzer` instance (3 × `u64`)
- **Throughput delta:** negligible (one add per rare eviction event)

---

## Pre-Merge Checklist

- [ ] All CI status checks passing
- [x] TDD Red gate committed first (4defc7b)
- [x] 9/9 new tests pass; 453 pre-existing tests green
- [x] DF-VALIDATION-001 evidence on file before PR filed
- [x] PC-016 T1692.001-masking claim explicitly NOT asserted in PR body
- [x] Precedent pattern consistent (insert_pending_request returns bool, per PR #366)
- [x] BC-INDEX v2.19 Amendment 5 traced to tests
- [x] Holdout pre-checked — no impact on existing scenarios
- [ ] Code review, security review, fresh-eyes review dispatched post-creation