### PR TITLE
refactor: PF-001 — convert 109 diagnostic-counter sites to saturating_add

### DIFF
--- a/src/analyzer/arp.rs
+++ b/src/analyzer/arp.rs
@@ -483,7 +483,7 @@ impl ArpAnalyzer {
         if let Some(eth_mac) = frame.outer_src_mac
             && eth_mac != frame.sender_mac
         {
-            self.mismatch_findings += 1;
+            self.mismatch_findings = self.mismatch_findings.saturating_add(1);
             findings.push(Finding {
                 category: ThreatCategory::Anomaly,
                 verdict: Verdict::Possible,
@@ -529,7 +529,7 @@ impl ArpAnalyzer {
         // keyed on sender_mac. Executed before the GARP/D1 branching so GARP floods
         // are detected uniformly with all other ARP frame types (BC-2.16.008 PC1).
         if let Some(storm_finding) = self.detect_storm(sender_mac, timestamp_secs) {
-            self.storm_findings += 1;
+            self.storm_findings = self.storm_findings.saturating_add(1);
             findings.push(storm_finding);
         }
 
@@ -582,8 +582,8 @@ impl ArpAnalyzer {
                     self.spoof_threshold,
                 );
 
-                self.garp_findings += 1;
-                self.spoof_findings += 1;
+                self.garp_findings = self.garp_findings.saturating_add(1);
+                self.spoof_findings = self.spoof_findings.saturating_add(1);
                 findings.push(upgraded_garp);
                 findings.push(d1);
 
@@ -598,7 +598,7 @@ impl ArpAnalyzer {
                 entry.mac = sender_mac;
             } else {
                 // BC-2.16.014 PC6 / EC-009: benign GARP (no conflict) → LOW only, no D1, no MITRE.
-                self.garp_findings += 1;
+                self.garp_findings = self.garp_findings.saturating_add(1);
                 findings.push(Finding {
                     category: ThreatCategory::Anomaly,
                     verdict: Verdict::Possible,
@@ -658,7 +658,7 @@ impl ArpAnalyzer {
                     timestamp_secs,
                     self.spoof_threshold,
                 );
-                self.spoof_findings += 1;
+                self.spoof_findings = self.spoof_findings.saturating_add(1);
                 findings.push(d1);
 
                 // Step 4 (Architecture Compliance Rule 1): MAC update AFTER emission.
@@ -699,11 +699,11 @@ impl ArpAnalyzer {
         use crate::findings::{Confidence, ThreatCategory, Verdict};
 
         // Always increment malformed_frames (BC-2.16.009 PC4; AC-012).
-        self.malformed_frames += 1;
+        self.malformed_frames = self.malformed_frames.saturating_add(1);
 
         // Increment malformed_findings — this method is only called from the
         // --arp-gated path in main.rs (BC-2.16.009 PC3/PC4; AC-012).
-        self.malformed_findings += 1;
+        self.malformed_findings = self.malformed_findings.saturating_add(1);
 
         // Construct and return the D11 LOW/Anomaly Finding (BC-2.16.009 PC3).
         // mitre_techniques: [] — T0814 withheld per DF-VALIDATION-001 / BC-2.16.009 Invariant 3.
@@ -1029,7 +1029,7 @@ impl ArpAnalyzer {
         } else {
             // Step 2 — in-window increment.
             if let Some(entry) = self.storm_counters.get_mut(&source_mac) {
-                entry.count_in_window += 1;
+                entry.count_in_window = entry.count_in_window.saturating_add(1);
             }
         }
 

--- a/src/analyzer/arp.rs
+++ b/src/analyzer/arp.rs
@@ -464,11 +464,11 @@ impl ArpAnalyzer {
         let mut findings = Vec::new();
 
         // (b) Count frame + opcode — all frames (including zero/broadcast sender_ip).
-        self.frames_analyzed += 1;
+        self.frames_analyzed = self.frames_analyzed.saturating_add(1);
         match frame.operation {
-            1 => self.request_count += 1,
-            2 => self.reply_count += 1,
-            _ => self.other_opcode_count += 1,
+            1 => self.request_count = self.request_count.saturating_add(1),
+            2 => self.reply_count = self.reply_count.saturating_add(1),
+            _ => self.other_opcode_count = self.other_opcode_count.saturating_add(1),
         }
 
         // (a) Filter zero/broadcast sender_ip — BC-2.16.005 Invariant 5.
@@ -853,7 +853,7 @@ impl ArpAnalyzer {
         }
 
         // Step 1: increment rebind_count (BC-2.16.004 PC1.a).
-        entry.rebind_count += 1;
+        entry.rebind_count = entry.rebind_count.saturating_add(1);
 
         // Step 2: set first_rebind_ts if currently None (BC-2.16.004 PC1.b).
         if entry.first_rebind_ts.is_none() {

--- a/src/analyzer/dnp3.rs
+++ b/src/analyzer/dnp3.rs
@@ -873,7 +873,8 @@ impl Dnp3Analyzer {
                             if app_fc != 0x06 {
                                 let app_seq = active_carry!(flow, direction)[11] & 0x0F;
                                 if Self::insert_pending_request(flow, (dest, app_seq), ts) {
-                                    self.pending_requests_evicted += 1;
+                                    self.pending_requests_evicted =
+                                        self.pending_requests_evicted.saturating_add(1);
                                 }
                             }
 

--- a/src/analyzer/dnp3.rs
+++ b/src/analyzer/dnp3.rs
@@ -493,8 +493,8 @@ impl Dnp3Analyzer {
         if data.len() > remaining_capacity {
             active_carry!(flow, direction).extend_from_slice(&data[..remaining_capacity]);
             // Excess bytes beyond 292 are discarded; record one overflow (BC-2.15.016 PC2).
-            flow.parse_errors += 1;
-            flow.malformed_in_window += 1;
+            flow.parse_errors = flow.parse_errors.saturating_add(1);
+            flow.malformed_in_window = flow.malformed_in_window.saturating_add(1);
             // Inline resync: reposition carry to next [0x05,0x64] or clear if none found.
             // Structurally identical to Change 2 (LENGTH-gate arm inline resync).
             // Prevents the frame-walk sync-check arm from firing for this same overflow event.
@@ -559,8 +559,8 @@ impl Dnp3Analyzer {
                         // Non-sync bytes at carry head: unambiguously junk.
                         // Count parse_error regardless of did_process (BC-2.15.024
                         // Principle 1 / F-F5-003 REVISION 2 Change 1 Path B).
-                        flow.parse_errors += 1;
-                        flow.malformed_in_window += 1;
+                        flow.parse_errors = flow.parse_errors.saturating_add(1);
+                        flow.malformed_in_window = flow.malformed_in_window.saturating_add(1);
                         // Byte-walk resync: find next [0x05,0x64] or clear.
                         let next_sync = active_carry!(flow, direction)
                             .windows(2)
@@ -592,8 +592,8 @@ impl Dnp3Analyzer {
                         // (BC-2.15.024 Principle 1: one error per structural event.)
                         let length_byte = active_carry!(flow, direction)[2];
                         if compute_dnp3_frame_len(length_byte).is_none() {
-                            flow.parse_errors += 1;
-                            flow.malformed_in_window += 1;
+                            flow.parse_errors = flow.parse_errors.saturating_add(1);
+                            flow.malformed_in_window = flow.malformed_in_window.saturating_add(1);
                             // Byte-walk resync: drain past head byte, find next sync or clear.
                             active_carry!(flow, direction).drain(..1);
                             let next_sync = active_carry!(flow, direction)
@@ -658,8 +658,8 @@ impl Dnp3Analyzer {
                 // double-count: the overflow arm's inline resync leaves carry starting at a
                 // valid sync head or empty — the resync arm is NOT entered for overflow
                 // residue until AFTER a full valid frame has been consumed first.
-                flow.parse_errors += 1;
-                flow.malformed_in_window += 1;
+                flow.parse_errors = flow.parse_errors.saturating_add(1);
+                flow.malformed_in_window = flow.malformed_in_window.saturating_add(1);
                 Self::check_malformed_anomaly(
                     flow,
                     &mut self.all_findings,
@@ -700,8 +700,8 @@ impl Dnp3Analyzer {
                     // Invalid LENGTH (< 5): structural parse error. Advance one byte.
                     // STORY-109: increment BOTH parse_errors (lifetime) AND
                     // malformed_in_window (windowed) — BC-2.15.024 two-counter model.
-                    flow.parse_errors += 1;
-                    flow.malformed_in_window += 1;
+                    flow.parse_errors = flow.parse_errors.saturating_add(1);
+                    flow.malformed_in_window = flow.malformed_in_window.saturating_add(1);
                     active_carry!(flow, direction).drain(..1);
                     // F-F5-003 REVISION 2 Change 2: inline byte-walk-forward resync.
                     // After drain(..1), immediately reposition carry to the next
@@ -747,8 +747,8 @@ impl Dnp3Analyzer {
                 _ => {
                     // Frame-length mismatch: structural reject.
                     // STORY-109: increment BOTH parse_errors AND malformed_in_window.
-                    flow.parse_errors += 1;
-                    flow.malformed_in_window += 1;
+                    flow.parse_errors = flow.parse_errors.saturating_add(1);
+                    flow.malformed_in_window = flow.malformed_in_window.saturating_add(1);
                     active_carry!(flow, direction).drain(..frame_len);
                     Self::check_malformed_anomaly(
                         flow,
@@ -763,7 +763,7 @@ impl Dnp3Analyzer {
             };
 
             // --- Valid, gate-passed frame: now genuinely count it (BC-2.15.016 PC7). ---
-            flow.frame_count += 1;
+            flow.frame_count = flow.frame_count.saturating_add(1);
 
             // --- Snapshot for unexpected-source check (BC-2.15.010 Invariant 5) ---
             // F-F5-001 REVISION 2 §R2-3: capture PRE-PUSH state of master_addrs_seen
@@ -783,7 +783,7 @@ impl Dnp3Analyzer {
                 if flow.master_addrs_seen.len() < MAX_MASTER_ADDRS {
                     flow.master_addrs_seen.push(header.source);
                 } else {
-                    self.master_addrs_dropped += 1;
+                    self.master_addrs_dropped = self.master_addrs_dropped.saturating_add(1);
                 }
             }
 
@@ -1017,7 +1017,7 @@ impl Dnp3Analyzer {
         }
 
         // BC-2.15.010 postcondition 1: increment counter.
-        flow.direct_operate_count += 1;
+        flow.direct_operate_count = flow.direct_operate_count.saturating_add(1);
 
         // BC-2.15.010 postcondition 2: seed window_start_ts on first FC in window.
         if flow.direct_operate_count == 1 {
@@ -1060,7 +1060,7 @@ impl Dnp3Analyzer {
                 });
                 flow.direct_operate_emitted = true;
             } else {
-                *dropped_findings += 1;
+                *dropped_findings = dropped_findings.saturating_add(1);
                 // Prevent re-counting on the next on_data call: the logical finding was
                 // seen once, the cap blocked it once.  Guard mirrors the emit path.
                 flow.direct_operate_emitted = true;
@@ -1119,12 +1119,12 @@ impl Dnp3Analyzer {
                 direction: None,
             });
         } else {
-            *dropped_findings += 1;
+            *dropped_findings = dropped_findings.saturating_add(1);
         }
 
         // BC-2.15.011 postcondition 2 / Architecture Compliance Rule 3:
         // restart_event_count is incremented UNCONDITIONALLY (even when capped).
-        flow.restart_event_count += 1;
+        flow.restart_event_count = flow.restart_event_count.saturating_add(1);
 
         // T0827 co-emission placeholder: STORY-109 inserts derived T0827 push HERE,
         // after the T0814 push, ensuring most-specific-first ordering (BC-2.15.013).
@@ -1170,7 +1170,7 @@ impl Dnp3Analyzer {
                 direction: None,
             });
         } else {
-            *dropped_findings += 1;
+            *dropped_findings = dropped_findings.saturating_add(1);
         }
     }
 
@@ -1220,7 +1220,7 @@ impl Dnp3Analyzer {
             }
             flow.pending_requests.remove(&key);
             // BC-2.15.014 PC1: increment UNCONDITIONALLY (even when cap or guard active).
-            flow.block_event_count += 1;
+            flow.block_event_count = flow.block_event_count.saturating_add(1);
         }
         // BC-2.15.014 PC3: emit T1691.001 when threshold reached, guard clear, in-window.
         if flow.block_event_count >= BLOCK_CMD_THRESHOLD && !flow.block_finding_emitted_this_window
@@ -1255,7 +1255,7 @@ impl Dnp3Analyzer {
                 });
                 flow.block_finding_emitted_this_window = true;
             } else {
-                *dropped_findings += 1;
+                *dropped_findings = dropped_findings.saturating_add(1);
                 // Prevent re-counting: block-finding was observed once; cap blocked it once.
                 flow.block_finding_emitted_this_window = true;
             }
@@ -1387,7 +1387,7 @@ impl Dnp3Analyzer {
                 });
                 flow.loss_of_control_emitted = true;
             } else {
-                *dropped_findings += 1;
+                *dropped_findings = dropped_findings.saturating_add(1);
                 // Prevent re-counting: T0827 was observed once; cap blocked it once.
                 flow.loss_of_control_emitted = true;
             }
@@ -1449,7 +1449,7 @@ impl Dnp3Analyzer {
                 direction: None,
             });
         } else {
-            *dropped_findings += 1;
+            *dropped_findings = dropped_findings.saturating_add(1);
         }
         // BC-2.15.018 PC2: direct_operate_count incremented so burst threshold can fire.
         // The burst detection (detect_control_class_burst_split) runs after this in on_data
@@ -1487,7 +1487,7 @@ impl Dnp3Analyzer {
             return;
         }
         if findings.len() >= MAX_FINDINGS {
-            *dropped_findings += 1;
+            *dropped_findings = dropped_findings.saturating_add(1);
             // Prevent re-counting: unexpected-source was observed once; cap blocked it once.
             flow.unexpected_source_emitted = true;
             return;
@@ -1613,7 +1613,7 @@ impl Dnp3Analyzer {
                     });
                     flow.unsolicited_anomaly_emitted = true;
                 } else {
-                    *dropped_findings += 1;
+                    *dropped_findings = dropped_findings.saturating_add(1);
                     // Prevent re-counting: unsolicited anomaly was observed once; cap blocked it.
                     flow.unsolicited_anomaly_emitted = true;
                 }
@@ -1678,7 +1678,7 @@ impl Dnp3Analyzer {
                         direction: None,
                     });
                 } else {
-                    *dropped_findings += 1;
+                    *dropped_findings = dropped_findings.saturating_add(1);
                 }
             }
             0x14 => {
@@ -1717,7 +1717,7 @@ impl Dnp3Analyzer {
                         direction: None,
                     });
                 } else {
-                    *dropped_findings += 1;
+                    *dropped_findings = dropped_findings.saturating_add(1);
                 }
             }
             _ => {}
@@ -1789,7 +1789,7 @@ impl Dnp3Analyzer {
                 });
                 flow.malformed_anomaly_emitted = true;
             } else {
-                *dropped_findings += 1;
+                *dropped_findings = dropped_findings.saturating_add(1);
                 // Prevent re-counting: malformed anomaly was observed once; cap blocked it.
                 flow.malformed_anomaly_emitted = true;
             }

--- a/src/analyzer/dns.rs
+++ b/src/analyzer/dns.rs
@@ -69,9 +69,9 @@ impl ProtocolAnalyzer for DnsAnalyzer {
 
     fn analyze(&mut self, packet: &ParsedPacket) -> Vec<Finding> {
         if Self::is_query(&packet.payload) {
-            self.query_count += 1;
+            self.query_count = self.query_count.saturating_add(1);
         } else {
-            self.response_count += 1;
+            self.response_count = self.response_count.saturating_add(1);
         }
 
         Vec::new()

--- a/src/analyzer/enip.rs
+++ b/src/analyzer/enip.rs
@@ -865,7 +865,7 @@ impl EnipAnalyzer {
                     // frames as required by BC-2.17.004 Invariant 3.
                     *flow.command_counts.entry(header.command).or_insert(0) += 1;
                     flow.parse_errors = flow.parse_errors.saturating_add(1);
-                    flow.malformed_in_window += 1;
+                    flow.malformed_in_window = flow.malformed_in_window.saturating_add(1);
                     check_t0814(
                         flow,
                         &mut self.all_findings,
@@ -891,7 +891,7 @@ impl EnipAnalyzer {
                     // The frame is definitively skipped (oversized); this is a committed outcome.
                     *flow.command_counts.entry(header.command).or_insert(0) += 1;
                     flow.parse_errors = flow.parse_errors.saturating_add(1);
-                    flow.malformed_in_window += 1;
+                    flow.malformed_in_window = flow.malformed_in_window.saturating_add(1);
                     check_t0814(
                         flow,
                         &mut self.all_findings,
@@ -954,7 +954,7 @@ impl EnipAnalyzer {
             };
             if active_carry_len > MAX_ENIP_CARRY_BYTES {
                 flow.parse_errors = flow.parse_errors.saturating_add(1);
-                flow.malformed_in_window += 1;
+                flow.malformed_in_window = flow.malformed_in_window.saturating_add(1);
                 // T0814 evaluation runs while is_non_enip == false (BC-2.17.018 Precond 6).
                 check_t0814(
                     flow,
@@ -1343,7 +1343,7 @@ impl EnipAnalyzer {
                         flow.write_burst_emitted = false;
                     } else {
                         // BC-2.17.012 postcondition 1: increment per-flow window counter.
-                        flow.write_count_in_window += 1;
+                        flow.write_count_in_window = flow.write_count_in_window.saturating_add(1);
                         // BC-2.17.012 postcondition 3: seed window timestamp on first write.
                         if flow.write_count_in_window == 1 {
                             flow.write_window_start_ts = timestamp;

--- a/src/analyzer/http.rs
+++ b/src/analyzer/http.rs
@@ -434,14 +434,14 @@ impl HttpAnalyzer {
                 Some(Ok(None)) => return, // Partial — wait for more data
                 Some(Err(e)) => {
                     if !had_success {
-                        self.parse_errors += 1;
+                        self.parse_errors = self.parse_errors.saturating_add(1);
                         if let Some(state) = self.flows.get_mut(flow_key) {
                             state.request_error_count = state.request_error_count.saturating_add(1);
                             if state.request_error_count >= POISON_THRESHOLD {
                                 state.request_poisoned = true;
                                 if !state.counted_as_non_http {
                                     state.counted_as_non_http = true;
-                                    self.non_http_flows += 1;
+                                    self.non_http_flows = self.non_http_flows.saturating_add(1);
                                 }
                             }
                         }
@@ -484,7 +484,7 @@ impl HttpAnalyzer {
                 Some(Ok(Some(parsed))) => {
                     had_success = true;
                     *self.status_codes.entry(parsed.status_code).or_insert(0) += 1;
-                    self.transactions += 1;
+                    self.transactions = self.transactions.saturating_add(1);
 
                     if let Some(state) = self.flows.get_mut(flow_key) {
                         state.response_buf.drain(..parsed.bytes_consumed);
@@ -494,7 +494,7 @@ impl HttpAnalyzer {
                 Some(Ok(None)) => return,
                 Some(Err(e)) => {
                     if !had_success {
-                        self.parse_errors += 1;
+                        self.parse_errors = self.parse_errors.saturating_add(1);
                         if let Some(state) = self.flows.get_mut(flow_key) {
                             state.response_error_count =
                                 state.response_error_count.saturating_add(1);
@@ -502,7 +502,7 @@ impl HttpAnalyzer {
                                 state.response_poisoned = true;
                                 if !state.counted_as_non_http {
                                     state.counted_as_non_http = true;
-                                    self.non_http_flows += 1;
+                                    self.non_http_flows = self.non_http_flows.saturating_add(1);
                                 }
                             }
                         }
@@ -905,7 +905,7 @@ mod vp_006_proptest_proofs {
                 return len;
             }
             if invalid {
-                self.consecutive_errors += 1;
+                self.consecutive_errors = self.consecutive_errors.saturating_add(1);
                 if self.consecutive_errors >= POISON_THRESHOLD as u32 {
                     self.poisoned = true; // poisons now, but THIS event is not skipped
                 }

--- a/src/analyzer/modbus.rs
+++ b/src/analyzer/modbus.rs
@@ -397,15 +397,15 @@ impl ModbusAnalyzer {
 
         // --- total_flows_analyzed: increment once per flow on first PDU (BC-2.14.021 post.3) ---
         if flow.pdu_count == 0 {
-            self.total_flows_analyzed += 1;
+            self.total_flows_analyzed = self.total_flows_analyzed.saturating_add(1);
         }
 
         // --- Per-flow PDU counter + last timestamp (always, regardless of direction) ---
-        flow.pdu_count += 1;
+        flow.pdu_count = flow.pdu_count.saturating_add(1);
         flow.last_ts = timestamp;
 
         // --- Analyzer-level PDU counter + FC distribution (always, regardless of direction) ---
-        self.total_pdu_count += 1;
+        self.total_pdu_count = self.total_pdu_count.saturating_add(1);
         *self.fn_code_counts.entry(fc).or_insert(0) += 1;
 
         // --- Classify FC ---
@@ -515,7 +515,7 @@ impl ModbusAnalyzer {
                     let overwrite =
                         flow.insert_request(header.transaction_id, header.unit_id, fc, timestamp);
                     if overwrite.is_some() {
-                        self.duplicate_inflight_txn += 1;
+                        self.duplicate_inflight_txn = self.duplicate_inflight_txn.saturating_add(1);
                     }
                 }
 
@@ -524,8 +524,8 @@ impl ModbusAnalyzer {
                         // -------------------------------------------------------
                         // Write-class detection (BC-2.14.013–016)
                         // -------------------------------------------------------
-                        self.total_write_count += 1;
-                        flow.write_count += 1; // per-flow counter (BC-2.14.013 post.2)
+                        self.total_write_count = self.total_write_count.saturating_add(1);
+                        flow.write_count = flow.write_count.saturating_add(1); // per-flow counter (BC-2.14.013 post.2)
 
                         // Determine tag subset per ORCHESTRATOR RULING BC-DISCREPANCY-001:
                         // Register-write set {0x06,0x10,0x16,0x17} → T0836.
@@ -556,7 +556,8 @@ impl ModbusAnalyzer {
                                 flow.t0831_burst_emitted = false;
                             } else {
                                 // Still within window → increment count FIRST (update-before-check).
-                                flow.t0831_window_write_count += 1;
+                                flow.t0831_window_write_count =
+                                    flow.t0831_window_write_count.saturating_add(1);
                                 // Now check emission: count >= 2 and not yet emitted.
                                 if flow.t0831_window_write_count >= 2 && !flow.t0831_burst_emitted {
                                     emit_t0831 = true;
@@ -617,7 +618,7 @@ impl ModbusAnalyzer {
                                 flow.window_write_count = 1;
                                 flow.window_burst_emitted = false;
                             } else {
-                                flow.window_write_count += 1;
+                                flow.window_write_count = flow.window_write_count.saturating_add(1);
                                 if flow.window_write_count > self.write_burst_threshold
                                     && !flow.window_burst_emitted
                                 {
@@ -683,7 +684,8 @@ impl ModbusAnalyzer {
                                 flow.sustained_burst_emitted = false;
                             } else {
                                 // Accumulate first (update-before-check).
-                                flow.sustained_window_write_count += 1;
+                                flow.sustained_window_write_count =
+                                    flow.sustained_window_write_count.saturating_add(1);
                                 // saturating_sub: backwards-clock → elapsed=0 → no spurious reset.
                                 // `>=` operator is INTENTIONAL (RULING-MODBUS-SIBLING-001 §2.3):
                                 // sustained window fires ON the 2-second mark (minimum-duration gate).
@@ -825,8 +827,8 @@ impl ModbusAnalyzer {
                     // -------------------------------------------------------
                     // Exception response (BC-2.14.011 + BC-2.14.019)
                     // -------------------------------------------------------
-                    self.total_exception_count += 1;
-                    flow.exception_count += 1; // per-flow counter (BC-2.14.019 inv4)
+                    self.total_exception_count = self.total_exception_count.saturating_add(1);
+                    flow.exception_count = flow.exception_count.saturating_add(1); // per-flow counter (BC-2.14.019 inv4)
 
                     // Attribute exception to pending request (BC-2.14.011).
                     flow.attribute_exception(header.transaction_id, header.unit_id, fc);
@@ -930,7 +932,7 @@ impl ModbusAnalyzer {
         // -------------------------------------------------------
         for f in &local_findings {
             if self.all_findings.len() >= MAX_FINDINGS {
-                self.dropped_findings += 1;
+                self.dropped_findings = self.dropped_findings.saturating_add(1);
             } else {
                 self.all_findings.push(f.clone());
             }
@@ -1125,7 +1127,7 @@ impl StreamHandler for ModbusAnalyzer {
                     // cargo-mutants survivors here are EQUIVALENT.
                     if dir_carry.len() + remaining.len() > MAX_ADU_CARRY_BYTES {
                         flow.is_non_modbus = true;
-                        self.parse_errors += 1;
+                        self.parse_errors = self.parse_errors.saturating_add(1);
                     } else {
                         dir_carry.extend_from_slice(remaining);
                     }
@@ -1147,7 +1149,7 @@ impl StreamHandler for ModbusAnalyzer {
                 flow.is_non_modbus = true;
                 flow.carry_c2s.clear();
                 flow.carry_s2c.clear();
-                self.parse_errors += 1;
+                self.parse_errors = self.parse_errors.saturating_add(1);
                 break; // Cannot safely advance: length field is invalid.
             }
 
@@ -1177,7 +1179,7 @@ impl StreamHandler for ModbusAnalyzer {
                 // cargo-mutants survivors here are EQUIVALENT.
                 if dir_carry.len() + remaining.len() > MAX_ADU_CARRY_BYTES {
                     flow.is_non_modbus = true;
-                    self.parse_errors += 1;
+                    self.parse_errors = self.parse_errors.saturating_add(1);
                 } else {
                     dir_carry.extend_from_slice(remaining);
                 }

--- a/src/analyzer/tls.rs
+++ b/src/analyzer/tls.rs
@@ -483,7 +483,7 @@ impl TlsAnalyzer {
         _flow_key: &FlowKey,
         last_ts: u32,
     ) {
-        self.handshakes_seen += 1;
+        self.handshakes_seen = self.handshakes_seen.saturating_add(1);
 
         let version = ch.version.0;
         Self::increment(
@@ -498,7 +498,7 @@ impl TlsAnalyzer {
             Some(raw) => match parse_tls_extensions(raw) {
                 Ok((_, v)) => v,
                 Err(_) => {
-                    self.parse_errors += 1;
+                    self.parse_errors = self.parse_errors.saturating_add(1);
                     Vec::new()
                 }
             },
@@ -707,7 +707,7 @@ impl TlsAnalyzer {
             Some(raw) => match parse_tls_extensions(raw) {
                 Ok((_, v)) => v,
                 Err(_) => {
-                    self.parse_errors += 1;
+                    self.parse_errors = self.parse_errors.saturating_add(1);
                     Vec::new()
                 }
             },
@@ -948,7 +948,7 @@ impl TlsAnalyzer {
                         }
                         self.handle_server_hello(sh, flow_key, last_ts);
                     }
-                    Ok(_) | Err(_) => self.parse_errors += 1,
+                    Ok(_) | Err(_) => self.parse_errors = self.parse_errors.saturating_add(1),
                 }
             }
 
@@ -1006,8 +1006,8 @@ impl TlsAnalyzer {
                 RecordStep::OversizedRecord => {
                     // LESSON-P1.05 / CNV-PAT-002: bump both counters so JSON consumers
                     // can distinguish DoS-protection drops from parse failures.
-                    self.parse_errors += 1;
-                    self.truncated_records += 1;
+                    self.parse_errors = self.parse_errors.saturating_add(1);
+                    self.truncated_records = self.truncated_records.saturating_add(1);
                     return;
                 }
                 RecordStep::CarryOverflow => {

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -474,7 +474,7 @@ impl StreamHandler for StreamDispatcher {
                     // NOT on coverage_gaps_enabled. Moving this inside the coverage_gaps block
                     // would zero the counter on all normal (coverage_gaps=false) runs, breaking
                     // BC-2.05.009 + holdouts HS-040/HS-095.
-                    self.unclassified_flows += 1;
+                    self.unclassified_flows = self.unclassified_flows.saturating_add(1);
                     // STORY-153 (BC-2.05.010 PC-1, AC-153-003): per-port TCP counter increment.
                     // Dual-gate: (outer) analyzer-present guard AND (inner) coverage_gaps_enabled.
                     // ADR-012 Decision 6 Clarification EXACT: unclassified_flows += 1 is above,

--- a/src/main.rs
+++ b/src/main.rs
@@ -439,7 +439,8 @@ fn run_analyze(
                         if enable_arp {
                             all_findings.extend(arp_analyzer.record_malformed(raw.data.len()));
                         } else {
-                            arp_analyzer.malformed_frames += 1;
+                            arp_analyzer.malformed_frames =
+                                arp_analyzer.malformed_frames.saturating_add(1);
                         }
                     }
                     Err(e) => {
@@ -448,7 +449,7 @@ fn run_analyze(
                                 "Warning: failed to decode packet ({e}). Further errors counted silently."
                             );
                         }
-                        total_decode_errors += 1;
+                        total_decode_errors = total_decode_errors.saturating_add(1);
                     }
                 }
                 pb.inc(1);
@@ -834,7 +835,7 @@ fn run_summary(
                                 "Warning: failed to decode packet ({e}). Further errors counted silently."
                             );
                         }
-                        total_decode_errors += 1;
+                        total_decode_errors = total_decode_errors.saturating_add(1);
                     }
                 }
             }

--- a/src/reassembly/lifecycle.rs
+++ b/src/reassembly/lifecycle.rs
@@ -163,7 +163,7 @@ impl TcpReassembler {
             if self.total_memory <= self.config.memcap && self.flows.len() <= flow_count_target {
                 break;
             }
-            self.stats.evictions += 1;
+            self.stats.evictions = self.stats.evictions.saturating_add(1);
             self.close_flow(key, CloseReason::MemoryPressure, handler);
         }
     }
@@ -180,7 +180,7 @@ impl TcpReassembler {
         timestamp: u32,
     ) {
         if self.findings.len() >= MAX_FINDINGS {
-            self.stats.dropped_findings += 1;
+            self.stats.dropped_findings = self.stats.dropped_findings.saturating_add(1);
             return;
         }
         self.findings.push(Finding {
@@ -210,7 +210,7 @@ impl TcpReassembler {
         timestamp: u32,
     ) {
         if self.findings.len() >= MAX_FINDINGS {
-            self.stats.dropped_findings += 1;
+            self.stats.dropped_findings = self.stats.dropped_findings.saturating_add(1);
             return;
         }
         self.findings.push(Finding {

--- a/src/reassembly/mod.rs
+++ b/src/reassembly/mod.rs
@@ -156,7 +156,7 @@ impl TcpReassembler {
         timestamp: u32,
         handler: &mut dyn StreamHandler,
     ) {
-        self.stats.packets_processed += 1;
+        self.stats.packets_processed = self.stats.packets_processed.saturating_add(1);
         self.packet_index += 1;
 
         // BC-2.04.013 v1.5 PC0 — idle-flow expiry wiring.
@@ -201,7 +201,7 @@ impl TcpReassembler {
         let Some((key, tcp)) = self.extract_tcp_context(packet) else {
             return;
         };
-        self.stats.packets_tcp += 1;
+        self.stats.packets_tcp = self.stats.packets_tcp.saturating_add(1);
 
         // Get-or-create the flow, evicting under capacity pressure.
         if !self.get_or_create_flow(&key, timestamp, handler) {
@@ -227,7 +227,7 @@ impl TcpReassembler {
             .get(&key)
             .is_some_and(|f| f.state == FlowState::Closed)
         {
-            self.stats.flows_fin += 1;
+            self.stats.flows_fin = self.stats.flows_fin.saturating_add(1);
             self.close_flow(&key, CloseReason::Fin, handler);
         }
 
@@ -243,7 +243,8 @@ impl TcpReassembler {
     /// processed as a TCP segment.
     fn extract_tcp_context(&mut self, packet: &ParsedPacket) -> Option<(FlowKey, TcpFields)> {
         if packet.protocol != Protocol::Tcp {
-            self.stats.packets_skipped_non_tcp += 1;
+            self.stats.packets_skipped_non_tcp =
+                self.stats.packets_skipped_non_tcp.saturating_add(1);
             return None;
         }
         let tcp = match &packet.transport {
@@ -292,7 +293,7 @@ impl TcpReassembler {
             }
             let flow = TcpFlow::new(key.clone(), timestamp);
             self.flows.insert(key.clone(), flow);
-            self.stats.flows_total += 1;
+            self.stats.flows_total = self.stats.flows_total.saturating_add(1);
         }
 
         let flow = self.flows.get_mut(key).unwrap();
@@ -335,7 +336,7 @@ impl TcpReassembler {
         // RST — flush salvageable data, close, and remove.
         if tcp.rst {
             flow.on_rst();
-            self.stats.flows_rst += 1;
+            self.stats.flows_rst = self.stats.flows_rst.saturating_add(1);
             self.close_flow(key, CloseReason::Rst, handler);
             return PostHandshake::FlowClosed;
         }
@@ -376,7 +377,7 @@ impl TcpReassembler {
             flow.set_initiator(packet.src_ip, tcp.src_port);
             let dir = flow.direction(packet.src_ip, tcp.src_port);
             flow.get_direction_mut(dir).infer_isn(tcp.seq);
-            self.stats.flows_partial += 1;
+            self.stats.flows_partial = self.stats.flows_partial.saturating_add(1);
         }
 
         let dir = flow.direction(packet.src_ip, tcp.src_port);
@@ -438,33 +439,40 @@ impl TcpReassembler {
         }
 
         match result {
-            InsertResult::Inserted => self.stats.segments_inserted += 1,
-            InsertResult::Duplicate => self.stats.segments_duplicates += 1,
+            InsertResult::Inserted => {
+                self.stats.segments_inserted = self.stats.segments_inserted.saturating_add(1)
+            }
+            InsertResult::Duplicate => {
+                self.stats.segments_duplicates = self.stats.segments_duplicates.saturating_add(1)
+            }
             InsertResult::PartialOverlap => {
-                self.stats.segments_overlaps += 1;
-                self.stats.segments_inserted += 1;
+                self.stats.segments_overlaps = self.stats.segments_overlaps.saturating_add(1);
+                self.stats.segments_inserted = self.stats.segments_inserted.saturating_add(1);
             }
             InsertResult::ConflictingOverlap => {
-                self.stats.segments_overlaps += 1;
+                self.stats.segments_overlaps = self.stats.segments_overlaps.saturating_add(1);
                 self.generate_conflicting_overlap_finding(key, packet.src_ip, timestamp);
             }
             InsertResult::Truncated => {
-                self.stats.segments_inserted += 1;
+                self.stats.segments_inserted = self.stats.segments_inserted.saturating_add(1);
                 self.generate_truncated_finding(key, packet.src_ip, timestamp);
             }
             InsertResult::DepthExceeded => {
-                self.stats.segments_depth_exceeded += 1;
+                self.stats.segments_depth_exceeded =
+                    self.stats.segments_depth_exceeded.saturating_add(1);
             }
             InsertResult::SegmentLimitReached => {
-                self.stats.segments_segment_limit += 1;
+                self.stats.segments_segment_limit =
+                    self.stats.segments_segment_limit.saturating_add(1);
                 // Partial insertion: some gap bytes were inserted before the limit
                 if bytes_added > 0 {
-                    self.stats.segments_overlaps += 1;
-                    self.stats.segments_inserted += 1;
+                    self.stats.segments_overlaps = self.stats.segments_overlaps.saturating_add(1);
+                    self.stats.segments_inserted = self.stats.segments_inserted.saturating_add(1);
                 }
             }
             InsertResult::OutOfWindow => {
-                self.stats.segments_out_of_window += 1;
+                self.stats.segments_out_of_window =
+                    self.stats.segments_out_of_window.saturating_add(1);
             }
             InsertResult::IsnMissing => {
                 // Programming error — ISN should always be set before insert.
@@ -525,7 +533,7 @@ impl TcpReassembler {
                     direction: Some(dir),
                 });
             } else {
-                self.stats.dropped_findings += 1;
+                self.stats.dropped_findings = self.stats.dropped_findings.saturating_add(1);
             }
         }
         // LESSON-P2.05 follow-up: a flow is exempt from small-segment
@@ -565,7 +573,7 @@ impl TcpReassembler {
                     direction: Some(dir),
                 });
             } else {
-                self.stats.dropped_findings += 1;
+                self.stats.dropped_findings = self.stats.dropped_findings.saturating_add(1);
             }
         }
         if flow_dir.out_of_window_count > out_of_window_threshold
@@ -591,7 +599,7 @@ impl TcpReassembler {
                     direction: Some(dir),
                 });
             } else {
-                self.stats.dropped_findings += 1;
+                self.stats.dropped_findings = self.stats.dropped_findings.saturating_add(1);
             }
         }
     }
@@ -644,7 +652,7 @@ impl TcpReassembler {
             .collect();
 
         for key in expired_keys {
-            self.stats.flows_expired += 1;
+            self.stats.flows_expired = self.stats.flows_expired.saturating_add(1);
             self.close_flow(&key, CloseReason::Timeout, handler);
         }
     }
@@ -674,7 +682,7 @@ impl TcpReassembler {
             .collect();
 
         for key in expired_keys {
-            self.stats.flows_expired += 1;
+            self.stats.flows_expired = self.stats.flows_expired.saturating_add(1);
             self.close_flow(&key, CloseReason::Timeout, handler);
         }
     }
@@ -693,7 +701,7 @@ impl TcpReassembler {
             .collect();
 
         for key in expired_keys {
-            self.stats.flows_expired += 1;
+            self.stats.flows_expired = self.stats.flows_expired.saturating_add(1);
             self.close_flow(&key, CloseReason::Timeout, handler);
         }
     }

--- a/src/summary.rs
+++ b/src/summary.rs
@@ -56,7 +56,7 @@ impl Summary {
     }
 
     pub fn ingest(&mut self, packet: &ParsedPacket) {
-        self.total_packets += 1;
+        self.total_packets = self.total_packets.saturating_add(1);
         self.total_bytes += packet.packet_len as u64;
         self.hosts.insert(packet.src_ip);
         self.hosts.insert(packet.dst_ip);


### PR DESCRIPTION
## Summary

Mechanical, behavior-preserving refactor that converts every persistent diagnostic counter increment from plain `+= 1` to `.saturating_add(1)` across the analyzer, reassembly, dispatcher, and summary layers.

- Closes **PF-001** (pattern sweep maint-2026-07-08)
- Closes **REBIND-COUNT-SATURATING-001**
- Completes the **SEC-004 / SEC-007** house-style class

No logic changes. No new failure modes. All converted sites are observable, long-lived counters whose overflow would silently corrupt reported statistics in very high-packet-rate captures.

## Site-count per file

| File | Sites converted |
|------|----------------|
| `src/analyzer/arp.rs` | 14 |
| `src/analyzer/dnp3.rs` | 29 |
| `src/analyzer/dns.rs` | 2 |
| `src/analyzer/enip.rs` | 4 |
| `src/analyzer/http.rs` | 6 |
| `src/analyzer/modbus.rs` | 15 |
| `src/analyzer/tls.rs` | 6 |
| `src/dispatcher.rs` | 1 |
| `src/main.rs` | 3 |
| `src/reassembly/lifecycle.rs` | 3 |
| `src/reassembly/mod.rs` | 24 |
| `src/summary.rs` | 1 |
| **Total** | **109** |

Delivered in two commits: initial pass 52 sites (42e8f3c), DF-SIBLING-SWEEP-001 completion pass 57 sites (5c5ecb6).

## Exclusion classification

All remaining `+= 1` hits in the changed files are intentionally out of scope. Every hit falls into one of three categories:

| Category | Examples | Rationale |
|----------|----------|-----------|
| Cursor / index arithmetic | `j += 1`, `k += 1`, `i += 1`, `cursor += 1`, `dispatched += 1`, `iterations += 1`, `self.packet_index += 1`, `len += 1` | Loop/byte-walk variables; no overflow risk in practice; semantics differ from saturation |
| HashMap `entry().or_insert(0)` idiom | `*flow.fc_counts.entry(fc).or_insert(0) += 1`, `*self.methods.entry(…).or_insert(0) += 1`, etc. (across dnp3, enip, http, modbus, tls, summary) | Frequency-map pattern; bounded by distinct key count; `saturating_add` not applicable to deref-then-assign idiom without restructuring |
| Comment text | Doc-comment and inline-comment occurrences of `+= 1` as prose describing algorithm steps | Not compiled code |

A whole-source grep (`git grep '\+= 1' src/`) on the branch tip confirms zero unclassified hits.

## Intentional exclusion (CH-01)

`src/reassembly/mod.rs:160` `self.packet_index += 1` is NOT converted. `packet_index` is arithmetic-load-bearing: it functions as a logical clock in idle-flow expiry via the comparison `self.packet_index - flow.last_activity_index > idle_packet_threshold`. Saturating at `u64::MAX` would freeze that subtraction at zero rather than cap a display counter, breaking expiry entirely. This site is intentionally left as plain `+= 1` and documented here so future sibling-sweep audits do not re-open it.

## Verification

```
cargo test --all-targets  ✓
cargo clippy --all-targets -- -D warnings  ✓
cargo fmt --check  ✓
git grep '+= 1' src/ | grep -v '.rs:.*//.*+= 1' | grep -v 'entry(' | grep -v 'saturating'  → 0 unclassified diagnostic sites
```

Adversarial review: CLEAN (one INFO note recorded above as CH-01). CI: 11/11 pass.