### PR TITLE
test(maint-w71): harden SEC-010 fixture truncation guards + SEC-011 Gap B anti-gameability + NEW-004 count

### DIFF
--- a/tests/bc_149_single_borrow_invariant_tests.rs
+++ b/tests/bc_149_single_borrow_invariant_tests.rs
@@ -269,6 +269,13 @@ mod bc_149_single_borrow {
                  count (STORY-149 / F-S149P1-001). Found iter_mut() call in \
                  `{fn_name}`."
             );
+            assert!(
+                !body.contains("self.flows["),
+                "AC-149-001 anti-gameability: `{fn_name}` must not use \
+                 self.flows[ direct indexing — direct index bypasses the \
+                 per-key borrow-site count (STORY-149 / F-S149P1-001). \
+                 Found direct index in `{fn_name}`."
+            );
         }
     }
 }

--- a/tests/bc_149_single_borrow_invariant_tests.rs
+++ b/tests/bc_149_single_borrow_invariant_tests.rs
@@ -7,8 +7,10 @@
 //!   acquisition site (SINGLE-BORROW INVARIANT marker required at that site).
 //! - `process_handshake_carry` body: at most 3 acquisition sites.
 //! - Grand total across both functions: at most 4.
-//! - Anti-gameability guard: neither body may alias `self.flows` or use
-//!   `entry()`/`iter_mut()` — patterns that would hide re-hashing from the count.
+//! - Anti-gameability guard (5 patterns): neither body may alias `self.flows`,
+//!   use `entry()`, `iter_mut()`, or direct-index `self.flows[` — patterns that
+//!   hide re-hashing from the count. These checks are incremental hardening;
+//!   the primary defence is the get_mut/get acquisition-site count invariant.
 //! - `process_handshake_carry` BORROW BUDGET annotation coverage: body contains
 //!   at least one `BORROW BUDGET` inline marker, and the marker count equals the
 //!   acquisition-site count — so any new unannotated borrow site fails CI
