### PR TITLE
test: add IEC-104 e2e pcap+pcapng fixtures + analyzer-level real-pcap detection test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,11 @@ Version numbers follow [Semantic Versioning](https://semver.org/).
   All four captures parse without panics; zero parse_errors on every run. Corpus grows
   from 36 to 40 files; smoke test now verifies 39 pinned entries.
 
+  Companion analyzer-level e2e test added in `tests/iec104_e2e_real_pcaps_tests.rs` (4 tests,
+  modeled on `enip_e2e_real_pcaps_tests.rs`) pinning per-technique finding counts and
+  category/verdict/confidence distributions as regression guards against the IEC-104
+  analyzer pipeline (BC-2.19, STORY-167..174).
+
 ### Fixed
 
 - **CHANGELOG accuracy corrections: carry-overflow Example 3 `mitre_techniques` and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ Version numbers follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- **IEC-104 E2E pcap/pcapng corpus fixtures (STORY-167..174 coverage).**
+
+  Four IEC 60870-5-104 real-world captures added to the E2E smoke-test corpus
+  (`bin/fetch-e2e-pcaps` + `tests/fixtures/E2E-PCAPS.md` + pinned expectations in
+  `tests/e2e_corpus_smoke_tests.rs`):
+
+  - `iec104.pcap` (Wireshark Foundation; 10 KB) — canonical IEC-104 reference:
+    U-frames (STARTDT/STOPDT/TESTFR) + I-frame ASDUs + C_IC general interrogation
+    lifecycle. Analyzer produces 66 findings (T1692.001 ×42, T0836 ×24).
+  - `iec104-sq.pcapng` (Wireshark Foundation; 584 B) — native pcapng; SQ-bit ASDU
+    (sequence-of-information-objects encoding). Exercises the pcapng reader with IEC-104.
+    0 findings (benign link-management only).
+  - `iec104-iti-diverse.pcap` (ITI/ICS-Security-Tools, CC-BY-4.0; 14 KB) — diverse ASDU
+    Type ID mix. Analyzer produces 31 findings (T1692.001 ×21, T0836 ×10).
+  - `iec104-iti-dissect.pcap` (ITI/ICS-Security-Tools, CC-BY-4.0; 11 KB) — broad Type ID /
+    COT coverage including control commands. Analyzer produces 11 findings
+    (T1692.001 ×9, T0814 ×2).
+
+  All four captures parse without panics; zero parse_errors on every run. Corpus grows
+  from 36 to 40 files; smoke test now verifies 39 pinned entries.
+
 ### Fixed
 
 - **CHANGELOG accuracy corrections: carry-overflow Example 3 `mitre_techniques` and

--- a/bin/fetch-e2e-pcaps
+++ b/bin/fetch-e2e-pcaps
@@ -147,6 +147,20 @@ REAL_CAPTURES=(
   # Technology (ITI). CloudShark provenance noted in ITI README.
   # Tests: test_e2e_BC_2_17_ethernet_ip_cip_large_clean_no_panic (CC-BY-4.0).
   "EthernetIP-CIP.pcap|c50b510b3242f94c8aed9a4b6723962f182d04feca8a8dac09a96a135649461d|https://raw.githubusercontent.com/ITI/ICS-Security-Tools/master/pcaps/EthernetIP/EthernetIP-CIP.pcap"
+  # --- IEC 60870-5-104 (IEC-104) captures (STORY-167..174; port 2404) ---
+  # Wireshark canonical IEC-104 sample: U-frames (STARTDT/STOPDT/TESTFR) + I-frame
+  # ASDUs + general interrogation (C_IC TypeID 100) lifecycle. TCP 2404.
+  # Credit: Wireshark Foundation; no per-file license; public sample; not redistributed.
+  "iec104.pcap|a78aa971adc51e54413a865937f1799ef57118d397cef57ccd93a358ed5b85d6|https://gitlab.com/wireshark/wireshark/-/wikis/uploads/__moin_import__/attachments/SampleCaptures/iec104.pcap"
+  # Native pcapng: IEC-104 with SQ-bit (sequence-of-IOs) ASDU. Small; exercises
+  # pcapng reader + SQ ASDU path. Credit: Wireshark Foundation; public sample; not redistributed.
+  "iec104-sq.pcapng|f855a11326f7aa4f719b1fbb65e5f8dfe3d9d194185a8f5faf5b5dc3cb831227|https://gitlab.com/wireshark/wireshark/-/wikis/uploads/__moin_import__/attachments/SampleCaptures/IEC104_SQ.pcapng"
+  # ITI diverse-ASDU IEC-104 capture (CC-BY-4.0). Attribution: ICS Security Tools,
+  # Illinois Institute of Technology (ITI).
+  "iec104-iti-diverse.pcap|07b9a0879dc83e420c4cf83b37fb5830d1d8fb5f6ac6edc435896f70b0fc6bc7|https://raw.githubusercontent.com/ITI/ICS-Security-Tools/master/pcaps/IEC60870-5-104/090813_diverse.pcap"
+  # ITI dissector-test IEC-104 capture: broad Type ID / COT coverage incl. control
+  # commands. CC-BY-4.0. Attribution: ICS Security Tools, Illinois Institute of Technology (ITI).
+  "iec104-iti-dissect.pcap|292c18a8765db3b1bcaa9bd0b8455e4e61b8366cc5910a7363b7381eb11441b8|https://raw.githubusercontent.com/ITI/ICS-Security-Tools/master/pcaps/IEC60870-5-104/TestDissectIec104.pcap"
 )
 
 # Link-only captures — NOT auto-fetched. They require manual browser download or are too

--- a/tests/e2e_corpus_smoke_tests.rs
+++ b/tests/e2e_corpus_smoke_tests.rs
@@ -118,6 +118,20 @@ const EXPECTED: &[(&str, Expected)] = &[
     ("enip_metasploit.pcapng", Expected::OkCount(1784)),
     // EthernetIP-CIP.pcap (ITI CC-BY-4.0): 8799 ENIP PDUs; 10880 total packets.
     ("EthernetIP-CIP.pcap", Expected::OkCount(10880)),
+    // ── IEC 60870-5-104 captures (STORY-167..174) ─────────────────────────
+    // Packet counts are reader-level (PcapSource::from_file).
+    //
+    // iec104.pcap (Wireshark Foundation; public sample; not redistributed):
+    //   U-frames + I-frame ASDUs + C_IC general interrogation lifecycle. 105 packets.
+    ("iec104.pcap", Expected::OkCount(105)),
+    // iec104-sq.pcapng (Wireshark Foundation; public sample; not redistributed):
+    //   Native pcapng; SQ-bit ASDU. 1 packet.
+    ("iec104-sq.pcapng", Expected::OkCount(1)),
+    // iec104-iti-diverse.pcap (ITI CC-BY-4.0): diverse ASDU Type ID mix. 173 packets.
+    ("iec104-iti-diverse.pcap", Expected::OkCount(173)),
+    // iec104-iti-dissect.pcap (ITI CC-BY-4.0): broad Type ID / COT coverage
+    //   incl. control commands. 147 packets.
+    ("iec104-iti-dissect.pcap", Expected::OkCount(147)),
     // ── Err captures (stable error substring) ─────────────────────────────
     // E-INP-011: multi-IDB link-type conflict (message ends with "(E-INP-011)")
     ("pcapng-example.pcapng", Expected::ErrContains("E-INP-011")),

--- a/tests/fixtures/E2E-PCAPS.md
+++ b/tests/fixtures/E2E-PCAPS.md
@@ -334,6 +334,60 @@ The actual JSON output has **201 Likely/High (Pattern A: Identity-read requests)
 | `enip_metasploit.pcapng` | `https://raw.githubusercontent.com/scy-phy/bro-cip-enip/master/testing/btest/Traces/enip/enip_metasploit.pcapng` |
 | `EthernetIP-CIP.pcap` | `https://raw.githubusercontent.com/ITI/ICS-Security-Tools/master/pcaps/EthernetIP/EthernetIP-CIP.pcap` |
 
+## IEC 60870-5-104 (IEC-104) captures (STORY-167..174)
+
+Real-world IEC-104 (TCP port 2404) captures used for E2E validation of the IEC-104
+analyzer (SS-19). All are auto-fetchable via `bin/fetch-e2e-pcaps`.
+
+### Sources
+
+Two sources used:
+
+- **Wireshark Foundation SampleCaptures** — canonical reference samples; no per-file license;
+  public samples; not redistributed. Credit: Wireshark Foundation.
+- **ITI/ICS-Security-Tools** (CC-BY-4.0) — `pcaps/IEC60870-5-104/` at
+  `github.com/ITI/ICS-Security-Tools`. Attribution: ICS Security Tools, Illinois Institute
+  of Technology (ITI). License: CC-BY-4.0.
+
+### Captures
+
+| File | Size | sha256 | Source | License | Content summary |
+|------|------|--------|--------|---------|----------------|
+| `iec104.pcap` | 10 KB | `a78aa971adc51e54413a865937f1799ef57118d397cef57ccd93a358ed5b85d6` | Wireshark SampleCaptures | local-use-only | Canonical IEC-104 reference: U-frames (STARTDT/STOPDT/TESTFR) + I-frame ASDUs + C_IC general interrogation (TypeID 100, COT 6 act/7 con/20 inrogen/10 actterm). 105 reader packets. Produces 66 findings: T1692.001 ×42 (control commands) + T0836 ×24 (parameter modification). |
+| `iec104-sq.pcapng` | 584 B | `f855a11326f7aa4f719b1fbb65e5f8dfe3d9d194185a8f5faf5b5dc3cb831227` | Wireshark SampleCaptures | local-use-only | **Native pcapng** (SHB magic `0x0A0D0D0A`); SQ-bit set in ASDU variable-structure qualifier (sequence-of-information-objects encoding). Only native IEC-104 pcapng found on an authoritative source. 1 reader packet; 0 findings (small link-layer exercise). |
+| `iec104-iti-diverse.pcap` | 14 KB | `07b9a0879dc83e420c4cf83b37fb5830d1d8fb5f6ac6edc435896f70b0fc6bc7` | ITI/ICS-Security-Tools | CC-BY-4.0 | IEC-104 diverse-ASDU capture from the same ITI ICS corpus as the ENIP fixtures. 173 reader packets. Produces 31 findings: T1692.001 ×21 + T0836 ×10. |
+| `iec104-iti-dissect.pcap` | 11 KB | `292c18a8765db3b1bcaa9bd0b8455e4e61b8366cc5910a7363b7381eb11441b8` | ITI/ICS-Security-Tools | CC-BY-4.0 | Wireshark-dissector test capture: deliberately broad Type ID / COT coverage including control commands (C_SC/C_DC/C_SE). 147 reader packets. Produces 11 findings: T1692.001 ×9 + T0814 ×2. |
+
+### Analyzer-level outcomes (IEC-104 --iec104 flag)
+
+| File | Findings | Techniques fired | Parse errors |
+|------|----------|-----------------|--------------|
+| `iec104.pcap` | 66 | T0836 ×24, T1692.001 ×42 | 0 |
+| `iec104-sq.pcapng` | 0 | — (benign link-management traffic only) | 0 |
+| `iec104-iti-diverse.pcap` | 31 | T0836 ×10, T1692.001 ×21 | 0 |
+| `iec104-iti-dissect.pcap` | 11 | T0814 ×2, T1692.001 ×9 | 0 |
+
+All four captures parse without panics; zero parse_errors across all.
+
+### Attribution
+
+- **`iec104.pcap`** and **`iec104-sq.pcapng`**: Wireshark Foundation public SampleCaptures
+  collection. No per-file license stated; public samples. Credit: Wireshark Foundation.
+  Not redistributed.
+- **`iec104-iti-diverse.pcap`** and **`iec104-iti-dissect.pcap`**: ITI/ICS-Security-Tools,
+  Illinois Institute of Technology (ITI). License: CC-BY-4.0. Redistributable with
+  attribution. Repo: `https://github.com/ITI/ICS-Security-Tools`, directory
+  `pcaps/IEC60870-5-104/`.
+
+### Direct download URLs (IEC-104 captures)
+
+| File | URL |
+|------|-----|
+| `iec104.pcap` | `https://gitlab.com/wireshark/wireshark/-/wikis/uploads/__moin_import__/attachments/SampleCaptures/iec104.pcap` |
+| `iec104-sq.pcapng` | `https://gitlab.com/wireshark/wireshark/-/wikis/uploads/__moin_import__/attachments/SampleCaptures/IEC104_SQ.pcapng` |
+| `iec104-iti-diverse.pcap` | `https://raw.githubusercontent.com/ITI/ICS-Security-Tools/master/pcaps/IEC60870-5-104/090813_diverse.pcap` |
+| `iec104-iti-dissect.pcap` | `https://raw.githubusercontent.com/ITI/ICS-Security-Tools/master/pcaps/IEC60870-5-104/TestDissectIec104.pcap` |
+
 ## Adding a capture
 
 1. Drop the `.pcap` in `tests/fixtures/local-samples/` (gitignored).

--- a/tests/iec104_e2e_real_pcaps_tests.rs
+++ b/tests/iec104_e2e_real_pcaps_tests.rs
@@ -1,0 +1,618 @@
+//! Full-pipeline end-to-end tests for the IEC-104 analyzer against real IEC-104 pcaps.
+//!
+//! Exercises the complete `PcapSource::from_file → decode_packet → TcpReassembler →
+//! StreamDispatcher → Iec104Analyzer` pipeline using real-world captures and asserts that
+//! the analyzer's outputs match the ground-truth outcomes established during
+//! analyzer-level validation (STORY-167..174 e2e coverage pass).
+//!
+//! ## Fixture management
+//!
+//! Captures live in `tests/fixtures/local-samples/` (gitignored — see E2E-PCAPS.md). When
+//! that directory is absent or a specific fixture file is missing, the affected test prints a
+//! skip notice and returns immediately. This keeps CI green without fixtures while still
+//! failing loudly (assertion-level) when fixtures are present. `#[ignore]` is NOT used.
+//!
+//! To populate fixtures locally:
+//!
+//! ```bash
+//! bin/fetch-e2e-pcaps
+//! ```
+//!
+//! ## Test cases and pcap mapping
+//!
+//! | Test | Pcap | What it asserts |
+//! |------|------|-----------------|
+//! | `test_e2e_BC_2_19_iec104_pcap_T0836_T1692_001_interrogation` | `iec104.pcap` (Wireshark Foundation) | T0836 ×24 + T1692.001 ×42 = 66 total; flows_analyzed=1; dropped_findings=0 |
+//! | `test_e2e_BC_2_19_iec104_sq_pcapng_zero_findings_benign_uframes` | `iec104-sq.pcapng` (Wireshark Foundation) | 0 findings (benign STARTDT/TESTFR-only SQ-bit fixture); flows_analyzed=1; dropped_findings=0 |
+//! | `test_e2e_BC_2_19_iec104_iti_diverse_T0836_T1692_001_mixed_asdu` | `iec104-iti-diverse.pcap` (ITI CC-BY-4.0) | T0836 ×10 + T1692.001 ×21 = 31 total; flows_analyzed=1; dropped_findings=0 |
+//! | `test_e2e_BC_2_19_iec104_iti_dissect_T0814_T1692_001_control_coverage` | `iec104-iti-dissect.pcap` (ITI CC-BY-4.0) | T0814 ×2 + T1692.001 ×9 = 11 total; flows_analyzed=6; dropped_findings=0 |
+//!
+//! ## Traces
+//!
+//! BC-2.19 (IEC-104 analyzer pipeline, STORY-167..174); dispatch port 2404 (BC-2.05.012 §P2).
+//!
+//! Per DF-TEST-NAMESPACE-001: all tests are wrapped in `mod iec104_e2e_real_pcaps`.
+
+#![allow(non_snake_case)]
+
+mod iec104_e2e_real_pcaps {
+    use std::path::Path;
+
+    use wirerust::analyzer::iec104::Iec104Analyzer;
+    use wirerust::decoder::{DecodedFrame, decode_packet};
+    use wirerust::dispatcher::StreamDispatcher;
+    use wirerust::reader::PcapSource;
+    use wirerust::reassembly::{ReassemblyConfig, TcpReassembler};
+
+    // -------------------------------------------------------------------------
+    // Fixture root — relative to the crate root (same convention as other E2E tests)
+    // -------------------------------------------------------------------------
+
+    const LOCAL_SAMPLES: &str = "tests/fixtures/local-samples";
+
+    // -------------------------------------------------------------------------
+    // Skip-if-absent guard (mirrors enip_e2e_real_pcaps_tests.rs pattern)
+    //
+    // Returns true if the fixture is present, false if the test should be skipped.
+    // -------------------------------------------------------------------------
+
+    /// Check whether a fixture file is present in `tests/fixtures/local-samples/`.
+    ///
+    /// When the file is absent the caller prints a skip notice and returns early.
+    /// This keeps CI green when the gitignored local-samples directory is not populated.
+    fn fixture_present(filename: &str) -> bool {
+        let path = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join(LOCAL_SAMPLES)
+            .join(filename);
+        if !path.exists() {
+            eprintln!(
+                "[iec104-e2e] SKIP: fixture '{}' not found at {}. \
+                 Run `bin/fetch-e2e-pcaps` to populate local-samples.",
+                filename,
+                path.display()
+            );
+            false
+        } else {
+            true
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Pipeline helper — run the full reader → reassembler → dispatcher → IEC-104
+    // pipeline on `filename`, return the Iec104Analyzer (which owns all_findings).
+    //
+    // Mirrors the `run_analyze` pipeline in `src/main.rs` and the pattern from
+    // `tests/enip_e2e_real_pcaps_tests.rs`.
+    // -------------------------------------------------------------------------
+
+    /// Run the full IEC-104 analysis pipeline on a pcap/pcapng file.
+    ///
+    /// The file must exist under `tests/fixtures/local-samples/`. This function panics
+    /// if `PcapSource::from_file` fails — the fixture was present but unreadable, which
+    /// is a test infrastructure failure, not a skip condition.
+    ///
+    /// Returns the `Iec104Analyzer` after `reassembler.finalize(&mut dispatcher)` so that
+    /// all per-flow state has been flushed and `on_flow_close` has been called for every
+    /// completed stream, making `summarize()` return the full aggregate.
+    fn run_iec104_pipeline(filename: &str) -> Iec104Analyzer {
+        let path = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join(LOCAL_SAMPLES)
+            .join(filename);
+
+        let source = PcapSource::from_file(&path)
+            .unwrap_or_else(|e| panic!("[iec104-e2e] failed to open {filename}: {e:#}"));
+
+        let config = ReassemblyConfig::default();
+        let mut reassembler = TcpReassembler::new(config);
+        // IEC-104 is the 6th (last) slot in StreamDispatcher::new.
+        // All other analyzers are None — this test exercises ONLY the IEC-104 path.
+        let mut dispatcher =
+            StreamDispatcher::new(None, None, None, None, None, Some(Iec104Analyzer::new()));
+
+        for raw in &source.packets {
+            if let Ok(DecodedFrame::Ip(parsed)) = decode_packet(&raw.data, source.datalink) {
+                reassembler.process_packet(&parsed, raw.timestamp_secs, &mut dispatcher);
+            }
+        }
+
+        // Flush any open flows (calls on_flow_close for each, folding per-flow frame counts
+        // into the aggregate fields read by summarize()).
+        reassembler.finalize(&mut dispatcher);
+
+        // Take ownership of the IEC-104 analyzer out of the dispatcher.
+        dispatcher
+            .take_iec104_analyzer()
+            .expect("[iec104-e2e] IEC-104 analyzer must be present after run_iec104_pipeline")
+    }
+
+    // =========================================================================
+    // Test 1 — iec104.pcap (Wireshark Foundation; public sample; not redistributed)
+    //
+    // Pcap: canonical Wireshark IEC-104 reference. U-frames (STARTDT/STOPDT/TESTFR) +
+    //       I-frame ASDUs + C_IC general interrogation (TypeID 100, COT 6/7/20/10).
+    //       105 reader packets; 1 TCP flow on port 2404.
+    // Expected: 66 findings = T0836 ×24 + T1692.001 ×42. All Impact/Possible/Medium.
+    //           flows_analyzed=1, total_findings=66, dropped_findings=0.
+    //
+    // Traces: BC-2.19 (STORY-167..174 IEC-104 analyzer pipeline).
+    // License: Wireshark Foundation public sample; no per-file license; not redistributed.
+    // =========================================================================
+
+    /// test_e2e_BC_2_19_iec104_pcap_T0836_T1692_001_interrogation
+    ///
+    /// iec104.pcap contains a real IEC-104 session: link-management U-frames
+    /// (STARTDT/STOPDT/TESTFR) followed by I-frame ASDUs carrying control commands
+    /// and a general-interrogation (C_IC TypeID 100) request/response lifecycle.
+    ///
+    /// The IEC-104 analyzer fires:
+    /// - T1692.001 ×42: control-command TypeID/COT-flagged I-frames
+    /// - T0836 ×24: parameter-modification / data-historian events
+    ///
+    /// All 66 findings are Impact/Possible/Medium (consistent with passive-monitor
+    /// detection of command traffic without out-of-band confirmation).
+    ///
+    /// Postconditions asserted (ground-truth from analyzer-level validation run):
+    /// - `iec104.all_findings.len()` == 66.
+    /// - T0836 count == 24.
+    /// - T1692.001 count == 42.
+    /// - Every finding is Impact / Possible / Medium.
+    /// - `iec104_summary.flows_analyzed` == 1.
+    /// - `iec104_summary.total_findings` == 66.
+    /// - `iec104_summary.dropped_findings` == 0.
+    ///
+    /// Traces: BC-2.19 (IEC-104 analyzer pipeline).
+    #[test]
+    fn test_e2e_BC_2_19_iec104_pcap_T0836_T1692_001_interrogation() {
+        if !fixture_present("iec104.pcap") {
+            return;
+        }
+
+        let iec104 = run_iec104_pipeline("iec104.pcap");
+
+        // ── Total findings count ──────────────────────────────────────────────
+        assert_eq!(
+            iec104.all_findings.len(),
+            66,
+            "iec104.pcap: expected exactly 66 findings (T0836 ×24 + T1692.001 ×42); \
+             got {} findings: {:?}",
+            iec104.all_findings.len(),
+            iec104
+                .all_findings
+                .iter()
+                .map(|f| f.mitre_techniques.as_slice())
+                .collect::<Vec<_>>()
+        );
+
+        // ── Per-technique counts ──────────────────────────────────────────────
+        let t0836_count = iec104
+            .all_findings
+            .iter()
+            .filter(|f| f.mitre_techniques.iter().any(|t| t == "T0836"))
+            .count();
+        let t1692_001_count = iec104
+            .all_findings
+            .iter()
+            .filter(|f| f.mitre_techniques.iter().any(|t| t == "T1692.001"))
+            .count();
+
+        assert_eq!(
+            t0836_count, 24,
+            "iec104.pcap: expected 24 T0836 findings; got {t0836_count}"
+        );
+        assert_eq!(
+            t1692_001_count, 42,
+            "iec104.pcap: expected 42 T1692.001 findings; got {t1692_001_count}"
+        );
+
+        // ── Category / verdict / confidence — all Impact/Possible/Medium ──────
+        for (i, f) in iec104.all_findings.iter().enumerate() {
+            assert_eq!(
+                format!("{:?}", f.category),
+                "Impact",
+                "iec104.pcap finding[{i}]: expected category=Impact; got {:?}",
+                f.category
+            );
+            assert_eq!(
+                format!("{}", f.verdict),
+                "POSSIBLE",
+                "iec104.pcap finding[{i}]: expected verdict=Possible; got {:?}",
+                f.verdict
+            );
+            assert_eq!(
+                format!("{}", f.confidence),
+                "MEDIUM",
+                "iec104.pcap finding[{i}]: expected confidence=Medium; got {:?}",
+                f.confidence
+            );
+        }
+
+        // ── Analyzer summary ──────────────────────────────────────────────────
+        let summary = iec104.summarize();
+        assert_eq!(
+            summary.analyzer_name, "IEC-104",
+            "iec104.pcap: analyzer_name must be 'IEC-104'"
+        );
+
+        let detail = &summary.detail;
+
+        assert_eq!(
+            detail["flows_analyzed"],
+            serde_json::json!(1u64),
+            "iec104.pcap: flows_analyzed must be 1; got {:?}",
+            detail["flows_analyzed"]
+        );
+        assert_eq!(
+            detail["total_findings"],
+            serde_json::json!(66u64),
+            "iec104.pcap: total_findings must be 66; got {:?}",
+            detail["total_findings"]
+        );
+        assert_eq!(
+            detail["dropped_findings"],
+            serde_json::json!(0u64),
+            "iec104.pcap: dropped_findings must be 0 (no cap overflow); got {:?}",
+            detail["dropped_findings"]
+        );
+    }
+
+    // =========================================================================
+    // Test 2 — iec104-sq.pcapng (Wireshark Foundation; public sample; not redistributed)
+    //
+    // Pcap: native pcapng (SHB magic 0x0A0D0D0A); SQ-bit set in ASDU variable-structure
+    //       qualifier (sequence-of-information-objects encoding). 1 reader packet; 1 flow.
+    // Expected: 0 findings (benign link-management traffic only — no attack techniques).
+    //           flows_analyzed=1, total_findings=0, dropped_findings=0.
+    //
+    // This fixture exercises:
+    //   (a) the pcapng reader with a native IEC-104 pcapng file, and
+    //   (b) the SQ-bit ASDU parsing path in the IEC-104 analyzer.
+    //
+    // Zero findings confirms no false positives on STARTDT/TESTFR control frames.
+    //
+    // Traces: BC-2.19 (IEC-104 analyzer pipeline).
+    // License: Wireshark Foundation public sample; no per-file license; not redistributed.
+    // =========================================================================
+
+    /// test_e2e_BC_2_19_iec104_sq_pcapng_zero_findings_benign_uframes
+    ///
+    /// iec104-sq.pcapng is a 584-byte native pcapng file containing a single IEC-104
+    /// session packet with the SQ bit set. The content is benign link-management traffic
+    /// (STARTDT/TESTFR U-frames or their acknowledgements) — no control commands, no
+    /// parameter modifications, no data injection.
+    ///
+    /// Postconditions asserted:
+    /// - `iec104.all_findings` is empty (0 findings — no false positives).
+    /// - `iec104_summary.flows_analyzed` == 1.
+    /// - `iec104_summary.total_findings` == 0.
+    /// - `iec104_summary.dropped_findings` == 0.
+    ///
+    /// Traces: BC-2.19 (IEC-104 analyzer pipeline).
+    #[test]
+    fn test_e2e_BC_2_19_iec104_sq_pcapng_zero_findings_benign_uframes() {
+        if !fixture_present("iec104-sq.pcapng") {
+            return;
+        }
+
+        let iec104 = run_iec104_pipeline("iec104-sq.pcapng");
+
+        // ── Zero findings (no false positives on benign SQ-bit traffic) ───────
+        assert!(
+            iec104.all_findings.is_empty(),
+            "iec104-sq.pcapng: expected 0 findings (benign STARTDT/TESTFR/SQ-bit only); \
+             got {} findings: {:?}",
+            iec104.all_findings.len(),
+            iec104
+                .all_findings
+                .iter()
+                .map(|f| f.mitre_techniques.as_slice())
+                .collect::<Vec<_>>()
+        );
+
+        // ── Analyzer summary ──────────────────────────────────────────────────
+        let summary = iec104.summarize();
+        let detail = &summary.detail;
+
+        assert_eq!(
+            detail["flows_analyzed"],
+            serde_json::json!(1u64),
+            "iec104-sq.pcapng: flows_analyzed must be 1; got {:?}",
+            detail["flows_analyzed"]
+        );
+        assert_eq!(
+            detail["total_findings"],
+            serde_json::json!(0u64),
+            "iec104-sq.pcapng: total_findings must be 0; got {:?}",
+            detail["total_findings"]
+        );
+        assert_eq!(
+            detail["dropped_findings"],
+            serde_json::json!(0u64),
+            "iec104-sq.pcapng: dropped_findings must be 0; got {:?}",
+            detail["dropped_findings"]
+        );
+    }
+
+    // =========================================================================
+    // Test 3 — iec104-iti-diverse.pcap (ITI/ICS-Security-Tools CC-BY-4.0)
+    //
+    // Pcap: IEC-104 traffic with a diverse mix of ASDU Type IDs from the ITI ICS corpus.
+    //       173 reader packets; 1 TCP flow on port 2404.
+    // Expected: 31 findings = T0836 ×10 + T1692.001 ×21. All Impact/Possible/Medium.
+    //           flows_analyzed=1, total_findings=31, dropped_findings=0.
+    //
+    // Traces: BC-2.19 (IEC-104 analyzer pipeline).
+    // License: ITI/ICS-Security-Tools CC-BY-4.0. Attribution: ICS Security Tools,
+    //          Illinois Institute of Technology (ITI).
+    // =========================================================================
+
+    /// test_e2e_BC_2_19_iec104_iti_diverse_T0836_T1692_001_mixed_asdu
+    ///
+    /// iec104-iti-diverse.pcap is from the same ITI ICS Security Tools corpus as the ENIP
+    /// fixtures. It contains a diverse ASDU Type ID mix representing realistic IEC-104
+    /// traffic from a SCADA deployment.
+    ///
+    /// Postconditions asserted (ground-truth from analyzer-level validation run):
+    /// - `iec104.all_findings.len()` == 31.
+    /// - T0836 count == 10.
+    /// - T1692.001 count == 21.
+    /// - Every finding is Impact / Possible / Medium.
+    /// - `iec104_summary.flows_analyzed` == 1.
+    /// - `iec104_summary.total_findings` == 31.
+    /// - `iec104_summary.dropped_findings` == 0.
+    ///
+    /// Traces: BC-2.19 (IEC-104 analyzer pipeline).
+    #[test]
+    fn test_e2e_BC_2_19_iec104_iti_diverse_T0836_T1692_001_mixed_asdu() {
+        if !fixture_present("iec104-iti-diverse.pcap") {
+            return;
+        }
+
+        let iec104 = run_iec104_pipeline("iec104-iti-diverse.pcap");
+
+        // ── Total findings count ──────────────────────────────────────────────
+        assert_eq!(
+            iec104.all_findings.len(),
+            31,
+            "iec104-iti-diverse.pcap: expected exactly 31 findings \
+             (T0836 ×10 + T1692.001 ×21); got {} findings: {:?}",
+            iec104.all_findings.len(),
+            iec104
+                .all_findings
+                .iter()
+                .map(|f| f.mitre_techniques.as_slice())
+                .collect::<Vec<_>>()
+        );
+
+        // ── Per-technique counts ──────────────────────────────────────────────
+        let t0836_count = iec104
+            .all_findings
+            .iter()
+            .filter(|f| f.mitre_techniques.iter().any(|t| t == "T0836"))
+            .count();
+        let t1692_001_count = iec104
+            .all_findings
+            .iter()
+            .filter(|f| f.mitre_techniques.iter().any(|t| t == "T1692.001"))
+            .count();
+
+        assert_eq!(
+            t0836_count, 10,
+            "iec104-iti-diverse.pcap: expected 10 T0836 findings; got {t0836_count}"
+        );
+        assert_eq!(
+            t1692_001_count, 21,
+            "iec104-iti-diverse.pcap: expected 21 T1692.001 findings; got {t1692_001_count}"
+        );
+
+        // ── Category / verdict / confidence — all Impact/Possible/Medium ──────
+        for (i, f) in iec104.all_findings.iter().enumerate() {
+            assert_eq!(
+                format!("{:?}", f.category),
+                "Impact",
+                "iec104-iti-diverse.pcap finding[{i}]: expected category=Impact; got {:?}",
+                f.category
+            );
+            assert_eq!(
+                format!("{}", f.verdict),
+                "POSSIBLE",
+                "iec104-iti-diverse.pcap finding[{i}]: expected verdict=Possible; got {:?}",
+                f.verdict
+            );
+            assert_eq!(
+                format!("{}", f.confidence),
+                "MEDIUM",
+                "iec104-iti-diverse.pcap finding[{i}]: expected confidence=Medium; got {:?}",
+                f.confidence
+            );
+        }
+
+        // ── Analyzer summary ──────────────────────────────────────────────────
+        let summary = iec104.summarize();
+        let detail = &summary.detail;
+
+        assert_eq!(
+            detail["flows_analyzed"],
+            serde_json::json!(1u64),
+            "iec104-iti-diverse.pcap: flows_analyzed must be 1; got {:?}",
+            detail["flows_analyzed"]
+        );
+        assert_eq!(
+            detail["total_findings"],
+            serde_json::json!(31u64),
+            "iec104-iti-diverse.pcap: total_findings must be 31; got {:?}",
+            detail["total_findings"]
+        );
+        assert_eq!(
+            detail["dropped_findings"],
+            serde_json::json!(0u64),
+            "iec104-iti-diverse.pcap: dropped_findings must be 0; got {:?}",
+            detail["dropped_findings"]
+        );
+    }
+
+    // =========================================================================
+    // Test 4 — iec104-iti-dissect.pcap (ITI/ICS-Security-Tools CC-BY-4.0)
+    //
+    // Pcap: Wireshark-dissector test capture — constructed to exercise broad Type ID /
+    //       COT coverage incl. control commands (C_SC/C_DC/C_SE). 147 reader packets;
+    //       6 TCP flows on port 2404.
+    // Expected: 11 findings = T0814 ×2 + T1692.001 ×9.
+    //           T0814: Anomaly/Possible/Medium; T1692.001: Impact/Possible/Medium.
+    //           flows_analyzed=6, total_findings=11, dropped_findings=0.
+    //
+    // The 6 flows reflect multiple independent IEC-104 sessions used to cover different
+    // Type ID families in a single dissector-test capture.
+    //
+    // Traces: BC-2.19 (IEC-104 analyzer pipeline).
+    // License: ITI/ICS-Security-Tools CC-BY-4.0. Attribution: ICS Security Tools,
+    //          Illinois Institute of Technology (ITI).
+    // =========================================================================
+
+    /// test_e2e_BC_2_19_iec104_iti_dissect_T0814_T1692_001_control_coverage
+    ///
+    /// iec104-iti-dissect.pcap is a Wireshark-dissector test capture deliberately
+    /// constructed to exercise a broad sweep of IEC-104 Type IDs and Causes of
+    /// Transmission, including control commands (C_SC/C_DC/C_SE). It spans 6 TCP
+    /// flows, reflecting multi-session coverage of distinct Type ID families.
+    ///
+    /// The IEC-104 analyzer fires:
+    /// - T1692.001 ×9: control-command TypeID detections (Impact/Possible/Medium)
+    /// - T0814 ×2: unexpected/spoofed message detections (Anomaly/Possible/Medium)
+    ///
+    /// Postconditions asserted (ground-truth from analyzer-level validation run):
+    /// - `iec104.all_findings.len()` == 11.
+    /// - T0814 count == 2; every T0814 finding is Anomaly / Possible / Medium.
+    /// - T1692.001 count == 9; every T1692.001 finding is Impact / Possible / Medium.
+    /// - `iec104_summary.flows_analyzed` == 6.
+    /// - `iec104_summary.total_findings` == 11.
+    /// - `iec104_summary.dropped_findings` == 0.
+    ///
+    /// Traces: BC-2.19 (IEC-104 analyzer pipeline).
+    #[test]
+    fn test_e2e_BC_2_19_iec104_iti_dissect_T0814_T1692_001_control_coverage() {
+        if !fixture_present("iec104-iti-dissect.pcap") {
+            return;
+        }
+
+        let iec104 = run_iec104_pipeline("iec104-iti-dissect.pcap");
+
+        // ── Total findings count ──────────────────────────────────────────────
+        assert_eq!(
+            iec104.all_findings.len(),
+            11,
+            "iec104-iti-dissect.pcap: expected exactly 11 findings \
+             (T0814 ×2 + T1692.001 ×9); got {} findings: {:?}",
+            iec104.all_findings.len(),
+            iec104
+                .all_findings
+                .iter()
+                .map(|f| f.mitre_techniques.as_slice())
+                .collect::<Vec<_>>()
+        );
+
+        // ── Per-technique counts ──────────────────────────────────────────────
+        let t0814_count = iec104
+            .all_findings
+            .iter()
+            .filter(|f| f.mitre_techniques.iter().any(|t| t == "T0814"))
+            .count();
+        let t1692_001_count = iec104
+            .all_findings
+            .iter()
+            .filter(|f| f.mitre_techniques.iter().any(|t| t == "T1692.001"))
+            .count();
+
+        assert_eq!(
+            t0814_count, 2,
+            "iec104-iti-dissect.pcap: expected 2 T0814 findings; got {t0814_count}"
+        );
+        assert_eq!(
+            t1692_001_count, 9,
+            "iec104-iti-dissect.pcap: expected 9 T1692.001 findings; got {t1692_001_count}"
+        );
+
+        // ── T0814 findings: Anomaly / Possible / Medium ───────────────────────
+        for (i, f) in iec104
+            .all_findings
+            .iter()
+            .filter(|f| f.mitre_techniques.iter().any(|t| t == "T0814"))
+            .enumerate()
+        {
+            assert_eq!(
+                format!("{:?}", f.category),
+                "Anomaly",
+                "iec104-iti-dissect.pcap T0814 finding[{i}]: expected category=Anomaly; \
+                 got {:?}",
+                f.category
+            );
+            assert_eq!(
+                format!("{}", f.verdict),
+                "POSSIBLE",
+                "iec104-iti-dissect.pcap T0814 finding[{i}]: expected verdict=Possible; \
+                 got {:?}",
+                f.verdict
+            );
+            assert_eq!(
+                format!("{}", f.confidence),
+                "MEDIUM",
+                "iec104-iti-dissect.pcap T0814 finding[{i}]: expected confidence=Medium; \
+                 got {:?}",
+                f.confidence
+            );
+        }
+
+        // ── T1692.001 findings: Impact / Possible / Medium ────────────────────
+        for (i, f) in iec104
+            .all_findings
+            .iter()
+            .filter(|f| f.mitre_techniques.iter().any(|t| t == "T1692.001"))
+            .enumerate()
+        {
+            assert_eq!(
+                format!("{:?}", f.category),
+                "Impact",
+                "iec104-iti-dissect.pcap T1692.001 finding[{i}]: expected category=Impact; \
+                 got {:?}",
+                f.category
+            );
+            assert_eq!(
+                format!("{}", f.verdict),
+                "POSSIBLE",
+                "iec104-iti-dissect.pcap T1692.001 finding[{i}]: expected verdict=Possible; \
+                 got {:?}",
+                f.verdict
+            );
+            assert_eq!(
+                format!("{}", f.confidence),
+                "MEDIUM",
+                "iec104-iti-dissect.pcap T1692.001 finding[{i}]: expected confidence=Medium; \
+                 got {:?}",
+                f.confidence
+            );
+        }
+
+        // ── Analyzer summary ──────────────────────────────────────────────────
+        let summary = iec104.summarize();
+        let detail = &summary.detail;
+
+        assert_eq!(
+            detail["flows_analyzed"],
+            serde_json::json!(6u64),
+            "iec104-iti-dissect.pcap: flows_analyzed must be 6 (6 TCP sessions); \
+             got {:?}",
+            detail["flows_analyzed"]
+        );
+        assert_eq!(
+            detail["total_findings"],
+            serde_json::json!(11u64),
+            "iec104-iti-dissect.pcap: total_findings must be 11; got {:?}",
+            detail["total_findings"]
+        );
+        assert_eq!(
+            detail["dropped_findings"],
+            serde_json::json!(0u64),
+            "iec104-iti-dissect.pcap: dropped_findings must be 0; got {:?}",
+            detail["dropped_findings"]
+        );
+    }
+} // mod iec104_e2e_real_pcaps


### PR DESCRIPTION
## Summary

- Closes the e2e coverage gap for the IEC-104 feature (STORY-167..174) — the corpus previously had zero IEC-104 captures.
- Adds 4 real captures to the LOCAL-ONLY corpus mechanism (gitignored; fetched via `bin/fetch-e2e-pcaps`, not committed): `iec104.pcap` + `IEC104_SQ.pcapng` (Wireshark, local-use credit), `090813_diverse.pcap` + `TestDissectIec104.pcap` (ITI, CC-BY-4.0). All sha256-pinned in `bin/fetch-e2e-pcaps`.
- New file `tests/iec104_e2e_real_pcaps_tests.rs`: analyzer-level detection test, full in-process pipeline, pins per-technique findings on real traffic — `iec104.pcap` T0836×24+T1692.001×42; `iti-diverse` T0836×10+T1692.001×21; `iti-dissect` T0814×2+T1692.001×9; `sq.pcapng` 0 (benign). Self-skips when fixtures absent (CI-safe, no `#[ignore]`).

## Changes

- `bin/fetch-e2e-pcaps`: 4 IEC-104 fixture entries with sha256 pins and license annotations.
- `tests/e2e_corpus_smoke_tests.rs`: 4 reader-level OkCount pins (105/1/173/147).
- `tests/iec104_e2e_real_pcaps_tests.rs` (NEW): analyzer-level detection test, self-skips when fixtures absent.
- `tests/fixtures/E2E-PCAPS.md`: documents the 4 captures with license and source.
- `CHANGELOG.md`: `[Unreleased]` entry (bin/ change triggers changelog-gate requirement).

## Test Evidence

Verified locally:
- Full corpus smoke test: 39 pins, 0 mismatch
- New analyzer test: 4/4 pass (real traffic pins)
- `iec104_analyzer_tests`: 221 pass / 0 fail
- `cargo fmt` + `cargo clippy --all-targets -- -D warnings`: clean

## CI Behavior

`tests/fixtures/local-samples` is gitignored so CI (no fixtures present) self-skips both e2e tests → CI stays green. This matches the established corpus pattern (`enip_e2e_real_pcaps_tests.rs`).

## Diff Scope (5 tracked files — no captures, no .gitignore changes)

1. `bin/fetch-e2e-pcaps` — 4 IEC-104 fixture entries added
2. `tests/e2e_corpus_smoke_tests.rs` — 4 new OkCount pins
3. `tests/iec104_e2e_real_pcaps_tests.rs` — new file
4. `tests/fixtures/E2E-PCAPS.md` — new file documenting captures
5. `CHANGELOG.md` — [Unreleased] entry

## Security Review

N/A — test infrastructure, tooling, and docs only. No product code changes. No trust-boundary changes.