### PR TITLE
fix(deps): bump crossbeam-epoch 0.9.18 -> 0.9.20 (RUSTSEC-2026-0204)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -360,9 +360,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
**Advisory:** RUSTSEC-2026-0204  
**Published:** 2026-07-06  
**Affected crate:** `crossbeam-epoch` 0.9.18  
**Fixed in:** ≥ 0.9.20  
**Bump:** 0.9.18 → 0.9.20  

## Advisory Details

RUSTSEC-2026-0204 describes an invalid pointer dereference in the `fmt::Pointer` implementation of `crossbeam-epoch`. The issue is present in 0.9.18 and fixed in 0.9.20.

## Exposure Assessment

The vulnerable crate is a **dev-dependency-only** transitive dependency. Dependency path:

```
criterion (dev)
  └─ rayon
       └─ crossbeam-deque
            └─ crossbeam-epoch  ← affected
```

`crossbeam-epoch` appears only in the `[dev-dependencies]` closure and is **not linked into any production binary or library target**. There is no runtime exposure in release builds.

## Diff

This is a **Cargo.lock-only** change — exactly one crate version record updated, no `Cargo.toml` changes:

```
crossbeam-epoch 0.9.18  →  0.9.20
checksum: 5b82ac4a...  →  2d691404...
```

## Motivation

This advisory is failing the `Audit` CI job repo-wide, blocking the `Audit` check on all open PRs including PR #370 (`fix/dnp3-observability-counters`). Merging this PR unblocks PR #370's Audit check.

## Pre-Merge Checklist

- [ ] CI Audit check passes (0 vulnerabilities)
- [x] Cargo.lock-only diff — no `Cargo.toml` changes
- [x] Exactly 1 crate updated
- [x] Dev-dependency path only — no runtime exposure
- [x] Local gates verified: audit 0 vulns, test/clippy/fmt green