### PR TITLE
chore: maint-2026-07-11 cleanup — wave-73 CR findings + doc drift + dnp3 lint hygiene

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,9 @@ Version numbers follow [Semantic Versioning](https://semver.org/).
   - `src/analyzer/dnp3.rs`: remove 9 spurious `#[allow(unused)]` attributes from
     actively-used `pub const` items (PC-NEW-001); add rationale comments to the 3
     `#[allow(clippy::too_many_arguments)]` suppressions that lacked them (PC-NEW-002).
+  - `src/analyzer/dnp3.rs` `Dnp3FlowState` doc-comment: reword stale present-tense
+    "are stubs … contain no logic yet" to past-tense provenance "were stubs through
+    STORY-107 and are fully implemented as of STORY-108/109" (F-P1-001).
 
 ## [0.12.0] - 2026-07-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,9 @@ Version numbers follow [Semantic Versioning](https://semver.org/).
   - `src/analyzer/dnp3.rs` `Dnp3FlowState` doc-comment: reword stale present-tense
     "are stubs … contain no logic yet" to past-tense provenance "were stubs through
     STORY-107 and are fully implemented as of STORY-108/109" (F-P1-001).
+  - `src/analyzer/arp.rs` two test doc-comments: remove stale "RED GATE: these two new
+    keys are absent from the current summarize() implementation" — both keys are fully
+    implemented and the tests are GREEN (F-P1-001 sibling sweep, DF-GREEN-DOC-TENSE-SWEEP).
 
 ## [0.12.0] - 2026-07-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,8 +59,9 @@ Version numbers follow [Semantic Versioning](https://semver.org/).
   - `src/analyzer/arp.rs` `detect_storm` doc-comment: note integer truncation in rate
     formula (ARP-RATE-INTDIV-DOC-001).
   - `src/analyzer/dnp3.rs`: remove 9 spurious `#[allow(unused)]` attributes from
-    actively-used `pub const` items (PC-NEW-001); add rationale comments to the 3
-    `#[allow(clippy::too_many_arguments)]` suppressions that lacked them (PC-NEW-002).
+    actively-used `pub const` items (PC-NEW-001); add rationale comments to 3 of the
+    6 `#[allow(clippy::too_many_arguments)]` suppressions — the 3 that lacked them;
+    the remaining 3 carried pre-existing `// N args: …` rationale (PC-NEW-002).
   - `src/analyzer/dnp3.rs` `Dnp3FlowState` doc-comment: reword stale present-tense
     "are stubs … contain no logic yet" to past-tense provenance "were stubs through
     STORY-107 and are fully implemented as of STORY-108/109" (F-P1-001).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,10 @@ Version numbers follow [Semantic Versioning](https://semver.org/).
   - `src/analyzer/arp.rs` two test doc-comments: remove stale "RED GATE: these two new
     keys are absent from the current summarize() implementation" — both keys are fully
     implemented and the tests are GREEN (F-P1-001 sibling sweep, DF-GREEN-DOC-TENSE-SWEEP).
+  - `src/analyzer/arp.rs` doc-comment count sweep: correct five remaining "eleven" →
+    "thirteen" occurrences (module doc, `summarize()` API doc, section comment); add
+    `bindings_evicted` and `storm_counters_evicted` to the `summarize()` key-contract
+    enumeration (F-P2-001, DF-SIBLING-SWEEP-001).
 
 ## [0.12.0] - 2026-07-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,35 @@ Version numbers follow [Semantic Versioning](https://semver.org/).
   Codifies wave-72 process-gap F-W72G-P2-OBS-001 per S-7.02 cycle-close obligation
   (F-S161P1-001 / VP-INDEX LMR-003 template-conformance exemption on factory side).
 
+- **maint-2026-07-11 cleanup — CR-001/002/003 + doc drift + dnp3 lint hygiene.**
+
+  - `bin/test_check_green_doc_tense.py` AC-158-005 test: add hermetic `_find_repo_root`
+    patch (mirroring AC-162-003 pattern); tighten assertion from `exit_code != 0` to
+    `exit_code == 1`; restore both patched helpers in `finally` (CR-001).
+  - `bin/check-green-doc-tense` `_find_repo_root` docstring/comment: reword to
+    "at most 6 candidates (start inclusive)" to match `range(6)` behavior (CR-002).
+  - `bin/test_check_green_doc_tense.py` test (c): replace `str.startswith` with
+    `Path.is_relative_to()` for correct filesystem-hierarchy containment check (CR-003).
+  - README.md `--arp-storm-rate` option description: add `>=` directional semantics and
+    calibration note (README-OPTIONS-L117-NEUTRAL-001).
+  - README.md ARP JSON schema note: correct `arp_summary` key claim — ARP counters are
+    flat in `analyzers[i].detail`, not nested under `arp_summary` (PG-W-README-JSON-SCHEMA).
+  - README.md DNP3 threshold-tuning note: add bidirectional-flow assumption and mirror-tap
+    guidance (DNP3-TUNING-BIDIR-001).
+  - `docs/adr/0002-modular-protocol-analyzers.md`: correct tech-debt item ID `PC-023` →
+    `PC-020` for `EnipAnalyzer` `StreamHandler` deviation (DOC-NEW-001).
+  - `docs/adr/0001-content-first-stream-dispatch.md`: add `unclassified_port_counts` and
+    `coverage_gaps_enabled` fields to the `StreamDispatcher` struct snippet (NEW-003).
+  - `CHANGELOG.md` v0.7.0 D3 ARP-storm entry: add inline errata noting `mitre_techniques: []`
+    per DF-VALIDATION-001 / BC-2.16.008 Invariant 3 (CHANGELOG-D3-T0830-DRIFT-001).
+  - `src/cli.rs` Modbus arg doc-comments: harmonize "1-second window" → "1s window" for
+    consistency with adjacent arg format (UNIT-FMT-5-20S-001).
+  - `src/analyzer/arp.rs` `detect_storm` doc-comment: note integer truncation in rate
+    formula (ARP-RATE-INTDIV-DOC-001).
+  - `src/analyzer/dnp3.rs`: remove 9 spurious `#[allow(unused)]` attributes from
+    actively-used `pub const` items (PC-NEW-001); add rationale comments to the 3
+    `#[allow(clippy::too_many_arguments)]` suppressions that lacked them (PC-NEW-002).
+
 ## [0.12.0] - 2026-07-10
 
 ### Changed (BREAKING)
@@ -803,7 +832,9 @@ Version numbers follow [Semantic Versioning](https://semver.org/).
   - **D2 Gratuitous ARP (GARP)** — unsolicited GARP frames flagged as Possible; binding-conflict
     GARP (GARP where the announced MAC differs from the established binding) escalated to Likely.
   - **D3 ARP storms** — high-rate ARP flood detection (configurable `--arp-storm-rate`, default
-    50 frames/window). Attributed to **T0830**.
+    50 frames/window). ~~Attributed to **T0830**.~~ (Corrected: D3 findings emit
+    `mitre_techniques: []` — T0814 attribution withheld per DF-VALIDATION-001 / BC-2.16.008
+    Invariant 3. See v0.7.0 shipping state vs. current behavior.)
   - **D11 Malformed ARP frames** — strict + lax/snaplen-truncated ARP parsing; frames that fail
     both passes are flagged as malformed-protocol anomalies.
   - **D12 L2/L3 MAC mismatch** — Ethernet source MAC vs. ARP sender hardware address mismatch

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Options:
 --dnp3-direct-operate-threshold N      Direct-operate burst threshold per flow (default: 10)
 --arp                                  Analyze ARP traffic (spoofing, GARP, storms, malformed, MAC mismatch; default-off; included in --all)
 --arp-spoof-threshold N                MAC-rebind escalation threshold per IP within 60s window (default: 3)
---arp-storm-rate N                     ARP storm frames/second per source MAC threshold (default: 50)
+--arp-storm-rate N                     ARP storm rate (frames/second per source MAC at or above which a storm finding is emitted; default: 50; engineering default — not derived from any external standard; see Known Limitations)
 --enip                                 Analyze EtherNet/IP TCP traffic (port 44818, default-off; included in --all)
 --enip-write-burst-threshold N         CIP write-burst threshold in SetAttribute requests/1s window (default: 50)
 --enip-error-burst-threshold N         CIP error-burst threshold in error responses/10s window (default: 5)
@@ -260,7 +260,8 @@ CLI flags:
 - `--arp-spoof-threshold N` — MAC-rebind escalation threshold within the 60s window (default: 3)
 - `--arp-storm-rate N` — frames/second per source MAC at or above which a storm finding is emitted (default: 50)
 
-JSON output counters (present in `arp_summary` when using `--json` / `--output-format json`):
+JSON output counters (present in the ARP analyzer's `detail` object in JSON output, at
+`analyzers[i].detail`, when using `--json` / `--output-format json`):
 - `bindings_evicted` — count of IP→MAC binding-table LRU evictions (table cap: 65 536 entries); a
   non-zero value means the oldest bindings were dropped to stay within the memory bound
 - `storm_counters_evicted` — count of per-MAC storm-counter-table LRU evictions (table cap:
@@ -409,7 +410,10 @@ at high rates should raise it above their baseline to avoid false positives.
 burst finding when more than 10 Control-class function codes arrive within the 60-second
 detection window (`--dnp3-direct-operate-threshold`, default 10). This value was chosen to
 tolerate routine maintenance while catching commissioning-speed attacks; quiet OT segments may
-need a lower value (3–5).
+need a lower value (3–5). Note: the threshold counts per-flow control events across both
+captured directions; a unidirectional mirror-tap deployment captures only one direction, which
+halves the observable FC rate — operators on mirror taps may need to halve the threshold to
+compensate.
 
 ### MACsec-Modified ARP limitation
 

--- a/bin/check-green-doc-tense
+++ b/bin/check-green-doc-tense
@@ -363,10 +363,10 @@ def _find_repo_root(start: Path) -> Path | None:
     - Invariant: when the return value is not None it is an ancestor-or-equal
       of *start* and satisfies `(p / ".git").exists() or (p / ".factory").is_dir()`.
 
-    Walk upward up to 6 levels from *start*.
+    Walk upward through at most 6 candidates (start inclusive).
     """
     candidate = start
-    for _ in range(6):  # at most 6 levels up
+    for _ in range(6):  # at most 6 candidates (start inclusive)
         if (candidate / ".git").exists() or (candidate / ".factory").is_dir():
             return candidate
         candidate = candidate.parent

--- a/bin/test_check_green_doc_tense.py
+++ b/bin/test_check_green_doc_tense.py
@@ -444,27 +444,34 @@ def run_tests() -> int:
     print()
     print("=== AC-158-005 zero-file guard (must exit non-zero when no files found) ===")
 
+    _orig_find_005 = mod._find_repo_root  # type: ignore[attr-defined]
     _orig_collect = mod._collect_rust_files  # type: ignore[attr-defined]
     try:
-        # Patch _collect_rust_files to return [] — simulates a repo with no
-        # tracked Rust files (e.g., src/ renamed or git ls-files returns nothing).
-        mod._collect_rust_files = lambda _repo_root: []  # type: ignore[attr-defined]
-        exit_code = mod.main()  # type: ignore[attr-defined]
-        if exit_code != 0:
-            print(
-                "  PASS  [zero-file guard: exits non-zero when _collect_rust_files "
-                "returns [] (AC-158-005)]"
-            )
-            passed += 1
-        else:
-            print(
-                "  FAIL  [zero-file guard: expected exit non-zero when "
-                "_collect_rust_files returns [], got 0 — "
-                "REGRESSION: zero-file guard (AC-158-005) no longer exits non-zero — "
-                "check the `if not rust_files:` guard in main()]"
-            )
-            failures += 1
+        with tempfile.TemporaryDirectory() as _td_005:
+            _hermetic_005 = Path(_td_005)
+            (_hermetic_005 / ".factory").mkdir()
+            mod._find_repo_root = lambda _s: _hermetic_005  # type: ignore[attr-defined]
+            # Patch _collect_rust_files to return [] — simulates a repo with no
+            # tracked Rust files (e.g., src/ renamed or git ls-files returns nothing).
+            mod._collect_rust_files = lambda _repo_root: []  # type: ignore[attr-defined]
+            exit_code = mod.main()  # type: ignore[attr-defined]
+            if exit_code == 1:
+                print(
+                    "  PASS  [zero-file guard: exits 1 exactly when _collect_rust_files "
+                    "returns [] (AC-158-005)]"
+                )
+                passed += 1
+            else:
+                print(
+                    "  FAIL  [zero-file guard: expected exit 1 when "
+                    "_collect_rust_files returns [], got "
+                    + repr(exit_code)
+                    + " — REGRESSION: zero-file guard (AC-158-005) no longer exits 1 — "
+                    "check the `if not rust_files:` guard in main()]"
+                )
+                failures += 1
     finally:
+        mod._find_repo_root = _orig_find_005  # type: ignore[attr-defined]
         mod._collect_rust_files = _orig_collect  # type: ignore[attr-defined]
 
     # ------------------------------------------------------------------
@@ -559,7 +566,7 @@ def run_tests() -> int:
         _deep_c = _root_c / "a" / "b" / "c" / "d"
         _deep_c.mkdir(parents=True)
         _result_c = _find_repo_root(_deep_c)
-        if _result_c is None or not str(_result_c).startswith(str(_root_c)):
+        if _result_c is None or not _result_c.is_relative_to(_root_c):
             print(
                 "  PASS  [_find_repo_root: no-sentinel temp tree returns None or "
                 "ancestor (F-W72G-P2-OBS-001)]"

--- a/docs/adr/0001-content-first-stream-dispatch.md
+++ b/docs/adr/0001-content-first-stream-dispatch.md
@@ -37,6 +37,10 @@ pub struct StreamDispatcher {
     dnp3: Option<Dnp3Analyzer>,      // Rule 6: port-20000 flows (ADR-007)
     enip: Option<EnipAnalyzer>,      // Rule 7: port-44818 flows (ADR-010)
     unclassified_flows: u64,
+    /// Per-port unclassified-flow counter; populated when coverage_gaps_enabled=true.
+    unclassified_port_counts: HashMap<(TransportProto, u16), u64>,
+    /// Feature flag: when true, unclassified_port_counts is populated on flow close.
+    coverage_gaps_enabled: bool,
 }
 
 enum DispatchTarget {

--- a/docs/adr/0002-modular-protocol-analyzers.md
+++ b/docs/adr/0002-modular-protocol-analyzers.md
@@ -177,7 +177,7 @@ Their actual interfaces are:
   direction: Direction)` and `on_flow_close(flow_key: FlowKey)` as plain inherent methods.
   `src/dispatcher.rs` calls them directly (not via the `StreamHandler` trait). The deviation from
   the generic `StreamAnalyzer` trait is purely that `EnipAnalyzer` was not retrofitted to that
-  interface (see tech-debt item PC-023). The dispatcher arm calls
+  interface (see tech-debt item PC-020). The dispatcher arm calls
   `enip.on_data(flow_key.clone(), ...)` with a per-packet `FlowKey` clone. See ADR-010 for the
   full EtherNet/IP design rationale.
 

--- a/src/analyzer/arp.rs
+++ b/src/analyzer/arp.rs
@@ -4,7 +4,7 @@
 //! maintains a bounded binding table (IP→MAC with LRU eviction), detects
 //! Gratuitous ARP (D2), D11 malformed ARP, D12 L2/L3 sender-MAC mismatch,
 //! D3 ARP storm rate detection, and exposes a `summarize()` method returning
-//! eleven canonical summary keys.
+//! thirteen canonical summary keys.
 //!
 //! STORY-113, STORY-114, and STORY-115 are all fully implemented and all tests pass (GREEN).
 //! `process_arp` emits D1 spoof findings (BC-2.16.004): MEDIUM on rebind, escalating
@@ -725,10 +725,10 @@ impl ArpAnalyzer {
         }]
     }
 
-    /// Produce the eleven-key `AnalysisSummary` for this capture.
+    /// Produce the thirteen-key `AnalysisSummary` for this capture.
     ///
     /// Returns an `AnalysisSummary` with `analyzer_name = "ARP"` and exactly
-    /// the following eleven keys in the `detail` BTreeMap (Architecture Compliance
+    /// the following thirteen keys in the `detail` BTreeMap (Architecture Compliance
     /// Rule 5 — exact string names are the contract per BC-2.16.010 PC1):
     ///
     /// - `"frames_analyzed"`
@@ -736,9 +736,11 @@ impl ArpAnalyzer {
     /// - `"reply_count"`
     /// - `"other_opcode_count"`
     /// - `"bindings_tracked"`
+    /// - `"bindings_evicted"`
     /// - `"spoof_findings"`
     /// - `"garp_findings"`
     /// - `"storm_findings"`
+    /// - `"storm_counters_evicted"`
     /// - `"mismatch_findings"`
     /// - `"malformed_findings"`
     /// - `"malformed_frames"`
@@ -2051,7 +2053,7 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
-    // AC-013 — BC-2.16.010 PC1/PC4: all eleven summary keys present, all 0 at zero frames
+    // AC-013 — BC-2.16.010 PC1/PC4: all thirteen summary keys present, all 0 at zero frames
     // -----------------------------------------------------------------------
 
     /// AC-013a (BC-2.16.010 PC4): all thirteen keys present with value 0 when no frames

--- a/src/analyzer/arp.rs
+++ b/src/analyzer/arp.rs
@@ -1003,7 +1003,7 @@ impl ArpAnalyzer {
     /// Step 2 — increment: count_in_window += 1 (window active path only).
     ///
     /// Step 3 — rate evaluation:
-    ///   rate = count_in_window / max(1, ts - window_start_ts).
+    ///   rate = count_in_window / max(1, ts - window_start_ts)  [integer division; truncates fractional rates].
     ///   If rate >= self.storm_rate AND !storm_emitted: emit MEDIUM/Anomaly Finding
     ///   with mitre_techniques: [] (T0814 withheld per DF-VALIDATION-001).
     ///   Set storm_emitted = true (one-shot guard per BC-2.16.008 Invariant 1).

--- a/src/analyzer/arp.rs
+++ b/src/analyzer/arp.rs
@@ -2054,7 +2054,7 @@ mod tests {
     // AC-013 — BC-2.16.010 PC1/PC4: all eleven summary keys present, all 0 at zero frames
     // -----------------------------------------------------------------------
 
-    /// AC-013a (BC-2.16.010 PC4): all eleven keys present with value 0 when no frames
+    /// AC-013a (BC-2.16.010 PC4): all thirteen keys present with value 0 when no frames
     /// have been processed.
     #[test]
     #[allow(non_snake_case)]
@@ -2065,7 +2065,7 @@ mod tests {
         // All thirteen canonical keys must be present and equal 0 (BC-2.16.010 v1.9 EC-001).
         // Updated 11→13 for BC-2.16.008 v2.0 / BC-2.16.010 v1.9: adds `bindings_evicted`
         // and `storm_counters_evicted` (silent-limit audit, surface-silent-resource-caps).
-        // RED GATE: these two new keys are absent from the current summarize() implementation.
+        // Both keys are implemented in summarize() and this test is GREEN.
         const EXPECTED_KEYS: &[&str] = &[
             "frames_analyzed",
             "request_count",
@@ -2102,7 +2102,7 @@ mod tests {
     ///
     /// Updated 11→13 for BC-2.16.008 v2.0 / BC-2.16.010 v1.9: adds `bindings_evicted`
     /// and `storm_counters_evicted` (silent-limit audit, surface-silent-resource-caps).
-    /// RED GATE: these two new keys are absent from the current summarize() implementation.
+    /// Both keys are implemented in summarize() — this test guards against regression.
     #[test]
     #[allow(non_snake_case)]
     fn test_BC_2_16_010_summarize_key_names_exact() {

--- a/src/analyzer/dnp3.rs
+++ b/src/analyzer/dnp3.rs
@@ -199,8 +199,8 @@ pub const MAX_FINDINGS: usize = 10_000;
 ///
 /// Carries the desync latch (`is_non_dnp3`) and the partial-frame accumulation
 /// buffer (`carry`) — both implemented in STORY-107 (carry-buffer frame-walk,
-/// AC-001..006).  Detection-emission and correlation-window fields are stubs for
-/// STORY-108/109; they compile but contain no logic yet.
+/// AC-001..006).  Detection-emission and correlation-window fields were stubs
+/// through STORY-107 and are fully implemented as of STORY-108/109.
 ///
 /// BC-2.15.009 (desync bail), ADR-007 Decision 4 (full field list).
 #[derive(Default)]

--- a/src/analyzer/dnp3.rs
+++ b/src/analyzer/dnp3.rs
@@ -119,14 +119,12 @@ pub enum Dnp3FcClass {
 
 /// Maximum outstanding pending control requests per flow for T1691.001
 /// request/response correlation.  Oldest entry evicted on overflow.
-#[allow(unused)]
 pub const MAX_PENDING_REQUESTS: usize = 256;
 
 /// Maximum on-wire DNP3 link frame size; also the per-flow carry-buffer bound
 /// (ADR-007 Decision 2).  LENGTH=255 → frame_len = 292 (proven ≤292 by VP-023 Sub-D).
 /// This is the **canonical** name, matching BC-2.15.016 postconditions 1–2 and the
 /// AC-001..006 test suite.
-#[allow(unused)]
 pub const MAX_DNP3_FRAME_LEN: usize = 292;
 
 /// Deprecated alias of [`MAX_DNP3_FRAME_LEN`] (the canonical name).
@@ -136,18 +134,15 @@ pub const MAX_DNP3_FRAME_LEN: usize = 292;
 /// single source of truth — this alias is retained only to avoid breaking any external
 /// reference and is defined in terms of the canonical constant.
 #[deprecated(note = "use MAX_DNP3_FRAME_LEN (canonical name per BC-2.15.016)")]
-#[allow(unused)]
 pub const MAX_DNP3_CARRY_BYTES: usize = MAX_DNP3_FRAME_LEN;
 
 /// Maximum unique master-station source addresses tracked per flow
 /// (BC-2.15.016 postconditions 5–6; ADR-007 Decision 4).
 /// Once full, new master source addresses are silently ignored.
-#[allow(unused)]
 pub const MAX_MASTER_ADDRS: usize = 64;
 
 /// Number of malformed/structural frames within the 300s correlation window
 /// that triggers a T0814 low/med-confidence anomaly finding (BC-2.15.024).
-#[allow(unused)]
 pub const MALFORMED_ANOMALY_THRESHOLD: u64 = 3;
 
 /// Shared correlation window length in seconds.  All six windowed correlation
@@ -155,7 +150,6 @@ pub const MALFORMED_ANOMALY_THRESHOLD: u64 = 3;
 /// `correlation_window_start_ts` reaches this value (BC-2.15.015).
 /// `block_event_count` and T1691.001 threshold share this window
 /// per BC-2.15.014 (no separate BLOCK_CMD_WINDOW_SECS constant).
-#[allow(unused)]
 pub const CORRELATION_WINDOW_SECS: u32 = 300;
 
 /// Per-request timeout for block-command inference (BC-2.15.014).
@@ -164,20 +158,17 @@ pub const CORRELATION_WINDOW_SECS: u32 = 300;
 /// `saturating_sub` used for all comparisons (BC-2.15.014 Inv 2 / BC-2.15.016
 /// Inv 8 / RULING-DNP3-SIBLING-001 §2.2 — prevents panic under
 /// overflow-checks=true on out-of-order pcap replay).
-#[allow(unused)]
 pub const BLOCK_CMD_TIMEOUT_SECS: u32 = 10;
 
 /// Minimum number of block-command timeout events within `CORRELATION_WINDOW_SECS`
 /// before a T1691.001 finding is emitted (BC-2.15.014 Inv 4 / Precondition 5).
 /// 3-of-300s sustained pattern prevents single-packet-loss false positives.
-#[allow(unused)]
 pub const BLOCK_CMD_THRESHOLD: u64 = 3;
 
 /// Combined restart + block-command event threshold for T0827 "Loss of Control"
 /// emission (BC-2.15.015 Precondition 1).  Distinct events required; single
 /// incident can increment at most one of the two accumulators per occurrence
 /// (BC-2.15.015 Inv 7).
-#[allow(unused)]
 pub const T0827_THRESHOLD: u64 = 3;
 
 /// Default threshold for the Direct-Operate burst guard (BC-2.15.017 / STORY-110).
@@ -1406,6 +1397,8 @@ impl Dnp3Analyzer {
     // Note: direct_operate_count is already incremented by detect_control_class_burst_split
     // which is called after this function in on_data. The BC-2.15.018 anomaly finding
     // is emitted here as a separate Suspicious/Possible/Medium finding.
+    // 9 params: BC-2.15.018 wiring requires flow state, findings vec, dropped counter,
+    // app_fc, dest/src addrs, timestamp, flow_key (for IP attribution), and direction.
     #[allow(clippy::too_many_arguments)]
     fn detect_broadcast_anomaly(
         _flow: &mut Dnp3FlowState,
@@ -1550,6 +1543,8 @@ impl Dnp3Analyzer {
     ///
     /// `app_ctrl` is the application-control byte (carry[11]); its bit 0x10 is
     /// the UNS bit included in the BC-2.15.019 PC1 evidence field.
+    // 10 params: standard 9-param wiring (BC-2.15.019) plus app_ctrl (UNS-bit byte
+    // required for PC1 evidence; cannot be folded into app_fc without losing the bit).
     #[allow(clippy::too_many_arguments)]
     fn detect_unsolicited_anomaly(
         flow: &mut Dnp3FlowState,
@@ -1634,6 +1629,8 @@ impl Dnp3Analyzer {
     ///   Also sets `flow.enable_unsolicited_seen = true` (context flag).
     ///
     /// Both push `mitre_techniques: vec!["T0814"]`.
+    // 9 params: BC-2.15.023 wiring requires flow state, findings vec, dropped counter,
+    // app_fc, dest/src addrs, timestamp, flow_key (for IP attribution), and direction.
     #[allow(clippy::too_many_arguments)]
     fn detect_unsolicited_control(
         flow: &mut Dnp3FlowState,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -182,7 +182,7 @@ pub enum Commands {
         modbus: bool,
 
         /// Per-flow write-burst threshold: fires T0806+T1692.001 when more than N
-        /// write-class FCs are observed within any 1-second window.
+        /// write-class FCs are observed within any 1s window.
         /// Default: 20. Must be >= 1.
         // BC-2.14.024
         #[arg(long, default_value_t = 20)]


### PR DESCRIPTION
## Summary

Maintenance chore PR applying 13 human-approved LOW/NIT/MINOR findings across four sweep
areas: wave-73 gate code-review (CR-001/002/003), documentation drift (7 findings), and
dnp3.rs lint hygiene (2 findings). All local gates green: `cargo test --all-targets`,
`cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and both Python test
suites (`python3 bin/test_compute_input_hash.py`, `python3 bin/test_check_green_doc_tense.py`).

**CHANGELOG gate:** `[Unreleased]` entry added at CHANGELOG.md covering all 13 findings
(satisfies AC-158-001 / PG-W71-CHANGELOG; `src/` and `bin/` modified).

## Finding Disposition Table

| ID | Severity | Source Artifact | Description | Disposition |
|----|----------|----------------|-------------|-------------|
| CR-001 | MINOR | `.factory/cycles/wave-73/wave-gate/code-review.md` | AC-158-005 test non-hermetic after `_find_repo_root` refactor; could pass with exit-2 instead of exit-1 | FIXED — hermetic `_find_repo_root` patch added, assertion tightened to `exit_code == 1` |
| CR-002 | NIT | `.factory/cycles/wave-73/wave-gate/code-review.md` | `_find_repo_root` docstring "6 levels" ambiguous vs `range(6)` (start inclusive) | FIXED — reworded to "at most 6 candidates (start inclusive)" |
| CR-003 | NIT | `.factory/cycles/wave-73/wave-gate/code-review.md` | Test (c) uses `str.startswith` instead of `Path.is_relative_to()` for path containment | FIXED — replaced with `_result_c.is_relative_to(_root_c)` |
| PG-W-README-JSON-SCHEMA | MEDIUM | `.factory/maintenance/doc-drift-findings-2026-07-11.md` | README.md:263 incorrectly claims ARP counters are in `arp_summary`; they are flat in `analyzers[i].detail` | FIXED — corrected to `analyzers[i].detail` with DNP3-section phrasing |
| README-OPTIONS-L117-NEUTRAL-001 | LOW | `.factory/maintenance/doc-drift-findings-2026-07-11.md` | `--arp-storm-rate` description lacks `>=` directional semantics and calibration note | FIXED — added "at or above which a storm finding is emitted" and calibration note |
| DNP3-TUNING-BIDIR-001 | LOW | `.factory/maintenance/doc-drift-findings-2026-07-11.md` | README Known Limitations DNP3 paragraph lacks bidirectional-flow assumption | FIXED — added one-sentence mirror-tap threshold guidance |
| DOC-NEW-001 | LOW | `.factory/maintenance/doc-drift-findings-2026-07-11.md` | ADR-0002:180 references tech-debt item PC-023; correct ID is PC-020 | FIXED — `PC-023` → `PC-020` |
| ROUTE-B-DEFERRED NEW-003 | LOW | `.factory/maintenance/doc-drift-findings-2026-07-11.md` | ADR-0001 `StreamDispatcher` struct snippet missing `unclassified_port_counts` and `coverage_gaps_enabled` fields | FIXED — both fields added to struct snippet |
| CHANGELOG-D3-T0830-DRIFT-001 | LOW | `.factory/maintenance/doc-drift-findings-2026-07-11.md` | CHANGELOG.md:806 v0.7.0 D3 entry claims T0830 attribution; current code emits `mitre_techniques: []` | FIXED — inline errata added per DF-VALIDATION-001 / BC-2.16.008 Invariant 3 |
| ARP-RATE-INTDIV-DOC-001 | LOW | `.factory/maintenance/doc-drift-findings-2026-07-11.md` | `detect_storm` doc-comment Step 3 formula does not note integer truncation | FIXED — added `[integer division; truncates fractional rates]` annotation |
| UNIT-FMT-5-20S-001 | LOW | `.factory/maintenance/doc-drift-findings-2026-07-11.md` | `src/cli.rs:185` "1-second window" inconsistent with adjacent "2s" format | FIXED — "1-second window" → "1s window" |
| PC-NEW-001 | NIT | `.factory/maintenance/pattern-findings-2026-07-11.md` | 9 spurious `#[allow(unused)]` on actively-used `pub const` items in `dnp3.rs` | FIXED — 9 attributes removed; 2 legitimate instances at lines 2085/2102 retained |
| PC-NEW-002 | NIT | `.factory/maintenance/pattern-findings-2026-07-11.md` | 6 `#[allow(clippy::too_many_arguments)]` in `dnp3.rs` lack rationale comments | FIXED — rationale comments added to 3 suppressions that lacked them (`detect_broadcast_anomaly`, `detect_unsolicited_anomaly`, `detect_unsolicited_control`) |

## Files Changed

- `CHANGELOG.md` — `[Unreleased]` entry + v0.7.0 D3 inline errata
- `README.md` — `--arp-storm-rate` description, ARP JSON schema note, DNP3 bidir guidance
- `bin/check-green-doc-tense` — `_find_repo_root` docstring (CR-002)
- `bin/test_check_green_doc_tense.py` — AC-158-005 hermetic patch + `is_relative_to` (CR-001, CR-003)
- `docs/adr/0001-content-first-stream-dispatch.md` — struct snippet fields (NEW-003)
- `docs/adr/0002-modular-protocol-analyzers.md` — PC-023 → PC-020 (DOC-NEW-001)
- `src/analyzer/arp.rs` — integer truncation doc note (ARP-RATE-INTDIV-DOC-001)
- `src/analyzer/dnp3.rs` — 9 `#[allow(unused)]` removals + 3 rationale comments (PC-NEW-001, PC-NEW-002)
- `src/cli.rs` — "1s window" harmonization (UNIT-FMT-5-20S-001)