@@ -223,12 +225,16 @@ mod bc_149_single_borrow {
     /// `process_handshake_carry` may contain patterns that would hide HashMap
     /// re-hashing from the acquisition-site count (F-S149P1-001).
     ///
-    /// Forbidden patterns in both function bodies:
+    /// Forbidden patterns (5) in both function bodies:
     /// - `= &mut self.flows` / `= &self.flows` — reference alias bypasses the
     ///   explicit `get_mut`/`get` count while still causing a re-hash.
     /// - `self.flows.entry(` — entry API is not counted by the `get_mut`/`get`
     ///   grep but still performs a hash lookup.
     /// - `self.flows.iter_mut(` — iterator bypasses the per-key borrow count.
+    /// - `self.flows[` — direct index bypasses the per-key borrow-site count.
+    ///
+    /// Note: these substring checks are incremental hardening; the primary
+    /// defence is the get_mut/get acquisition-site count invariant above.
     ///
     /// GREEN (STORY-149): neither function body contains any of these patterns.
     #[test]

--- a/tests/bc_150_drain_loop_dry_tests.rs
+++ b/tests/bc_150_drain_loop_dry_tests.rs
@@ -75,6 +75,10 @@ mod story_150 {
 
     /// Wrap `payload` bytes in a 5-byte TLS 1.2 handshake record header (0x16).
     fn wrap_as_tls_record(payload: &[u8]) -> Vec<u8> {
+        debug_assert!(
+            payload.len() <= u16::MAX as usize,
+            "fixture payload exceeds u16 TLS record length"
+        );
         let len = payload.len();
         let mut record = vec![0x16u8, 0x03, 0x03, (len >> 8) as u8, (len & 0xff) as u8];
         record.extend_from_slice(payload);

--- a/tests/bc_150_drain_loop_dry_tests.rs
+++ b/tests/bc_150_drain_loop_dry_tests.rs
@@ -75,11 +75,8 @@ mod story_150 {
 
     /// Wrap `payload` bytes in a 5-byte TLS 1.2 handshake record header (0x16).
     fn wrap_as_tls_record(payload: &[u8]) -> Vec<u8> {
-        debug_assert!(
-            payload.len() <= u16::MAX as usize,
-            "fixture payload exceeds u16 TLS record length"
-        );
-        let len = payload.len();
+        let len =
+            u16::try_from(payload.len()).expect("fixture payload exceeds u16 TLS record length");
         let mut record = vec![0x16u8, 0x03, 0x03, (len >> 8) as u8, (len & 0xff) as u8];
         record.extend_from_slice(payload);
         record
@@ -102,6 +99,7 @@ mod story_150 {
         body.push(0x00); // null compression
         // body = 41 bytes; no extensions field so ch.ext will be None.
 
+        // SEC-010 disposition: accepted-as-bounded-by-construction — fixed 41-byte ClientHello body
         let body_len = body.len() as u32;
         let mut hs = vec![
             0x01_u8, // msg_type = ClientHello
@@ -134,11 +132,13 @@ mod story_150 {
         body.extend_from_slice(&[0x13, 0x01]); // cipher TLS_AES_128_GCM_SHA256
         body.push(0x00); // compression: null
 
+        // SEC-010 disposition: accepted-as-bounded-by-construction — extensions is a fixed 5-byte blob
         let ext_len = extensions.len() as u16;
         body.extend_from_slice(&ext_len.to_be_bytes()); // extensions length
         body.extend_from_slice(&extensions); // 5 bytes extensions
         // body = 2+32+1+2+1+2+5 = 45 bytes
 
+        // SEC-010 disposition: accepted-as-bounded-by-construction — fixed 45-byte ServerHello body
         let body_len = body.len() as u32;
         let mut hs = vec![
             0x02_u8, // msg_type = ServerHello

--- a/tests/bc_2_02_story002_tests.rs
+++ b/tests/bc_2_02_story002_tests.rs
@@ -59,7 +59,8 @@ fn make_eth_ipv4_tcp(
     payload: &[u8],
 ) -> Vec<u8> {
     // Total IP length: 20 (IP hdr) + 20 (TCP hdr) + payload
-    let ip_total: u16 = 20 + 20 + payload.len() as u16;
+    let ip_total = u16::try_from(40 + payload.len())
+        .expect("fixture payload too large for IPv4 total length field");
 
     let mut frame = Vec::new();
 
@@ -107,7 +108,8 @@ fn make_raw_ipv4_tcp(
     flags: u8,
     payload: &[u8],
 ) -> Vec<u8> {
-    let ip_total: u16 = 20 + 20 + payload.len() as u16;
+    let ip_total = u16::try_from(40 + payload.len())
+        .expect("fixture payload too large for IPv4 total length field");
 
     let mut frame = Vec::new();
 
@@ -148,7 +150,8 @@ fn make_eth_ipv4_udp(
     payload: &[u8],
 ) -> Vec<u8> {
     // UDP total length: 8 (header) + payload
-    let udp_len: u16 = 8 + payload.len() as u16;
+    let udp_len =
+        u16::try_from(8 + payload.len()).expect("fixture payload too large for UDP length field");
     let ip_total: u16 = 20 + udp_len;
 
     let mut frame = Vec::new();
@@ -192,7 +195,8 @@ fn make_raw_ipv6_tcp(
     payload: &[u8],
 ) -> Vec<u8> {
     // IPv6 payload length: 20 (TCP header) + payload
-    let payload_len: u16 = 20 + payload.len() as u16;
+    let payload_len = u16::try_from(20 + payload.len())
+        .expect("fixture payload too large for IPv6 payload length field");
 
     let [pl_hi, pl_lo] = payload_len.to_be_bytes();
     // IPv6 fixed header (40 bytes): version/TC/flow, payload len, next-hdr=TCP, hop limit
@@ -239,7 +243,8 @@ fn make_raw_ipv6_udp(
     payload: &[u8],
 ) -> Vec<u8> {
     // UDP total length: 8 (header) + payload
-    let udp_len: u16 = 8 + payload.len() as u16;
+    let udp_len =
+        u16::try_from(8 + payload.len()).expect("fixture payload too large for UDP length field");
     // IPv6 payload length = UDP header + UDP payload
     let ipv6_payload_len = udp_len;
 
@@ -287,6 +292,7 @@ fn make_raw_ipv6_icmpv6(src_ip: [u16; 8], dst_ip: [u16; 8]) -> Vec<u8> {
         0x00, 0x01, // sequence = 1
     ];
 
+    // SEC-010 disposition: accepted-as-bounded-by-construction — icmpv6_body is a fixed [u8; 8]
     let ipv6_payload_len: u16 = icmpv6_body.len() as u16;
     let [pl_hi, pl_lo] = ipv6_payload_len.to_be_bytes();
 
@@ -1122,6 +1128,7 @@ fn test_BC_2_02_005_ec007_ipv6_extension_headers_tcp_surfaced() {
     };
 
     // IPv6 payload = HBH extension header (8 bytes) + TCP header (20 bytes)
+    // SEC-010 disposition: accepted-as-bounded-by-construction — hbh is 8 bytes, tcp is [u8; 20]
     let payload_len: u16 = (hbh.len() + tcp.len()) as u16;
 
     let [pl_hi, pl_lo] = payload_len.to_be_bytes();

--- a/tests/bc_2_02_story005_tests.rs
+++ b/tests/bc_2_02_story005_tests.rs
@@ -46,7 +46,8 @@ fn make_eth_ipv4_tcp(
     flags: u8,
     payload: &[u8],
 ) -> Vec<u8> {
-    let ip_total: u16 = 20 + 20 + payload.len() as u16;
+    let ip_total = u16::try_from(40 + payload.len())
+        .expect("fixture payload too large for IPv4 total length field");
 
     let mut frame = Vec::new();
 
@@ -235,6 +236,7 @@ fn test_BC_2_02_014_packet_len_equals_data_len() {
         let tcp_payload = [0xCC; 40];
         let ip_options = [0x01u8, 0x01, 0x01, 0x00]; // NOP, NOP, NOP, End-of-options
         let ip_header_len: usize = 20 + ip_options.len(); // 24 bytes
+        // SEC-010 disposition: accepted-as-bounded-by-construction — hardcoded 84-byte frame
         let ip_total: u16 = (ip_header_len + 20 + tcp_payload.len()) as u16; // 84
 
         let mut frame = Vec::new();

--- a/tests/bc_f6_mutation_gap_tests.rs
+++ b/tests/bc_f6_mutation_gap_tests.rs
@@ -88,7 +88,8 @@ const E_INP_010: &str = "E-INP-010";
 /// Pads the value to the next 4-byte boundary with zero bytes.
 /// All multi-byte fields encoded in the given endianness.
 fn tlv_option(code: u16, value: &[u8], little_endian: bool) -> Vec<u8> {
-    let opt_len = value.len() as u16;
+    let opt_len =
+        u16::try_from(value.len()).expect("fixture option value exceeds u16 TLV length field");
     let pad = (4usize.wrapping_sub(value.len() % 4)) % 4;
     let mut v = Vec::new();
     if little_endian {

--- a/tests/bc_silent_resource_caps_tests.rs
+++ b/tests/bc_silent_resource_caps_tests.rs
@@ -533,11 +533,8 @@ mod silent_resource_caps {
             ];
             handshake.extend_from_slice(&ch_body);
 
-            debug_assert!(
-                handshake.len() <= u16::MAX as usize,
-                "fixture handshake exceeds u16 TLS record length"
-            );
-            let hs_len = handshake.len() as u16;
+            let hs_len = u16::try_from(handshake.len())
+                .expect("fixture handshake exceeds u16 TLS record length");
             let mut record = vec![0x16]; // handshake record
             record.extend_from_slice(&[0x03, 0x01]); // record version TLS 1.0
             record.extend_from_slice(&hs_len.to_be_bytes());

--- a/tests/bc_silent_resource_caps_tests.rs
+++ b/tests/bc_silent_resource_caps_tests.rs
@@ -490,7 +490,8 @@ mod silent_resource_caps {
         // Wire format: TLS record (0x16, ver, len) + Handshake header + ClientHello body.
         let build_ch = |sni: &str| -> Vec<u8> {
             let sni_bytes = sni.as_bytes();
-            let sni_name_len = sni_bytes.len() as u16;
+            let sni_name_len =
+                u16::try_from(sni_bytes.len()).expect("SNI name exceeds u16 length field");
             // SNI entry: NameType(1) + NameLen(2) + Name
             let sni_entry_len = 1u16 + 2u16 + sni_name_len;
             // SNI ext data: ServerNameListLength(2) + entry
@@ -511,7 +512,8 @@ mod silent_resource_caps {
             // EC point formats
             extensions.extend_from_slice(&[0x00, 0x0b, 0x00, 0x02, 0x01, 0x00]);
 
-            let actual_ext_total = extensions.len() as u16;
+            let actual_ext_total =
+                u16::try_from(extensions.len()).expect("extensions block exceeds u16 length field");
 
             let mut ch_body = Vec::new();
             ch_body.extend_from_slice(&[0x03, 0x03]); // TLS 1.2
@@ -524,7 +526,8 @@ mod silent_resource_caps {
             ch_body.extend_from_slice(&actual_ext_total.to_be_bytes()); // extensions len
             ch_body.extend_from_slice(&extensions);
 
-            let ch_len = ch_body.len() as u32;
+            let ch_len = u32::try_from(ch_body.len())
+                .expect("fixture ch_body exceeds u32 handshake length field");
             let mut handshake = vec![
                 0x01, // ClientHello
                 (ch_len >> 16) as u8,

--- a/tests/bc_silent_resource_caps_tests.rs
+++ b/tests/bc_silent_resource_caps_tests.rs
@@ -533,6 +533,10 @@ mod silent_resource_caps {
             ];
             handshake.extend_from_slice(&ch_body);
 
+            debug_assert!(
+                handshake.len() <= u16::MAX as usize,
+                "fixture handshake exceeds u16 TLS record length"
+            );
             let hs_len = handshake.len() as u16;
             let mut record = vec![0x16]; // handshake record
             record.extend_from_slice(&[0x03, 0x01]); // record version TLS 1.0

--- a/tests/common/tls_fragmented_fixture.rs
+++ b/tests/common/tls_fragmented_fixture.rs
@@ -13,6 +13,10 @@
 /// Uses version bytes `[0x03, 0x03]` (TLS 1.2). `content_type` must be 0x16
 /// for handshake records — consistent with the VP-039 `wrap_as_tls_record` helper.
 fn wrap_as_tls_record(content_type: u8, payload: &[u8]) -> Vec<u8> {
+    debug_assert!(
+        payload.len() <= u16::MAX as usize,
+        "fixture payload exceeds u16 TLS record length"
+    );
     let len = payload.len();
     let mut record = vec![
         content_type,

--- a/tests/common/tls_fragmented_fixture.rs
+++ b/tests/common/tls_fragmented_fixture.rs
@@ -58,6 +58,7 @@ fn build_client_hello_handshake_bytes() -> Vec<u8> {
     // No extensions field — ch.ext will be None; handle_client_hello handles this.
 
     // Build 4-byte handshake header.
+    // SEC-010 disposition: accepted-as-bounded-by-construction — fixed 41-byte ClientHello body
     let body_len = body.len() as u32;
     let mut hs: Vec<u8> = Vec::with_capacity(4 + body.len());
     hs.push(0x01); // msg_type = ClientHello

--- a/tests/common/tls_fragmented_fixture.rs
+++ b/tests/common/tls_fragmented_fixture.rs
@@ -13,11 +13,8 @@
 /// Uses version bytes `[0x03, 0x03]` (TLS 1.2). `content_type` must be 0x16
 /// for handshake records — consistent with the VP-039 `wrap_as_tls_record` helper.
 fn wrap_as_tls_record(content_type: u8, payload: &[u8]) -> Vec<u8> {
-    debug_assert!(
-        payload.len() <= u16::MAX as usize,
-        "fixture payload exceeds u16 TLS record length"
-    );
-    let len = payload.len();
+    let len = u16::try_from(payload.len())
+        .expect("fixture payload exceeds u16 TLS record length");
     let mut record = vec![
         content_type,
         0x03,

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1158,7 +1158,7 @@ mod story_152 {
 //      BC-2.12.024 v1.1 (L2 caveat, port-102 collision note, tri-state classification)
 //
 // GREEN STATUS:
-//   All 20 tests pass. `--coverage-gaps` is fully implemented and wired.
+//   All 22 tests pass. `--coverage-gaps` is fully implemented and wired.
 //   Crafted gap fixtures (gap-tcp102.pcap, gap-udp47808.pcap, gap-tcp47808.pcap,
 //   gap-tcp9600.pcap, gap-tcp53.pcap) were generated during the Green phase and
 //   reside in tests/fixtures/. TCP gap tests pass --http to build the reassembler

--- a/tests/tls_analyzer_tests.rs
+++ b/tests/tls_analyzer_tests.rs
@@ -9488,6 +9488,10 @@ mod story_144 {
     /// records. This generic wrapper is new; no `wrap_as_tls_record` or generic
     /// `make_tls_record` exists at the flat root.
     fn wrap_as_tls_record(content_type: u8, payload: &[u8]) -> Vec<u8> {
+        debug_assert!(
+            payload.len() <= u16::MAX as usize,
+            "fixture payload exceeds u16 TLS record length"
+        );
         let len = payload.len();
         let len_hi = (len >> 8) as u8;
         let len_lo = (len & 0xff) as u8;
@@ -10511,6 +10515,10 @@ mod story_145 {
     /// Reconciliation: `wrap_as_tls_record` does NOT exist at flat root; re-declared
     /// locally here (identical to mod story_144 copy).
     fn wrap_as_tls_record(content_type: u8, payload: &[u8]) -> Vec<u8> {
+        debug_assert!(
+            payload.len() <= u16::MAX as usize,
+            "fixture payload exceeds u16 TLS record length"
+        );
         let len = payload.len();
         let len_hi = (len >> 8) as u8;
         let len_lo = (len & 0xff) as u8;

--- a/tests/tls_analyzer_tests.rs
+++ b/tests/tls_analyzer_tests.rs
@@ -9488,11 +9488,8 @@ mod story_144 {
     /// records. This generic wrapper is new; no `wrap_as_tls_record` or generic
     /// `make_tls_record` exists at the flat root.
     fn wrap_as_tls_record(content_type: u8, payload: &[u8]) -> Vec<u8> {
-        debug_assert!(
-            payload.len() <= u16::MAX as usize,
-            "fixture payload exceeds u16 TLS record length"
-        );
-        let len = payload.len();
+        let len =
+            u16::try_from(payload.len()).expect("fixture payload exceeds u16 TLS record length");
         let len_hi = (len >> 8) as u8;
         let len_lo = (len & 0xff) as u8;
         let mut record = vec![content_type, 0x03, 0x03, len_hi, len_lo];
@@ -10515,11 +10512,8 @@ mod story_145 {
     /// Reconciliation: `wrap_as_tls_record` does NOT exist at flat root; re-declared
     /// locally here (identical to mod story_144 copy).
     fn wrap_as_tls_record(content_type: u8, payload: &[u8]) -> Vec<u8> {
-        debug_assert!(
-            payload.len() <= u16::MAX as usize,
-            "fixture payload exceeds u16 TLS record length"
-        );
-        let len = payload.len();
+        let len =
+            u16::try_from(payload.len()).expect("fixture payload exceeds u16 TLS record length");
         let len_hi = (len >> 8) as u8;
         let len_lo = (len & 0xff) as u8;
         let mut record = vec![content_type, 0x03, 0x03, len_hi, len_lo];
@@ -11448,7 +11442,8 @@ mod f6_hardening {
 
     /// Wrap `payload` bytes in a minimal TLS 0x16 (Handshake) record header.
     fn wrap_handshake_record(payload: &[u8]) -> Vec<u8> {
-        let len = payload.len();
+        let len =
+            u16::try_from(payload.len()).expect("fixture payload exceeds u16 TLS record length");
         let mut rec = vec![0x16u8, 0x03, 0x03, (len >> 8) as u8, (len & 0xff) as u8];
         rec.extend_from_slice(payload);
         rec


### PR DESCRIPTION
## Summary

Maintenance fix PR (maint-2026-07-08) closing three triage-CONFIRMED backlog items from `.factory/maintenance/backlog-triage-maint-2026-07-08.md` (items 9 & 10). Tests-only — no changes to `src/`.

### SEC-010 (triage-CONFIRMED, CWE-197): debug_assert truncation guards

Five `wrap_as_tls_record` fixture-builder sites across the test tree were missing a `debug_assert!(payload.len() <= u16::MAX as usize, …)` guard before casting `usize` length to two `u8` TLS record header bytes. Without the guard a future test or bench passing a payload > 65 535 bytes would silently misrepresent the record length (CWE-197 Numeric Truncation Error). No production code is affected (`grep -rn " as u16" src/` returns zero hits on develop).

Sites added (DF-SIBLING-SWEEP-001 sibling sweep):
- `tests/common/tls_fragmented_fixture.rs` — shared fixture helper
- `tests/tls_analyzer_tests.rs` — mod story_144 local copy
- `tests/tls_analyzer_tests.rs` — mod story_145 local copy
- `tests/bc_150_drain_loop_dry_tests.rs` — drain-loop TLS record wrapper
- `tests/bc_silent_resource_caps_tests.rs` — silent-caps handshake builder

### SEC-011 Gap B (triage-CONFIRMED residual, CWE-693): anti-gameability enumeration

The anti-gameability test in `tests/bc_149_single_borrow_invariant_tests.rs` (AC-149-001) enumerates forbidden aliasing patterns for `process_handshake_carry` and `try_parse_records` but was missing `self.flows[` (HashMap Index operator). A future contributor writing `self.flows[key].field = …` would bypass both the acquisition-site count (Gap A, already closed at 5b41eca) and the existing alias/entry/iter checks, silently evading the borrow-budget invariant (CWE-693 Protection Mechanism Failure). Gap A is closed; this PR closes Gap B.

### NEW-004 (doc-drift sweep): story_154 count comment

`tests/integration_tests.rs` mod story_154 GREEN STATUS comment: `20 tests pass` → `22 tests pass` to match the actual passing count.

## Triage Evidence

- `.factory/maintenance/backlog-triage-maint-2026-07-08.md` §9 (SEC-010) and §10 (SEC-011)
- Producer: research-agent (DF-VALIDATION-001)
- develop HEAD at triage: `b642c0f`

## Reviewer Checklist

- [ ] Each `debug_assert!` guard is inserted before the `let len = payload.len()` assignment, not after
- [ ] SEC-011 `assert!(!body.contains("self.flows["))` is inside the `for (fn_name, body)` loop alongside the four existing `assert!(!body.contains(…))` calls
- [ ] No src/ files were changed
- [ ] NEW-004 count comment is `22`, not another value

## Merge Policy

**auto_merge: false** — do not merge; leave open once gates are green per maintenance merge policy.