### PR TITLE
docs(maint): add IEC-104 documentation and fix doc drift (maint-2026-07-21 DOC-001..005)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,13 @@ Version numbers follow [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- **`src/cli.rs` ENIP write-burst doc-comment unit format (DOC-005, maint-2026-07-21).**
+
+  The `--enip-write-burst-threshold` arg doc-comment at `src/cli.rs:259` used
+  "within any 1-second window" (hyphenated, spelled out). Changed to "within any 1s window"
+  to match the adjacent Modbus write-burst arg at `src/cli.rs:185` (fixed in maint-2026-07-11
+  as UNIT-FMT-5-20S-001). No behavior change; doc-comment only.
+
 - **`bin/check-green-doc-tense` pattern leading-`\b` tightening + test coverage +
   subprocess timeout (wave-84 gate code-review CR-002/CR-005/CR-006/SEC-003).**
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -253,7 +253,7 @@ Deferred or open findings — STATE.md Drift Items, spec contradictions, and rev
 | Path | Purpose |
 |------|---------|
 | `README.md` | Project overview |
-| `docs/adr/` | Architecture Decision Records (0001 stream dispatch, 0002 modular analyzers, 0003 reporting pipeline, 0004 process-wide warning atomics, 0005 binary ICS protocol integration, 0006 multi-technique finding attribution, 0007 DNP3 stream dispatch and parser design, 0009 pcapng reader design, 0010 EtherNet/IP CIP stream dispatch, 0011 TLS handshake reassembly, 0012 protocols catalog and coverage-gaps system) |
+| `docs/adr/` | Architecture Decision Records (0001 stream dispatch, 0002 modular analyzers, 0003 reporting pipeline, 0004 process-wide warning atomics, 0005 binary ICS protocol integration, 0006 multi-technique finding attribution, 0007 DNP3 stream dispatch and parser design, 0009 pcapng reader design, 0010 EtherNet/IP CIP stream dispatch, 0011 TLS handshake reassembly, 0012 protocols catalog and coverage-gaps system, 0013 IEC-104 stream dispatch and parser design) |
 | `docs/superpowers/plans/` | Implementation plans (from the superpowers skill) |
 | `docs/superpowers/specs/` | Specifications (from the superpowers skill) |
 | `.github/workflows/ci.yml` | CI pipeline (test, clippy, fmt, semantic PR) |

--- a/README.md
+++ b/README.md
@@ -7,13 +7,14 @@ Inspired by [pcapper](https://github.com/SackOfHacks/pcapper) — reimagined for
 ## Features
 
 - **One-pass triage** — hosts, services, protocols, and threat signals from pcap files
-- **Protocol analysis** — DNS, HTTP, TLS, Modbus, DNP3, ARP, and EtherNet/IP (CIP) traffic analysis with extensible analyzer framework
+- **Protocol analysis** — DNS, HTTP, TLS, Modbus, DNP3, ARP, EtherNet/IP (CIP), and IEC 60870-5-104 traffic analysis with extensible analyzer framework
 - **HTTP forensics** — stream-level HTTP/1.x parsing with detection for path traversal, web shells, unusual methods, and anomalies; `dropped_map_entries` JSON counter surfaces silently-dropped entries when per-analyzer counter maps reach their cap
 - **TLS forensics** — ClientHello/ServerHello parsing, SNI extraction, JA3/JA3S fingerprinting, weak cipher and deprecated SSL 2.0/3.0 detection; multi-record handshake-message reassembly (SNI/JA3/JA3S fragmentation-evasion closed; per-direction carry buffer with `buffer_saturation_drops` overflow telemetry); `dropped_map_entries` JSON counter surfaces silently-dropped entries when per-analyzer counter maps reach their cap
 - **Modbus TCP forensics** — ICS/OT threat detection on port 502; parses MBAP header and function codes; detects 7 MITRE ATT&CK for ICS techniques (T1692.001, T0836, T0835, T0831, T0806, T0814, T0888); configurable write-burst and sustained-rate thresholds; `dropped_transactions` JSON counter surfaces silently-dropped transactions when the per-flow transaction map reaches its cap; enabled via `--modbus`
 - **DNP3 TCP forensics** — ICS/OT threat detection on port 20000; parses IEEE Std 1815-2012 data-link frames; detects MITRE ATT&CK for ICS techniques T1692.001, T1691.001, T0827, T0814, and T0836; anomaly detection for broadcast control, unsolicited responses, and malformed frames; `dropped_findings`, `master_addrs_dropped`, and `pending_requests_evicted` JSON counters surface cap-related telemetry; enabled via `--dnp3`
 - **ARP security forensics** — link-layer and OT network threat detection; detects ARP spoofing / cache poisoning, gratuitous ARP anomalies, ARP storms, malformed ARP frames, and L2/L3 sender-MAC mismatch; MITRE attribution to T0830 and T1557.002; enabled via `--arp`
 - **EtherNet/IP CIP forensics** — ICS/OT threat detection on port 44818; parses ODVA EtherNet/IP encapsulation header (24-byte, little-endian) and Common Packet Format item walk with CIP service extraction; detects 6 MITRE ATT&CK for ICS techniques (T0836 write-burst, T0846 remote system discovery, T0814 malformed-frame/crash-probe, T0888 error-burst/identity-read, T0858 controller stop, T0816 device reset); configurable write-burst and error-burst thresholds; emits `enip_summary` JSON key; references ADR-010; enabled via `--enip`
+- **IEC 60870-5-104 forensics** — ICS/OT threat detection on port 2404; parses APCI header and ASDU structure; detects MITRE ATT&CK for ICS techniques T1692.001, T0836, T0827, T0881, T0814; U-frame session state machine with STARTDT/STOPDT/TESTFR tracking; N(S) sequence desync detection; `dropped_findings` and `flows_analyzed` JSON counters; enabled via `--iec104`
 - **TCP stream reassembly** — forensic-grade reassembly engine with first-wins overlap policy, configurable depth/memory/window limits
 - **Multi-link-type support** — Ethernet, Raw IP, IPv4, IPv6, and Linux Cooked (SLL) in both
   classic pcap and pcapng captures
@@ -118,6 +119,7 @@ Options:
 --enip                                 Analyze EtherNet/IP TCP traffic (port 44818, default-off; included in --all)
 --enip-write-burst-threshold N         CIP write-burst threshold in SetAttribute requests/1s window (default: 50)
 --enip-error-burst-threshold N         CIP error-burst threshold in error responses/10s window (default: 5)
+--iec104                               Analyze IEC 60870-5-104 TCP traffic (port 2404, default-off; included in --all)
 --no-collapse                          Disable collapsing of repeated findings in both flat and grouped (--mitre) terminal output. By default, collapse is enabled in both modes. When --mitre is used, collapse groups identical findings within each MITRE tactic bucket with a (xN) count suffix. Pass --no-collapse to restore one-line-per-finding output in both modes. Has no effect on --json, --csv, or --output-format json|csv output.
 --mitre                                Group findings by MITRE ATT&CK tactic and show technique names; collapses identical findings within each tactic bucket with a (xN) count suffix by default (pass --no-collapse to disable)
 -a, --all                              Run all analyzers
@@ -172,7 +174,7 @@ PCAP file → Reader → Decoder → Analyzers → Reporter
                          ↓         ↓
                          │    ArpAnalyzer (packet-level)
                          ↓
-                   Reassembly Engine → StreamDispatcher → StreamAnalyzers (HTTP, TLS, Modbus, DNP3, EtherNet/IP)
+                   Reassembly Engine → StreamDispatcher → StreamAnalyzers (HTTP, TLS, Modbus, DNP3, EtherNet/IP, IEC-104)
                          ↓
                       Summary
 ```
@@ -186,6 +188,7 @@ PCAP file → Reader → Decoder → Analyzers → Reporter
 | Modbus Analyzer | (built-in) | Modbus TCP ICS/OT threat detection (port 502) |
 | DNP3 Analyzer | (built-in) | DNP3 TCP ICS/OT threat detection (port 20000) |
 | ENIP/CIP Analyzer | (built-in) | EtherNet/IP TCP ICS/OT threat detection (port 44818) |
+| IEC-104 Analyzer | (built-in) | IEC 60870-5-104 TCP ICS/OT threat detection (port 2404) |
 | ARP Analyzer | (built-in) | Link-layer ARP spoofing and anomaly detection |
 | Reassembly | (built-in) | TCP stream reassembly engine |
 | CLI | `clap` | Argument parsing |
@@ -201,6 +204,7 @@ PCAP file → Reader → Decoder → Analyzers → Reporter
 | Modbus TCP | 502 | `--modbus` | off | T1692.001, T0836, T0835, T0831, T0806, T0814, T0888 |
 | DNP3 TCP | 20000 | `--dnp3` | off | T1692.001, T1691.001, T0827, T0814, T0836 |
 | EtherNet/IP TCP | 44818 | `--enip` | off | T0836, T0846, T0814, T0888, T0858, T0816 |
+| IEC 60870-5-104 TCP | 2404 | `--iec104` | off | T1692.001, T0836, T0827, T0881, T0814 |
 | ARP | link-layer | `--arp` | off | T0830, T1557.002 |
 
 ### DNP3 TCP Analyzer
@@ -302,6 +306,39 @@ CLI flags:
   window (default: 50); strict `>` semantics — fires on the (N+1)th write
 - `--enip-error-burst-threshold N` — CIP error-burst threshold in error responses per 10s window
   (default: 5); strict `>` semantics — fires on the (N+1)th error
+
+### IEC 60870-5-104 Analyzer
+
+The IEC-104 analyzer (`--iec104`) processes TCP streams on port 2404. It parses the 6-byte
+APCI header and ASDU structure; classifies I-format, S-format, and U-format frames; and
+maintains a per-flow U-frame session state machine tracking STARTDT/STOPDT/TESTFR command
+sequences. The analyzer is dispatched as Rule 8 in the stream dispatcher — after
+content-signature rules (TLS, HTTP) and port-based rules for TLS, HTTP, Modbus, DNP3, and
+EtherNet/IP — so TLS or HTTP traffic on port 2404 routes correctly before reaching this
+rule. Architecture: ADR-013.
+
+Detections emitted:
+
+| Detection | Technique | Tactic | Trigger |
+|-----------|-----------|--------|---------|
+| Switching control command (C_SC/C_DC/C_RC) | T1692.001 | Impair Process Control | TypeID 45–47 observed on passive monitor |
+| Set-point/bitstring write command (C_SE/C_BO) | T1692.001, T0836 | Impair Process Control | TypeID 48–51 observed on passive monitor |
+| Reset Process command (C_RP_NA_1) | T0827 | Impact | TypeID 105 observed; verdict Likely |
+| STOPDT-act (service stop) | T0881 | Inhibit Response Function | U-frame CF1=0x13; verdict Possible (session was started) or Likely (no prior STARTDT on this flow) |
+| Non-canonical U-frame CF1 | T0814 | Inhibit Response Function | U-frame CF1 not in canonical set {0x07,0x0B,0x13,0x23,0x43,0x83}; potential CVE-2026-1773 denial-of-service attack |
+| N(S) sequence desync | T1692.001 | Impair Process Control | I-format N(S) gap > 12 (15-bit modular); possible replay injection or adversarial manipulation |
+| Malformed LEN byte | T0814 | Inhibit Response Function | 0x68 start byte followed by LEN outside [4, 253]; one finding per direction per flow |
+| Carry-buffer overflow | T0814 | Inhibit Response Function | Directional carry buffer exceeds 255 bytes; adversarial or non-conformant byte sequence |
+| Reserved/invalid TypeID | T0814 | Inhibit Response Function | TypeID=0 (undefined) or TypeID in [128, 255] (private-use/reserved range) |
+
+CLI flags:
+- `--iec104` — enable IEC 60870-5-104 TCP analysis (also included in `-a`/`--all`; default-off)
+
+JSON output counters (present in the IEC-104 analyzer's `detail` object in JSON output, at
+`analyzers[i].detail`, when using `--json` / `--output-format json`):
+- `dropped_findings` — count of findings silently dropped after the `MAX_FINDINGS = 10 000`
+  per-analyzer cap was reached; a non-zero value means some detection events were not emitted
+- `flows_analyzed` — count of flows processed (closed flows plus still-open flows at summarize time)
 
 ## Supported Capture Formats
 

--- a/docs/adr/0001-content-first-stream-dispatch.md
+++ b/docs/adr/0001-content-first-stream-dispatch.md
@@ -36,6 +36,7 @@ pub struct StreamDispatcher {
     modbus: Option<ModbusAnalyzer>,  // Rule 5: port-502 flows (ADR-005)
     dnp3: Option<Dnp3Analyzer>,      // Rule 6: port-20000 flows (ADR-007)
     enip: Option<EnipAnalyzer>,      // Rule 7: port-44818 flows (ADR-010)
+    iec104: Option<Iec104Analyzer>,  // Rule 8: port-2404 flows (ADR-013)
     unclassified_flows: u64,
     /// Per-port unclassified-flow counter; populated when coverage_gaps_enabled=true.
     unclassified_port_counts: HashMap<(TransportProto, u16), u64>,
@@ -49,6 +50,7 @@ enum DispatchTarget {
     Modbus,
     Dnp3,
     Enip,
+    Iec104,
     None,
 }
 ```
@@ -62,7 +64,8 @@ Classification rule order (see module-level comment in `src/dispatcher.rs`):
 5. Port 502 → `Modbus`
 6. Port 20000 → `Dnp3`
 7. Port 44818 → `Enip` (ADR-010)
-8. No match → `None`
+8. Port 2404 → `Iec104` (ADR-013)
+9. No match → `None`
 
 ## Alternatives Considered
 

--- a/docs/adr/0002-modular-protocol-analyzers.md
+++ b/docs/adr/0002-modular-protocol-analyzers.md
@@ -155,6 +155,7 @@ Analyzers register themselves in a global registry (e.g., via `inventory` crate)
 | DNP3 | custom dispatch interface (see ADR-0007) | `src/analyzer/dnp3.rs` | v0.6.0 |
 | ARP | custom packet-level interface (no separate ADR; see §Deviations below) | `src/analyzer/arp.rs` | v0.7.0 |
 | EtherNet/IP | custom dispatch interface (see ADR-010 and §Deviations below) | `src/analyzer/enip.rs` | v0.11.0 |
+| IEC 60870-5-104 | custom dispatch interface (see ADR-013 and §Deviations below) | `src/analyzer/iec104.rs` | v0.13.0 |
 
 ### Deviations from generic traits (DNP3 and ARP)
 
@@ -181,7 +182,17 @@ Their actual interfaces are:
   `enip.on_data(flow_key.clone(), ...)` with a per-packet `FlowKey` clone. See ADR-010 for the
   full EtherNet/IP design rationale.
 
+- **`Iec104Analyzer`** — exposes `on_data(flow_key: FlowKey, data: &[u8], ts: u32,
+  direction: Direction)` and `on_flow_close(flow_key: FlowKey)` as plain inherent methods.
+  `src/dispatcher.rs` calls them directly (not via the `StreamHandler` trait). The deviation mirrors
+  the `EnipAnalyzer` pattern: `Iec104Analyzer` was designed from the start with the same
+  pure-core / effectful-shell separation mandated by ADR-013 Decision 8 (Kani formal-verification
+  amenability), which is incompatible with the `StreamHandler` trait's required method signatures.
+  The dispatcher arm calls `iec104.on_data(flow_key.clone(), ...)` with a per-packet `FlowKey`
+  clone. See ADR-013 for the full IEC 60870-5-104 design rationale.
+
 The "Adding a New Analyzer" steps above describe the standard generic-trait path. For DNP3, step 2
 is replaced by direct inherent-method dispatch as described in ADR-0007. For ARP, step 2 is
 replaced by direct inherent-method dispatch as described in the §Deviations section above; there
-is no separate ADR for the ARP deviation.
+is no separate ADR for the ARP deviation. For IEC-104, step 2 is replaced by direct inherent-method
+dispatch as described in ADR-013.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -256,7 +256,7 @@ pub enum Commands {
         iec104: bool,
 
         /// Per-flow write-burst threshold: fires T0836 when more than N write-class
-        /// requests are observed within any 1-second window. Default: 50.
+        /// requests are observed within any 1s window. Default: 50.
         /// 0 triggers detection on the very first write (1 > 0).
         // BC-2.17.023 Invariant 1 (OA-001 RESOLVED=50)
         #[arg(long, default_value_t = 50)]


### PR DESCRIPTION
## Summary

Fixes five documentation drift findings identified in the maint-2026-07-21 sweep (Sweep 2).
Source artifact: `.factory/maintenance/doc-drift-findings-2026-07-21.md`.

| Finding | Severity | File(s) | Description |
|---------|----------|---------|-------------|
| DOC-001 | HIGH | `README.md` | IEC-104 analyzer entirely absent from README — no Features bullet, no protocol table row, no Analyze flags entry, no dedicated section |
| DOC-002 | MED | `docs/adr/0001-content-first-stream-dispatch.md` | `StreamDispatcher` struct snippet and rule-order table missing IEC-104 (`iec104` field, `Iec104` variant, Rule 8 = port 2404) |
| DOC-003 | MED | `docs/adr/0002-modular-protocol-analyzers.md` | Existing Analyzers table and Deviations section do not include IEC-104 (v0.13.0) |
| DOC-004 | MED | `CLAUDE.md` | ADR-013 absent from Project References table `docs/adr/` row (only ADRs 0001–0012 listed) |
| DOC-005 | LOW | `src/cli.rs:259` | ENIP write-burst threshold doc-comment uses "1-second window"; should match Modbus arg at `src/cli.rs:185` ("1s window") — recurrence of UNIT-FMT-5-20S-001 |

## Per-File Changes

- **`README.md`** (+39 lines): Added IEC 60870-5-104 Features bullet; Supported Protocol Analyzers table row (port 2404, `--iec104`, MITRE ICS techniques T1692.001/T0836/T0827/T0881/T0814); Analyze flags entry; dedicated IEC-104 section mirroring DNP3/ARP/ENIP pattern with detection table, CLI flags, and JSON counters (`dropped_findings`, `flows_analyzed`).
- **`docs/adr/0001-content-first-stream-dispatch.md`** (+5 lines): Added `iec104: Option<Iec104Analyzer>` field to struct snippet; `Iec104,` variant to `DispatchTarget` enum; updated rule table from 8 to 9 entries (Rule 8 = port 2404 → `Iec104`, Rule 9 = no match → `None`).
- **`docs/adr/0002-modular-protocol-analyzers.md`** (+13 lines): Added IEC-104 row to Existing Analyzers table (v0.13.0, custom dispatch interface); added IEC-104 Deviations entry describing `on_data`/`on_flow_close` inherent-method dispatch pattern (mirrors DNP3 deviation).
- **`CLAUDE.md`** (+1 line): Appended "0013 IEC-104 stream dispatch and parser design" to the `docs/adr/` row in Project References table.
- **`src/cli.rs:259`** (1 line changed): `"within any 1-second window"` → `"within any 1s window"` (doc-comment only; no behavior change).
- **`CHANGELOG.md`** (+7 lines): Added `[Unreleased]` Fixed entry for DOC-005 (src/cli.rs touch triggers AC-158-001 CHANGELOG obligation).

## Test Evidence

| Gate | Result |
|------|--------|
| `cargo check` | PASS (author-verified on branch HEAD 0d7ae585) |
| `cargo clippy --all-targets -- -D warnings` | PASS (author-verified) |
| `cargo fmt --check` | PASS (author-verified) |
| `bin/validate-citations` (citation preflight) | PASS — 14 anchors checked, 0 failures |

## Row-Verify Mandate Compliance (PG-W74-PRDESC-ROW-VERIFY)

This PR description contains no per-test results table and no aggregate test counts. The mandate is not triggered: no row-verification or aggregate-count cross-check is required.

## Scope Notes

- `src/cli.rs` change is a doc-comment only (`///` line); no behavioral change, no new test required.
- CHANGELOG obligation applies because `src/` is touched (AC-158-001, PG-W71-CHANGELOG). The `[Unreleased]` entry is present.
- No new dependencies introduced. No public API surface change.