### PR TITLE
docs(FIX-F5-002): correct FIX-F5-001 demo-evidence provenance + JSON + CHANGELOG direction-parity accuracy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,32 @@ Version numbers follow [Semantic Versioning](https://semver.org/).
   `track_ns_desync` each gain `source_ip: Option<IpAddr>` and
   `timestamp: Option<chrono::DateTime<chrono::Utc>>` parameters (callers updated).
 
+- **Documentation accuracy corrections for FIX-F5-001 and FIX-P4-001 evidence artifacts
+  (FIX-F5-002).**
+
+  Corrects three categories of inaccuracy introduced during demo-evidence authoring; no
+  source or test code is changed:
+
+  1. **Wrong provenance for sibling source_ip/timestamp enrichment:** The FIX-F5-001
+     evidence report (`docs/demo-evidence/FIX-F5-001/evidence-report.md`) incorrectly
+     cited STORY-172 and STORY-173 as the origin of DNP3/EtherNet/IP source_ip enrichment.
+     Those stories implement IEC-104 carry buffers and the IEC-104 dispatcher respectively;
+     the DNP3/EtherNet/IP house pattern for source_ip+timestamp originates from the
+     S-139/S-140 lineage (PR #328). Corrected to cite S-139/S-140 (PR #328) and to note
+     that IEC-104 additionally populates `direction: Some(direction)`, which DNP3 and
+     EtherNet/IP do not.
+
+  2. **Fabricated JSON in Before/After block:** The evidence-report JSON examples contained
+     incorrect field values (`category: "anomaly"`, `confidence: "high"`, fabricated summary
+     and evidence strings, `direction: "client_to_server"` with wrong casing). Replaced with
+     the actual T0881 STOPDT-act finding values from `src/analyzer/iec104.rs` lines 382–396:
+     `category: "impact"`, `confidence: "medium"`, real summary string,
+     `evidence: ["CF1=0x13 (STOPDT-act)"]`, `direction: "ClientToServer"` (serde default,
+     no `rename_all`).
+
+  3. **Wrong year in example timestamps:** Example timestamps using `2025-07-17` corrected
+     to `2026-07-17`.
+
 - **IEC-104 findings now carry the `direction` JSON key (FIX-P4-001,
   IEC104-FINDING-DIRECTION-001).**
 
@@ -43,9 +69,11 @@ Version numbers follow [Semantic Versioning](https://semver.org/).
   backward-compatible JSON change — JSON consumers that tolerate unknown keys or use
   subset/contains assertions are unaffected.
 
-  The fix brings IEC-104 into conformance with the TLS / Modbus / HTTP / DNP3 /
-  EtherNet/IP house pattern where `direction: Some(direction)` is set on every
-  emitted finding.
+  The fix brings IEC-104 direction enrichment into conformance with the TLS / Modbus /
+  HTTP analyzers, which already set `direction: Some(direction)` on every emitted finding.
+  Note: DNP3 and EtherNet/IP analyzers set `direction: None`; IEC-104's direction
+  population therefore exceeds the DNP3/EtherNet/IP baseline (which provides only
+  `source_ip` + `timestamp` parity, not direction).
 
   **Emit sites fixed (10 total):**
   - `process_u_frame`: STOPDT-act T0881 finding + non-canonical U-frame T0814 finding.

--- a/docs/demo-evidence/FIX-F5-001/evidence-report.md
+++ b/docs/demo-evidence/FIX-F5-001/evidence-report.md
@@ -7,7 +7,9 @@ FIX-F5-001 closes **BC-2.19.011 PC-3** by adding additive `source_ip` and `times
 **Behavior Change:** IEC-104 findings now include network context previously omitted.
 - **Closes:** BC-2.19.011 PC-3 (IEC-104 flow context enrichment)
 - **Traces:** FIX-F5-001 F-01, FIX-F5-001 F-02
-- **Sibling Parity:** DNP3 and EtherNet/IP analyzers already carry this enrichment (STORY-172, STORY-173)
+- **Sibling Parity:** DNP3 and EtherNet/IP analyzers already carry `source_ip` and `timestamp` enrichment
+  (S-139/S-140 lineage, PR #328); IEC-104 additionally populates `direction: Some(direction)`,
+  which DNP3 and EtherNet/IP do not (those analyzers set `direction: None`).
 
 ---
 
@@ -53,7 +55,7 @@ All 10 tests pass, verifying source_ip and timestamp enrichment across 9 distinc
 - **Test:** `test_fix_f5_001_carry_overflow_source_ip_and_timestamp`
 - **Behavior:** T0814 findings on carry buffer overflow now include network context
 - **Before:** `source_ip=None, timestamp=None`
-- **After:** `source_ip=Some(10.0.0.1), timestamp=Some(2025-07-17T...)`
+- **After:** `source_ip=Some(10.0.0.1), timestamp=Some(2026-07-17T...)`
 
 ### AC-3: Malformed Frame Length Detection (T0814)
 - **Test:** `test_fix_f5_001_malformed_len_source_ip_and_timestamp`
@@ -88,21 +90,24 @@ All 10 tests pass, verifying source_ip and timestamp enrichment across 9 distinc
 
 ### Before FIX-F5-001 (source_ip and timestamp omitted)
 
-Typical IEC-104 finding JSON serialization before the fix:
+T0881 STOPDT-act finding JSON before FIX-F5-001 (after FIX-P4-001, so `direction` is already
+present). `category`, `verdict`, `confidence`, `summary`, and `evidence` values match the
+actual `src/analyzer/iec104.rs` emit site (lines 382–396):
 
 ```json
 {
-  "category": "anomaly",
-  "verdict": "likely",
-  "confidence": "high",
-  "summary": "Detected STOPDT activation frame (IEC-104 connection termination)",
-  "evidence": ["Frame type: U-frame", "Control field: 0x13 (STOPDT-act)"],
+  "category": "impact",
+  "verdict": "possible",
+  "confidence": "medium",
+  "summary": "IEC-104 STOPDT-act received: CF1=0x13 — ICS data-transfer service stop request observed (T0881 inhibit-response-function; BC-2.19.011/012)",
+  "evidence": ["CF1=0x13 (STOPDT-act)"],
   "mitre_techniques": ["T0881"],
-  "direction": "client_to_server"
+  "direction": "ClientToServer"
 }
 ```
 
-Notice: No `source_ip`, no `timestamp` in JSON.
+Notice: No `source_ip`, no `timestamp` in JSON (both fields omit when `None` via
+`#[serde(skip_serializing_if = "Option::is_none")]`).
 
 ### After FIX-F5-001 (source_ip and timestamp populated)
 
@@ -110,21 +115,21 @@ With FIX-F5-001, the same finding now serializes as:
 
 ```json
 {
-  "category": "anomaly",
-  "verdict": "likely",
-  "confidence": "high",
-  "summary": "Detected STOPDT activation frame (IEC-104 connection termination)",
-  "evidence": ["Frame type: U-frame", "Control field: 0x13 (STOPDT-act)"],
+  "category": "impact",
+  "verdict": "possible",
+  "confidence": "medium",
+  "summary": "IEC-104 STOPDT-act received: CF1=0x13 — ICS data-transfer service stop request observed (T0881 inhibit-response-function; BC-2.19.011/012)",
+  "evidence": ["CF1=0x13 (STOPDT-act)"],
   "mitre_techniques": ["T0881"],
   "source_ip": "10.0.0.1",
-  "timestamp": "2025-07-17T12:34:56.123456Z",
-  "direction": "client_to_server"
+  "timestamp": "2026-07-17T12:34:56.123456Z",
+  "direction": "ClientToServer"
 }
 ```
 
 Added keys:
 - `"source_ip": "10.0.0.1"` — initiator endpoint IP from flow context
-- `"timestamp": "2025-07-17T12:34:56.123456Z"` — UTC timestamp when finding was detected
+- `"timestamp": "2026-07-17T12:34:56.123456Z"` — UTC timestamp when finding was detected
 
 ---
 
@@ -185,7 +190,7 @@ This ensures backward compatibility: downstream consumers that don't use these f
 | Behavioral Contract | BC-2.19.011 PC-3 |
 | Fix ID | FIX-F5-001 |
 | Feature Flags | FIX-F5-001 F-01 (source_ip enrichment), FIX-F5-001 F-02 (timestamp enrichment) |
-| Sibling Features | STORY-172 (DNP3 carry enrichment), STORY-173 (EtherNet/IP enrichment) |
+| Sibling Features | S-139/S-140 DNP3/EtherNet/IP `source_ip`+`timestamp` house pattern (PR #328); IEC-104 additionally sets `direction` (DNP3/ENIP set `direction: None`) |
 | Test Module | `tests/iec104_analyzer_tests.rs:fix_f5_001` |
 
 ---


### PR DESCRIPTION
## Summary

- **F5R2-01 MEDIUM — Wrong provenance for sibling source_ip/timestamp enrichment:** The FIX-F5-001 evidence report (`docs/demo-evidence/FIX-F5-001/evidence-report.md`) incorrectly cited STORY-172 and STORY-173 as the origin of DNP3/EtherNet/IP source_ip enrichment. Those stories implement IEC-104 carry buffers and the IEC-104 dispatcher respectively; the actual lineage is S-139/S-140 (PR #328). Corrected to cite S-139/S-140 (PR #328) and notes that IEC-104 additionally populates `direction: Some(direction)`, which DNP3 and EtherNet/IP do not (those set `direction: None`).

- **F5R2-02 MEDIUM — Fabricated JSON in Before/After block:** The evidence-report JSON examples contained incorrect field values (`category: "anomaly"`, `confidence: "high"`, fabricated summary and evidence strings, `direction: "client_to_server"` with wrong casing). Replaced with actual T0881 STOPDT-act finding values from `src/analyzer/iec104.rs` lines 382–396: `category: "impact"` (snake_case ThreatCategory serde), `confidence: "medium"` (lowercase Confidence serde), `direction: "ClientToServer"` (default CamelCase, no `rename_all`).

- **F5R2-03 LOW — Wrong year in example timestamps:** Example timestamps using `2025-07-17` corrected to `2026-07-17`.

- **CHANGELOG accuracy — FIX-P4-001 direction-parity correction:** Previous entry claimed DNP3/EtherNet/IP "house pattern sets direction: Some" — both actually set `direction: None`. Corrected to note that IEC-104's direction enrichment exceeds the DNP3/EtherNet/IP baseline; the actual parity is `source_ip` + `timestamp`.

## Changes

- `docs/demo-evidence/FIX-F5-001/evidence-report.md` — corrected provenance rows, regenerated JSON verified against `src/findings.rs` serde annotations (`ThreatCategory` snake_case, `Confidence` lowercase, `Direction` CamelCase), year correction.
- `CHANGELOG.md` — FIX-P4-001 direction-parity correction + new FIX-F5-002 entry.

**Zero `.rs` changes.** `git diff --name-only develop..fix/FIX-F5-002` = `CHANGELOG.md` + `docs/demo-evidence/FIX-F5-001/evidence-report.md` only.

## Test plan

- [ ] Verify diff is docs-only (`CHANGELOG.md` + `evidence-report.md`) — no `.rs` files
- [ ] Verify corrected JSON values match `src/findings.rs` serde annotations (row-verify per PG-W74)
- [ ] Verify provenance now correctly cites S-139/S-140 (PR #328) for DNP3/EtherNet/IP house pattern
- [ ] CI passes on develop base (no code changes; `cargo test --all-targets` unaffected)
- [ ] Security review not required (docs-only; no code or trust-boundary surface)