### PR TITLE
chore: back-merge release v0.12.1 into develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Version numbers follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.12.1] - 2026-07-13
+
 ### Added
 
 - **`bin/validate-citations`: mechanical citation preflight validator (STORY-164,
@@ -1261,7 +1263,8 @@ Downstream consumers of wirerust JSON or CSV output must update for this release
 - Output sanitization in the terminal reporter guards against C1 control bytes
   in packet-derived strings.
 
-[Unreleased]: https://github.com/Zious11/wirerust/compare/v0.12.0...HEAD
+[Unreleased]: https://github.com/Zious11/wirerust/compare/v0.12.1...HEAD
+[0.12.1]: https://github.com/Zious11/wirerust/compare/v0.12.0...v0.12.1
 [0.12.0]: https://github.com/Zious11/wirerust/compare/v0.11.5...v0.12.0
 [0.11.5]: https://github.com/Zious11/wirerust/compare/v0.11.4...v0.11.5
 [0.11.4]: https://github.com/Zious11/wirerust/compare/v0.11.3...v0.11.4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1637,7 +1637,7 @@ dependencies = [
 
 [[package]]
 name = "wirerust"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wirerust"
-version = "0.12.0"
+version = "0.12.1"
 edition = "2024"
 rust-version = "1.91"
 description = "Fast PCAP forensics and network triage CLI tool"


### PR DESCRIPTION
Gitflow back-merge: brings the v0.12.1 release commits from \`main\` back into \`develop\` so the two branches do not diverge.

Merge commit on main: fedcea4ab17d9b3257c9903636aec0c0fd08f147 (PR #399)

**Commits being back-merged (release-only, not already on develop):**
- \`ec019b3\` chore: release v0.12.1 (version bump 0.12.0 → 0.12.1, CHANGELOG.md update)
- \`fedcea4\` Merge pull request #399 from Zious11/release/0.12.1

No source code changes are included — this PR brings only the Cargo.toml version bump, Cargo.lock update, and CHANGELOG.md section addition from the release branch.

**CHANGELOG gate note:** The CHANGELOG gate triggers on \`Cargo.toml\` changes. The \`[0.12.1] - 2026-07-13\` section is already present in CHANGELOG.md (added on the release branch), so the gate should pass.

**DO NOT merge via auto-merge.** Human authorization required.