### PR TITLE
docs: correct TypeID 45 C_SC_NA_1 direction label in FIX-P4-001 demo evidence

### DIFF
--- a/docs/demo-evidence/FIX-P4-001/AC-P4-001-test-results.txt
+++ b/docs/demo-evidence/FIX-P4-001/AC-P4-001-test-results.txt
@@ -58,7 +58,7 @@ emission sites:
    - Trace: IEC104-FINDING-DIRECTION-001; FIX-P4-001 (emit site :424)
 
 6. test_fix_p4_001_detect_threats_type45_direction_c2s
-   - Verifies: Type 45 (monitoring direction) TypeID emits direction=Some(ClientToServer)
+   - Verifies: Type 45 (control direction, C_SC_NA_1) TypeID emits direction=Some(ClientToServer)
    - Trace: IEC104-FINDING-DIRECTION-001; FIX-P4-001
 
 7. test_fix_p4_001_detect_threats_type48_direction_s2c

--- a/docs/demo-evidence/FIX-P4-001/evidence-report.md
+++ b/docs/demo-evidence/FIX-P4-001/evidence-report.md
@@ -43,7 +43,7 @@ All 11 tests verify that the `direction` field is populated correctly across the
 | `test_fix_p4_001_process_u_frame_stopdt_direction_c2s` | `process_u_frame()` (STOPDT-act) | STOPDT with ClientToServer |
 | `test_fix_p4_001_process_u_frame_stopdt_direction_s2c` | `process_u_frame()` (STOPDT-act) | STOPDT with ServerToClient |
 | `test_fix_p4_001_process_u_frame_noncanonical_direction_c2s` | `process_u_frame()` (non-canonical) | Non-canonical U-frame with ClientToServer |
-| `test_fix_p4_001_detect_threats_type45_direction_c2s` | `detect_threats()` (TypeID 45) | Monitoring direction with ClientToServer |
+| `test_fix_p4_001_detect_threats_type45_direction_c2s` | `detect_threats()` (TypeID 45) | Control direction (C_SC_NA_1) with ClientToServer |
 | `test_fix_p4_001_detect_threats_type48_direction_s2c` | `detect_threats()` (TypeID 48) | ASDU type with ServerToClient |
 | `test_fix_p4_001_detect_threats_type105_direction_c2s` | `detect_threats()` (TypeID 105) | ASDU type with ClientToServer |
 | `test_fix_p4_001_detect_threats_type0_direction_c2s` | `detect_threats()` (TypeID 0 invalid) | Invalid ASDU with ClientToServer |


### PR DESCRIPTION
## Summary

**Defect:** Two FIX-P4-001 demo-evidence files (`evidence-report.md:46` and `AC-P4-001-test-results.txt:61`) mislabeled IEC-104 TypeID 45 (C_SC_NA_1) as \"monitoring direction\". TypeID 45 is a single-command ASDU used exclusively in the **control direction** (client→server), not the monitoring direction.

**Code ground-truth anchor:** `src/analyzer/iec104.rs:744-748` — the analyzer matches TypeID 45 in the control-direction branch; it never appears in monitoring-direction handling.

**Fix:** Both files corrected from \"monitoring direction\" to \"control direction (C_SC_NA_1)\".

**Sibling sweep:** STORY-170 references to \"monitoring direction\" in the same vicinity cover TypeIDs 1–44 (process information in monitoring direction) — those are correct and untouched.

**Provenance:** Deferred carry-forward `IEC104-DEMO-TYPEID45-MISLABEL` from D-468 / F5 R5 LOW finding.

## Scope

- **Docs-only:** modifies only `docs/demo-evidence/FIX-P4-001/` — no `src/`, `Cargo.toml`, or `bin/` files touched.
- **No CHANGELOG entry required:** AC-158-001 trigger set excludes `docs/`.
- **No behavior change:** prose correction only; no code, no tests, no runtime surface.
- **No demo recording needed:** no behavior change to record.
- **No security review needed:** prose-only correction in documentation; no executable surface, no new dependencies, no input-handling changes.
- **Citation preflight:** PASS via `bin/validate-citations` (run before commit).

## Test Evidence

This PR has no test-evidence table — it is a prose-only correction with no associated test cases. CI checks passing is the sole evidence gate (PG-W74-PRDESC-ROW-VERIFY: no fabricated table).