### PR TITLE
fix(enip): eliminate unsafe *mut EnipFlowState split-borrow in PDU dispatch (STORY-181, SEC-001)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ Version numbers follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- **ENIP `on_data` PDU dispatch loop: unsafe `*mut EnipFlowState` split-borrow replaced
+  with safe take-remove-reinsert (STORY-181, SEC-001, wave-85).**
+
+  The PDU dispatch loop in `src/analyzer/enip.rs` `on_data` previously acquired a raw
+  `*mut EnipFlowState` pointer via `self.flows.get_mut(&flow_key)` and called
+  `self.process_pdu(unsafe { &mut *flow_ptr }, ...)`, relying on a multi-line SAFETY
+  comment to guarantee that `process_pdu` never accesses `self.flows`. This pattern was
+  sound but fragile — any future change to `process_pdu` touching `self.flows` would
+  silently break soundness.
+
+  The fix removes the raw pointer entirely. Before the dispatch loop,
+  `self.flows.remove(&flow_key)` produces an owned `EnipFlowState`; `process_pdu(&mut
+  self, &mut flow, ...)` is called with this local variable (structurally disjoint from
+  `self.flows`); after the loop, `self.flows.insert(flow_key, flow)` re-inserts the flow.
+  The compiler enforces disjointness — no convention required. No `unsafe` block, no
+  `#[allow(clippy::ptr_as_ptr)]`, no raw-pointer cast remains in `on_data`. Behavior is
+  identical; all 2667 tests pass unchanged.
+
+  Resolves SEC-001 from `.factory/tech-debt-register.md` (MEDIUM, carry-forward since
+  PR #334).
+
 ### Added
 
 - **IEC-104 timed control command detection: TypeIDs 58–64 emit T1692.001 and T0836

--- a/bin/validate-citations
+++ b/bin/validate-citations
@@ -117,10 +117,10 @@ def parse_line(raw: str) -> tuple[str, int, int | None, str | None] | None:
     """Parse one line from a citations table.
 
     Returns (path, start_line, end_line_or_None, anchor_or_None) for a valid
-    citation line, or None if the line should be skipped (blank, comment, or
-    a non-blank/non-comment line that fails the citation regex match --
-    callers distinguish this MALFORMED case from the skip case by re-checking
-    the stripped/comment status of the raw line, per F-S164P1-002).
+    citation line, or None if the line should be skipped (blank or comment),
+    or None if the line fails the citation regex (caller should treat as
+    MALFORMED). Callers distinguish the skip case from the MALFORMED case by
+    re-checking the stripped/comment status of the raw line, per F-S164P1-002.
     """
     stripped = raw.strip()
     if not stripped or stripped.startswith("#"):

--- a/docs/demo-evidence/STORY-181/AC-181-001-unsafe-eliminated.md
+++ b/docs/demo-evidence/STORY-181/AC-181-001-unsafe-eliminated.md
@@ -1,0 +1,109 @@
+# AC-181-001: Unsafe *mut EnipFlowState Split-Borrow Eliminated
+
+**AC:** AC-181-001  
+**Story:** STORY-181 (SEC-001 ENIP unsafe split-borrow refactor)  
+**Date:** 2026-07-24  
+**Branch:** feature/STORY-181-enip-sec001-split-borrow
+
+---
+
+## Verdict: PASS
+
+---
+
+## grep Confirms Zero Unsafe Symbols at Former Site
+
+Command:
+```
+grep -n "flow_ptr\|ptr_as_ptr\|\*mut EnipFlowState\|unsafe" src/analyzer/enip.rs
+```
+
+Output:
+```
+(no output — zero matches)
+```
+
+All four patterns that defined the SEC-001 unsafe block (`flow_ptr`, `ptr_as_ptr`,
+`*mut EnipFlowState`, `unsafe`) are absent from `src/analyzer/enip.rs` after the refactor.
+
+---
+
+## Before: Old Unsafe Block (git show 421bf572:src/analyzer/enip.rs, lines 985–1000)
+
+```rust
+        for pdu in pdu_queue {
+            // SAFETY (split-borrow): flow_ptr aliases self.flows[flow_key]. process_pdu
+            // only touches self.all_findings, self.error_count, self.write_count,
+            // self.dropped_findings, self.enip_write_burst_threshold,
+            // self.enip_error_burst_threshold — none of which overlap with self.flows.
+            // The aliased field is therefore not accessed by process_pdu, making the
+            // exclusive-reference invariant sound.
+            let flow_ptr: *mut EnipFlowState = self
+                .flows
+                .get_mut(&flow_key)
+                .expect("flow exists: inserted above and not removed");
+            // SAFETY: flow_ptr is a valid &mut obtained from self.flows. process_pdu does
+            // not call self.flows or alias flow_ptr through any other path.
+            #[allow(clippy::ptr_as_ptr)]
+            self.process_pdu(unsafe { &mut *flow_ptr }, &pdu, timestamp, src_ip);
+        }
+```
+
+The old pattern:
+- Created `*mut EnipFlowState` via `self.flows.get_mut(&flow_key)` (live aliasing `self.flows`)
+- Called `self.process_pdu(unsafe { &mut *flow_ptr }, ...)` (simultaneously `&mut self` + `&mut *flow_ptr`)
+- Required a multi-line SAFETY comment to document a convention the compiler could not enforce
+- Carried `#[allow(clippy::ptr_as_ptr)]` to silence the lint on the raw pointer cast
+
+---
+
+## After: Take-Remove-Reinsert Pattern (current HEAD, src/analyzer/enip.rs, lines 978–1001)
+
+```rust
+        // Dispatch each collected valid PDU using take-remove-reinsert (SEC-001 fix).
+        // The flow is removed from self.flows before the loop; the resulting owned local
+        // EnipFlowState is structurally disjoint from self.flows. process_pdu(&mut self,
+        // &mut flow, ...) is therefore safe: &mut self (for process_pdu's access to
+        // self.all_findings, self.error_count, self.write_count, self.dropped_findings,
+        // and threshold fields) and &mut flow (the local variable) do not alias — the
+        // compiler enforces this disjointness, not a convention. After all PDUs are
+        // dispatched, the flow is re-inserted.
+        // is_non_enip safety: if the flag was already true on on_data entry, the early
+        // return at ~801 fired before any PDUs were collected, so pdu_queue is empty here.
+        // If the flag was latched during this call's carry-cap check (~955-974), pdu_queue
+        // may still contain items (per RULING-137-002 this latch branch is currently
+        // structurally unreachable; retained as defensive documentation for the anticipated
+        // carry-cap redesign); process_pdu gates on flow.is_non_enip (process_pdu's
+        // is_non_enip early-return gate) and skips all detection for those PDUs.
+        let mut flow = self
+            .flows
+            .remove(&flow_key)
+            .expect("flow exists: inserted above and not removed");
+        for pdu in pdu_queue {
+            self.process_pdu(&mut flow, &pdu, timestamp, src_ip);
+        }
+        self.flows.insert(flow_key, flow);
+```
+
+The new pattern:
+- `self.flows.remove(&flow_key)` produces an owned local `EnipFlowState`
+- `&mut flow` (the local) and `&mut self` (for `process_pdu`) are structurally disjoint
+- The compiler enforces disjointness — no convention required
+- No `unsafe` block, no `*mut` cast, no `#[allow(clippy::ptr_as_ptr)]`
+
+---
+
+## process_pdu Signature: Unchanged
+
+The method signature at `src/analyzer/enip.rs` line 1032 is:
+```rust
+    pub fn process_pdu(
+        &mut self,
+        flow: &mut EnipFlowState,
+        pdu: &[u8],
+        timestamp: u32,
+        src_ip: IpAddr,
+    ) {
+```
+
+Identical to the pre-refactor signature. The fix is local to the `on_data` call site.

--- a/docs/demo-evidence/STORY-181/AC-181-002-behavior-identical.md
+++ b/docs/demo-evidence/STORY-181/AC-181-002-behavior-identical.md
@@ -1,0 +1,86 @@
+# AC-181-002: All Existing ENIP Tests Pass Unchanged
+
+**AC:** AC-181-002  
+**Story:** STORY-181 (SEC-001 ENIP unsafe split-borrow refactor)  
+**Date:** 2026-07-24  
+**Branch:** feature/STORY-181-enip-sec001-split-borrow
+
+---
+
+## Verdict: PASS — 184/184 ENIP tests, zero failures
+
+---
+
+## ENIP Integration Test Suite
+
+Command:
+```
+cargo test --test enip_analyzer_tests
+```
+
+Output (tail):
+```
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.07s
+     Running tests/enip_analyzer_tests.rs (target/debug/deps/enip_analyzer_tests-831d4c1100defc5d)
+
+test result: ok. 184 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.07s
+```
+
+184 tests pass, 0 failures.
+
+---
+
+## Carry-Path Regression Witnesses (BC-2.17.016)
+
+The three tests named in the story AC are confirmed passing:
+
+### test_carry_buffer_partial_header
+```
+cargo test --test enip_analyzer_tests "test_carry_buffer_partial_header"
+
+running 1 test
+test frame_walk::test_carry_buffer_partial_header ... ok
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 183 filtered out; finished in 0.00s
+```
+
+### test_carry_buffer_two_frames_one_segment
+```
+cargo test --test enip_analyzer_tests "test_carry_buffer_two_frames_one_segment"
+
+running 1 test
+test frame_walk::test_carry_buffer_two_frames_one_segment ... ok
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 183 filtered out; finished in 0.00s
+```
+
+### test_ec_x1_cross_direction_no_splice
+```
+cargo test --test enip_analyzer_tests "test_ec_x1_cross_direction_no_splice"
+
+running 1 test
+test direction_and_clock::test_ec_x1_cross_direction_no_splice ... ok
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 183 filtered out; finished in 0.01s
+```
+
+All three carry-path tests pass. BC-2.17.016 regression guard is satisfied.
+
+---
+
+## Full Suite Summary (cargo test --all-targets)
+
+Command:
+```
+cargo test --all-targets
+```
+
+Selected result lines (all targets, zero failures):
+```
+test result: ok. 184 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.06s  (enip)
+test result: ok. 248 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.06s  (iec104)
+test result: ok. 229 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.38s  (dnp3)
+test result: ok. 160 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 15.94s (tls)
+```
+
+Every test-result line in the full suite reads `0 failed`. No test assertion was modified.

--- a/docs/demo-evidence/STORY-181/AC-181-003-no-api-change.md
+++ b/docs/demo-evidence/STORY-181/AC-181-003-no-api-change.md
@@ -1,0 +1,63 @@
+# AC-181-003: No Public API Surface Change
+
+**AC:** AC-181-003  
+**Story:** STORY-181 (SEC-001 ENIP unsafe split-borrow refactor)  
+**Date:** 2026-07-24  
+**Branch:** feature/STORY-181-enip-sec001-split-borrow
+
+---
+
+## Verdict: PASS
+
+---
+
+## process_pdu Signature Unchanged
+
+Command:
+```
+grep -n "fn process_pdu" src/analyzer/enip.rs
+```
+
+Output:
+```
+1032:    pub fn process_pdu(
+```
+
+Current signature at `src/analyzer/enip.rs` lines 1032–1037:
+```rust
+    pub fn process_pdu(
+        &mut self,
+        flow: &mut EnipFlowState,
+        pdu: &[u8],
+        timestamp: u32,
+        src_ip: IpAddr,
+    ) {
+```
+
+This is identical to the pre-refactor signature. The fix is internal to the `on_data`
+function body; no `pub` or `pub(crate)` signatures were changed.
+
+---
+
+## git diff Stat: Only enip.rs, bin/, CHANGELOG Touched
+
+Command:
+```
+git diff 421bf572..HEAD --stat
+```
+
+Output:
+```
+ CHANGELOG.md           | 23 +++++++++++++++++++++++
+ bin/validate-citations |  8 ++++----
+ src/analyzer/enip.rs   | 45 ++++++++++++++++++++++++---------------------
+ 3 files changed, 51 insertions(+), 25 deletions(-)
+```
+
+Exactly three files:
+- `src/analyzer/enip.rs` — the refactored implementation (SEC-001 fix)
+- `bin/validate-citations` — the AC-181-004 docstring update (advisory)
+- `CHANGELOG.md` — required [Unreleased] entry (PG-W71-CHANGELOG)
+
+`Cargo.toml` is **not** in the diff. No new crate dependencies. No Cargo.toml changes.
+The refactor scope is implementation-internal to `on_data` only.

--- a/docs/demo-evidence/STORY-181/AC-181-004-bin-docstring.md
+++ b/docs/demo-evidence/STORY-181/AC-181-004-bin-docstring.md
@@ -1,0 +1,140 @@
+# AC-181-004: parse_line() Docstring Clarified for Regex-Mismatch None Return
+
+**AC:** AC-181-004  
+**Story:** STORY-181 (ROUTE-W74 OBS-1 residual, bin/ housekeeping)  
+**Date:** 2026-07-24  
+**Branch:** feature/STORY-181-enip-sec001-split-borrow
+
+---
+
+## Verdict: PASS
+
+---
+
+## parse_line() Docstring (bin/validate-citations, lines 116–131)
+
+The third return case (regex-mismatch None) is now documented:
+
+```python
+def parse_line(raw: str) -> tuple[str, int, int | None, str | None] | None:
+    """Parse one line from a citations table.
+
+    Returns (path, start_line, end_line_or_None, anchor_or_None) for a valid
+    citation line, or None if the line should be skipped (blank or comment),
+    or None if the line fails the citation regex (caller should treat as
+    MALFORMED). Callers distinguish the skip case from the MALFORMED case by
+    re-checking the stripped/comment status of the raw line, per F-S164P1-002.
+    """
+    stripped = raw.strip()
+    if not stripped or stripped.startswith("#"):
+        return None
+    m = _CITATION_RE.match(raw)
+    if not m:
+        return None
+    ...
+```
+
+OBS-1 (wave-74 gate-summary carry-forward) is resolved: the docstring now enumerates
+all three `None` return cases:
+1. Valid citation line → returns `(path, start_line, end_line_or_None, anchor_or_None)`
+2. Blank or comment line → returns `None` (skip)
+3. Regex mismatch → returns `None` (caller treats as MALFORMED)
+
+---
+
+## bin/test_validate_citations.py: 27/27 PASS
+
+Command:
+```
+python3 bin/test_validate_citations.py
+```
+
+Output:
+```
+test_T01_valid_line_citation_passes:
+  [PASS] T01 valid single-line citation: exit=0, out='PASS: 1 citations verified'
+
+test_T02_valid_range_citation_passes:
+  [PASS] T02 valid range citation: exit=0, out='PASS: 1 citations verified'
+
+test_T03_nonexistent_file_rejected:
+  [PASS] T03 nonexistent file rejected: exit=1
+
+test_T04_out_of_range_single_line_rejected:
+  [PASS] T04 out-of-range single line rejected: exit=1
+
+test_T05_out_of_range_range_endpoint_rejected:
+  [PASS] T05 out-of-range range endpoint rejected: exit=1
+
+test_T06_comments_and_blanks_ignored:
+  [PASS] T06 comments and blank lines ignored: exit=0, out='PASS: 1 citations verified'
+
+test_T07_empty_input_passes:
+  [PASS] T07 empty input: exit=0, out='PASS: 0 citations verified'
+
+test_T08_invalid_range_start_gt_end:
+  [PASS] T08 invalid range (start > end) rejected: exit=1
+
+test_T09_bad_argument_exits_2:
+  [PASS] T09 nonexistent citations file → exit 2: exit=2
+
+test_T10_multiple_valid_citations_count:
+  [PASS] T10 multiple valid citations: exit=0, out='PASS: 3 citations verified'
+
+test_T11_mixed_valid_and_invalid:
+  [PASS] T11 mixed valid+invalid → FAIL with count: exit=1
+
+test_T12_malformed_line_reported:
+  [PASS] T12 malformed citation reported: exit=1
+
+test_T13_zero_line_number_rejected:
+  [PASS] T13 zero line number rejected: exit=1
+
+test_T14_zero_range_start_rejected:
+  [PASS] T14 zero range start rejected: exit=1
+
+test_T15_malformed_counts_in_fail_denominator:
+  [PASS] T15 malformed counted in FAIL denominator: exit=1
+
+test_T16_absolute_path_rejected:
+  [PASS] T16 absolute path rejected as OUTSIDE REPO: exit=1
+
+test_T17_parent_escape_rejected:
+  [PASS] T17 parent-escape path rejected as OUTSIDE REPO: exit=1
+
+test_T18_non_utf8_citations_file_exits_2:
+  [PASS] T18 non-UTF-8 citations file → exit 2: exit=2
+
+test_T19_unreadable_citations_file_exits_2:
+  [PASS] T19 unreadable file → exit 2: exit=2
+
+test_T20_non_utf8_stdin_exits_2:
+  [PASS] T20 non-UTF-8 stdin → exit 2: exit=2
+
+test_T21_directory_target_not_a_file:
+  [PASS] T21 directory target → NOT A FILE, exit 1: exit=1
+
+test_T22_unreadable_target_file:
+  [PASS] T22 unreadable target → UNREADABLE, exit 1: exit=1
+
+test_T23_anchor_present_passes:
+  [PASS] T23 anchor present (+ EC-002 regex-special anchor): exit=0, out='PASS: 2 citations verified'
+
+test_T24_anchor_absent_symbol_not_at_line:
+  [PASS] T24 anchor absent -> SYMBOL NOT AT LINE, exit 1: exit=1
+
+test_T25_bare_citation_still_passes:
+  [PASS] T25 bare citation backward-compat control: exit=0, out='PASS: 1 citations verified'
+
+test_T26_range_citation_anchor_asserts_start_line_only:
+  [PASS] T26 range anchor asserts start-line-only: a_exit=0, b_exit=1
+
+test_T27_symbol_failure_message_truncates_long_line:
+  [PASS] T27 long-line SYMBOL NOT AT LINE message truncated to <=80 chars: exit=1, found_len=80
+
+============================================================
+Results: 27 passed, 0 failed
+All tests passed.
+```
+
+All 27 tests pass. The docstring addition is behavior-neutral.

--- a/docs/demo-evidence/STORY-181/evidence-report.md
+++ b/docs/demo-evidence/STORY-181/evidence-report.md
@@ -1,0 +1,129 @@
+# Evidence Report — STORY-181
+
+**Story:** STORY-181: Fix SEC-001 ENIP Unsafe Split-Borrow in on_data: Eliminate *mut EnipFlowState Raw Pointer in PDU Dispatch Loop (Behavior-Preserving Refactor)  
+**Wave:** 85  
+**Date:** 2026-07-24  
+**Branch:** feature/STORY-181-enip-sec001-split-borrow  
+**Product type:** Library (behavior-preserving refactor — no CLI/web surface; internal-only change to `on_data` PDU dispatch loop)
+
+---
+
+## ENIP Test Suite: 184/184 PASS
+
+Command:
+```
+cargo test --test enip_analyzer_tests
+```
+
+Output (tail):
+```
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.07s
+     Running tests/enip_analyzer_tests.rs (target/debug/deps/enip_analyzer_tests-831d4c1100defc5d)
+
+test result: ok. 184 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.07s
+```
+
+---
+
+## Coverage Map
+
+| AC | Description | Evidence File | Verdict |
+|----|-------------|---------------|---------|
+| AC-181-001 | Unsafe `*mut EnipFlowState` split-borrow eliminated; take-remove-reinsert in place | `AC-181-001-unsafe-eliminated.md` | PASS |
+| AC-181-002 | All 184 ENIP tests pass; 3 carry-path regression witnesses confirmed | `AC-181-002-behavior-identical.md` | PASS |
+| AC-181-003 | `process_pdu` signature unchanged; `git diff --stat` shows only enip.rs/bin/CHANGELOG; no Cargo.toml | `AC-181-003-no-api-change.md` | PASS |
+| AC-181-004 | `parse_line()` docstring updated; 27/27 `test_validate_citations.py` pass | `AC-181-004-bin-docstring.md` | PASS |
+
+---
+
+## AC-181-001 Summary
+
+`grep -n "flow_ptr\|ptr_as_ptr\|\*mut EnipFlowState\|unsafe" src/analyzer/enip.rs` returns
+**zero matches**. The four SEC-001 symbols are absent from the file.
+
+Before (commit 421bf572, lines 985–1000): `let flow_ptr: *mut EnipFlowState = self.flows.get_mut(...)` 
+with `self.process_pdu(unsafe { &mut *flow_ptr }, &pdu, ...)` and `#[allow(clippy::ptr_as_ptr)]`.
+
+After (HEAD, lines 978–1001): `self.flows.remove(&flow_key)` → local owned `flow` →
+`self.process_pdu(&mut flow, &pdu, ...)` → `self.flows.insert(flow_key, flow)`.
+Compiler-enforced disjointness. No unsafe, no raw pointer, no clippy allow.
+
+---
+
+## AC-181-002 Summary
+
+184 ENIP tests pass (0 failures). Three BC-2.17.016 carry-path regression witnesses confirmed:
+- `frame_walk::test_carry_buffer_partial_header` — ok
+- `frame_walk::test_carry_buffer_two_frames_one_segment` — ok
+- `direction_and_clock::test_ec_x1_cross_direction_no_splice` — ok
+
+Full suite (`cargo test --all-targets`): all test-result lines read `0 failed`.
+
+---
+
+## AC-181-003 Summary
+
+`git diff 421bf572..HEAD --stat` output:
+```
+ CHANGELOG.md           | 23 +++++++++++++++++++++++
+ bin/validate-citations |  8 ++++----
+ src/analyzer/enip.rs   | 45 ++++++++++++++++++++++++---------------------
+ 3 files changed, 51 insertions(+), 25 deletions(-)
+```
+
+`Cargo.toml` absent. No new dependencies. No public API change.
+
+---
+
+## AC-181-004 Summary
+
+`parse_line()` at `bin/validate-citations` line 116 now documents all three return cases
+including `None` when the line fails the citation regex (caller treats as MALFORMED).
+`python3 bin/test_validate_citations.py`: 27 passed, 0 failed.
+
+---
+
+## End-to-End CLI Run (Optional)
+
+No ENIP-specific pcap fixture exists in `tests/fixtures/`. No CLI demo was built for
+this refactor story per the task specification ("only if a fixture already exists").
+
+---
+
+## Recording Method
+
+This is a behavior-preserving refactor story (no new behavioral surface). Evidence is
+captured as annotated CLI transcript markdown files showing real command output for each AC:
+- Source-level grep verification (AC-181-001 unsafe elimination)
+- `cargo test` run output (AC-181-002 behavior identity)
+- `git diff --stat` + signature grep (AC-181-003 no API change)
+- Docstring excerpt + `test_validate_citations.py` output (AC-181-004 bin housekeeping)
+
+VHS/Playwright recordings are not applicable at this story scope.
+
+---
+
+## Artifact List
+
+| File | AC Coverage |
+|------|-------------|
+| `AC-181-001-unsafe-eliminated.md` | AC-181-001: grep zero-match + before/after code excerpt |
+| `AC-181-002-behavior-identical.md` | AC-181-002: 184/184 enip tests + 3 carry-path witnesses + full suite summary |
+| `AC-181-003-no-api-change.md` | AC-181-003: process_pdu signature grep + git diff stat |
+| `AC-181-004-bin-docstring.md` | AC-181-004: docstring excerpt + 27/27 test_validate_citations.py |
+| `evidence-report.md` | Index (this file) |
+
+---
+
+## Demo-Evidence Path-Scrub Gate (PG-W70-DEMO-SCRUB)
+
+Gate defined in: `.factory/maintenance/demo-evidence-scrub-gate.md`
+
+Command run before commit (PG-W70-DEMO-SCRUB canonical pattern):
+```
+grep -rE '<host-path-pattern>' docs/demo-evidence/STORY-181/
+```
+
+Result: **zero matches** — no absolute host paths present in any evidence file.
+
+Gate status: **PASSED** (2026-07-24).

--- a/src/analyzer/enip.rs
+++ b/src/analyzer/enip.rs
@@ -975,29 +975,24 @@ impl EnipAnalyzer {
         } // flow borrow released here
 
         // ── PDU dispatch phase ────────────────────────────────────────────────────────
-        // Dispatch each collected valid PDU. Re-acquire flow per call.
-        // Safety: process_pdu does NOT access self.flows (verified by inspection); the
-        // flow we pass is from self.flows[flow_key], and process_pdu only mutates
+        // Dispatch each collected valid PDU using take-remove-reinsert (SEC-001 fix).
+        // The flow is removed from self.flows before the loop; the resulting owned local
+        // EnipFlowState is structurally disjoint from self.flows. process_pdu(&mut self,
+        // &mut flow, ...) is therefore safe: &mut self (for process_pdu's access to
         // self.all_findings, self.error_count, self.write_count, self.dropped_findings,
-        // and threshold fields.
-        // We re-borrow self.flows[flow_key] each iteration; pdu_queue is empty if
-        // is_non_enip was set above (carry overflow clears it before block exit).
+        // and threshold fields) and &mut flow (the local variable) do not alias — the
+        // compiler enforces this disjointness, not a convention. After all PDUs are
+        // dispatched, the flow is re-inserted.
+        // pdu_queue is empty if is_non_enip was set above (carry overflow clears it before
+        // block exit).
+        let mut flow = self
+            .flows
+            .remove(&flow_key)
+            .expect("flow exists: inserted above and not removed");
         for pdu in pdu_queue {
-            // SAFETY (split-borrow): flow_ptr aliases self.flows[flow_key]. process_pdu
-            // only touches self.all_findings, self.error_count, self.write_count,
-            // self.dropped_findings, self.enip_write_burst_threshold,
-            // self.enip_error_burst_threshold — none of which overlap with self.flows.
-            // The aliased field is therefore not accessed by process_pdu, making the
-            // exclusive-reference invariant sound.
-            let flow_ptr: *mut EnipFlowState = self
-                .flows
-                .get_mut(&flow_key)
-                .expect("flow exists: inserted above and not removed");
-            // SAFETY: flow_ptr is a valid &mut obtained from self.flows. process_pdu does
-            // not call self.flows or alias flow_ptr through any other path.
-            #[allow(clippy::ptr_as_ptr)]
-            self.process_pdu(unsafe { &mut *flow_ptr }, &pdu, timestamp, src_ip);
+            self.process_pdu(&mut flow, &pdu, timestamp, src_ip);
         }
+        self.flows.insert(flow_key, flow);
     }
 
     /// Main per-PDU detection dispatch for a single validated ENIP frame.

--- a/src/analyzer/enip.rs
+++ b/src/analyzer/enip.rs
@@ -983,8 +983,11 @@ impl EnipAnalyzer {
         // and threshold fields) and &mut flow (the local variable) do not alias — the
         // compiler enforces this disjointness, not a convention. After all PDUs are
         // dispatched, the flow is re-inserted.
-        // pdu_queue is empty if is_non_enip was set above (carry overflow clears it before
-        // block exit).
+        // is_non_enip safety: if the flag was already true on on_data entry, the early
+        // return at ~801 fired before any PDUs were collected, so pdu_queue is empty here.
+        // If the flag was latched during this call's carry-cap check (~955-974), pdu_queue
+        // may still contain items; process_pdu gates on flow.is_non_enip (early return,
+        // line ~1033) and skips all detection for those PDUs.
         let mut flow = self
             .flows
             .remove(&flow_key)
@@ -1014,7 +1017,10 @@ impl EnipAnalyzer {
     /// the frame-walk loop in `on_data` (BC-2.17.016 PC-0, STORY-137).
     ///
     /// # Parameters
-    /// - `flow_key` — identifies the TCP flow; used to look up `EnipFlowState`.
+    /// - `flow`     — owned-out `EnipFlowState` passed by the `on_data` dispatch loop;
+    ///   caller removes the state from `self.flows` before the loop and reinserts it
+    ///   after (SEC-001 pattern). Caller guarantees this is the state for the flow
+    ///   being dispatched.
     /// - `pdu`      — complete ENIP frame bytes (header + payload, 24 + header.length bytes).
     /// - `timestamp` — pcap-relative capture timestamp (seconds, u32).
     /// - `src_ip`   — source IP address of the sending endpoint.

--- a/src/analyzer/enip.rs
+++ b/src/analyzer/enip.rs
@@ -986,8 +986,10 @@ impl EnipAnalyzer {
         // is_non_enip safety: if the flag was already true on on_data entry, the early
         // return at ~801 fired before any PDUs were collected, so pdu_queue is empty here.
         // If the flag was latched during this call's carry-cap check (~955-974), pdu_queue
-        // may still contain items; process_pdu gates on flow.is_non_enip (early return,
-        // line ~1033) and skips all detection for those PDUs.
+        // may still contain items (per RULING-137-002 this latch branch is currently
+        // structurally unreachable; retained as defensive documentation for the anticipated
+        // carry-cap redesign); process_pdu gates on flow.is_non_enip (process_pdu's
+        // is_non_enip early-return gate) and skips all detection for those PDUs.
         let mut flow = self
             .flows
             .remove(&flow_key)


### PR DESCRIPTION
# [STORY-181] Fix SEC-001 ENIP Unsafe Split-Borrow in on_data: Eliminate *mut EnipFlowState Raw Pointer in PDU Dispatch Loop (Behavior-Preserving Refactor)

**Epic:** E-20 — EtherNet/IP ENIP/CIP Analyzer
**Mode:** maintenance (behavior-preserving refactor)
**Convergence:** CONVERGED after 3 adversarial passes (P1 NITPICK_ONLY / P2 NITPICK_ONLY / P3 CLEAN — BC-5.39.001 satisfied)

![Tests](https://img.shields.io/badge/tests-2667%2F2667-brightgreen)
![ENIP Suite](https://img.shields.io/badge/enip_suite-184%2F184-brightgreen)
![Clippy](https://img.shields.io/badge/clippy-0_warnings-brightgreen)
![Holdout](https://img.shields.io/badge/holdout-N%2FA--BY--DESIGN-blue)

This PR eliminates SEC-001 from the wirerust tech-debt register: the `on_data` PDU dispatch
loop in `src/analyzer/enip.rs` previously cast `self.flows.get_mut(&flow_key)` to a raw
`*mut EnipFlowState` and called `self.process_pdu(unsafe { &mut *flow_ptr }, ...)`, relying
on a multi-line SAFETY comment to guarantee that `process_pdu` never accesses `self.flows`.
The fix replaces this with a safe take-remove-reinsert pattern: `self.flows.remove(&flow_key)`
produces an owned local flow, `process_pdu(&mut self, &mut flow, ...)` receives a structurally
disjoint reference, and `self.flows.insert(flow_key, flow)` re-inserts after the loop. The
compiler now enforces the disjointness invariant — no `unsafe` block, no raw-pointer cast,
no `#[allow(clippy::ptr_as_ptr)]` remain in `on_data`. The PR also fixes the ROUTE-W74 OBS-1
residual: the `parse_line()` docstring in `bin/validate-citations` now documents the
regex-mismatch `None` return path (AC-181-004). All 2667 tests pass unchanged; behavior is
identical to pre-refactor.

---

## Architecture Changes

```mermaid
graph TD
    EnipAnalyzer["EnipAnalyzer\n(src/analyzer/enip.rs)"]
    OnData["on_data()\n[PDU dispatch loop]"]
    ProcessPdu["process_pdu()\n[per-PDU analysis]"]
    FlowsMap["self.flows\nHashMap<FlowKey, EnipFlowState>"]

    EnipAnalyzer --> OnData
    OnData -->|"BEFORE: unsafe *mut raw ptr\n(aliased self.flows)"| ProcessPdu
    OnData -->|"AFTER: safe remove→local→insert\n(compiler-enforced disjoint)"| ProcessPdu
    OnData -->|"remove() / insert()"| FlowsMap
    ProcessPdu -.->|"NEVER accesses\n(now structurally enforced)"| FlowsMap

    style OnData fill:#90EE90
```

<details>
<summary><strong>Architecture Decision Record</strong></summary>

### ADR: SEC-001 Take-Remove-Reinsert Pattern for EnipFlowState Split-Borrow

**Context:** `on_data` needed simultaneous access to `self` (for `process_pdu(&mut self, ...)`)
and to an element of `self.flows` (an `&mut EnipFlowState`). The prior approach used a raw
`*mut` pointer to sidestep the borrow checker, relying on a documented invariant that
`process_pdu` never accesses `self.flows`. This invariant was verified-by-inspection, not
structurally enforced.

**Decision:** Replace the raw pointer with a take-remove-reinsert pattern:
`flows.remove()` → process loop with local owned value → `flows.insert()`.

**Rationale:** The `remove`/`insert` approach gives the compiler full visibility into borrow
lifetimes. The flow is absent from `self.flows` during the dispatch loop, so any future
`process_pdu` change that accessed `self.flows` would be caught at compile time rather than
remaining a latent soundness risk. The behavioral contract (carry buffer accumulation,
direction isolation) is preserved because `process_pdu` only mutates fields other than
`self.flows`.

**Alternatives Considered:**
1. Refactor `process_pdu` to not require `&mut self` — rejected because it would require
   significant signature changes and introduce a separate borrow splitting complexity.
2. Keep the unsafe block but add more tests — rejected because tests cannot enforce the
   aliasing invariant; only structural safety can.

**Consequences:**
- Zero unsafe blocks remain in `src/analyzer/enip.rs` (SEC-001 closed).
- The invariant "process_pdu does NOT access self.flows" is now compiler-enforced rather
  than convention-based — future maintainers get a compile error if this changes.
- EC-002 (empty pdu_queue): remove+insert is a no-op that preserves flow state correctly.

</details>

---

## Story Dependencies

```mermaid
graph LR
    STORY181["STORY-181\n✅ this PR"]

    style STORY181 fill:#FFD700
```

**depends_on:** `[]` — no blocking predecessors. All prior E-20 stories (including
STORY-139 ENIP carry buffer, wave 62) are already merged to develop. No dependency hold.

---

## Spec Traceability

```mermaid
flowchart LR
    BC["BC-2.17.016\nENIP Per-Direction\nCarry Buffer"]
    AC1["AC-181-001\nunsafe eliminated"]
    AC2["AC-181-002\nbehavior identical"]
    AC3["AC-181-003\nno API change"]
    AC4["AC-181-004\nbin docstring"]

    T1["test_carry_buffer_partial_header\n(regression guard)"]
    T2["test_carry_buffer_two_frames_one_segment\n(regression guard)"]
    T3["test_ec_x1_cross_direction_no_splice\n(regression guard)"]

    S1["src/analyzer/enip.rs\non_data() lines 978–1001"]
    S2["bin/validate-citations\nparse_line() docstring"]

    BC --> AC1
    BC --> AC2
    BC --> AC3
    AC2 --> T1
    AC2 --> T2
    AC2 --> T3
    T1 --> S1
    T2 --> S1
    T3 --> S1
    AC4 --> S2
```

---

## Test Evidence

### Coverage Summary

| Metric | Value | Threshold | Status |
|--------|-------|-----------|--------|
| Full cargo test --all-targets | 2667 / 2667 pass | 100% | PASS |
| ENIP integration suite | 184 / 184 pass | 100% | PASS |
| validate-citations tests | 27 / 27 pass | 100% | PASS |
| Clippy -D warnings | 0 warnings | 0 | PASS |
| Cargo fmt | clean | clean | PASS |
| Holdout satisfaction | N/A-BY-DESIGN | N/A | N/A (refactor) |
| Mutation kill rate | not run (refactor; behavior-preserving) | advisory | N/A |

### BC-2.17.016 Carry-Path Regression Witnesses (AC-181-002 Mandate)

Per AC-181-002, the PR description MUST enumerate at least three existing tests that exercise
the carry path. The following three carry-path regression tests confirmed passing at HEAD
`0b5ba318`:

| Test | Module | Result |
|------|--------|--------|
| `test_carry_buffer_partial_header` | `frame_walk` | PASS |
| `test_carry_buffer_two_frames_one_segment` | `frame_walk` | PASS |
| `test_ec_x1_cross_direction_no_splice` | `direction_and_clock` | PASS |

**Row-verify (PG-W74-PRDESC-ROW-VERIFY):** These test names are drawn directly from the
evidence-report at `docs/demo-evidence/STORY-181/AC-181-002-behavior-identical.md` which
confirms each ran and passed. The ENIP test binary confirmed 184/184 at HEAD commit
`0b5ba318`. Aggregate count cross-check: `cargo test --all-targets` returned 2667 passing
/ 0 failed / 5 ignored — consistent with the baseline-identical characterization in the
convergence report.

### Test Flow

```mermaid
graph LR
    Unit["2667 Unit/Integration Tests"]
    ENIP["184 ENIP Suite Tests"]
    Python["27 Python Tests\n(bin/test_validate_citations.py)"]
    Clippy["Clippy -D warnings"]
    Fmt["cargo fmt --check"]

    Unit -->|"0 failed"| Pass1["PASS"]
    ENIP -->|"0 failed"| Pass2["PASS"]
    Python -->|"0 failed"| Pass3["PASS"]
    Clippy -->|"0 warnings"| Pass4["PASS"]
    Fmt -->|"clean"| Pass5["PASS"]

    style Pass1 fill:#90EE90
    style Pass2 fill:#90EE90
    style Pass3 fill:#90EE90
    style Pass4 fill:#90EE90
    style Pass5 fill:#90EE90
```

| Metric | Value |
|--------|-------|
| **New tests** | 0 added (behavior-preserving refactor; all existing tests serve as regression guard) |
| **Total suite** | 2667 tests PASS |
| **ENIP suite** | 184 tests PASS |
| **Regressions** | 0 |
| **Red Gate** | N/A-BY-DESIGN (log: `.factory/cycles/wave-085/STORY-181/implementation/red-gate-log.md`) |

<details>
<summary><strong>Detailed Test Results — BC-2.17.016 Carry-Path Tests</strong></summary>

### Carry-Path Regression Witnesses

| Test | Module | Result | Duration |
|------|--------|--------|----------|
| `test_carry_buffer_partial_header` | `frame_walk` | PASS | < 1ms |
| `test_carry_buffer_two_frames_one_segment` | `frame_walk` | PASS | < 1ms |
| `test_ec_x1_cross_direction_no_splice` | `direction_and_clock` | PASS | < 1ms |

These three tests cover the BC-2.17.016 postconditions:
- Partial-header carry accumulation (c2s and s2c buffers survive the dispatch loop refactor)
- Two-frame-per-segment carry drain (multi-PDU dispatch loop iterates correctly over local flow)
- Cross-direction isolation (no c2s/s2c carry splice across direction boundary)

### Red Gate Log

This story is a behavior-preserving refactor (SEC-001 split-borrow elimination). The TDD
Red Gate is N/A-BY-DESIGN: no new behavioral assertions were required (the refactor changes
no observable behavior). Baseline at worktree base `421bf572`: 2667 passing / 0 failed /
5 ignored (log commit `e7f76508`). This N/A status was explicitly adjudicated in the
implementation plan and is recorded in the red-gate-log above.

</details>

---

## Holdout Evaluation

| Metric | Value | Notes |
|--------|-------|-------|
| Result | **N/A — evaluated at wave gate** | Behavior-preserving refactor; no new behavioral surface |

This is a maintenance refactor story (SEC-001 tech-debt closure). No new user-facing behavior
is introduced. Holdout evaluation applies at the wave gate level, not per-story for
behavior-preserving refactors.

---

## Adversarial Review

| Pass | Code Tip | Findings | Critical | High | LOW | Status |
|------|----------|----------|----------|------|-----|--------|
| P1 | e9572820 | 2 | 0 | 0 | 2 | SWEPT (294168fa) |
| P2 | 294168fa | 2 | 0 | 0 | 2 | SWEPT (093ff519) |
| P3 | 093ff519 | 0 | 0 | 0 | 0 | CLEAN — CONVERGED |

**Convergence:** CONVERGED 3/3 (BC-5.39.001 satisfied) — clean streak P1/P2/P3.
All findings were LOW severity; zero HIGH or CRITICAL at any pass.
Report: `.factory/cycles/wave-085/STORY-181/convergence-report.md`

<details>
<summary><strong>Adversarial Finding Dispositions</strong></summary>

### F-181-P1-001 (LOW) — False pdu_queue Invariant Comment
- **Location:** `src/analyzer/enip.rs` (dispatch-phase inline comment)
- **Category:** code-quality (comment precision)
- **Problem:** Inline comment over-stated a PDU-queue guarantee that was not fully correct.
- **Resolution:** Comment corrected in `294168fa` to accurately reflect the actual invariant.

### F-181-P1-002 (LOW) — Stale process_pdu flow_key Parameter Docstring
- **Location:** `src/analyzer/enip.rs` `process_pdu` docstring
- **Category:** code-quality (documentation)
- **Problem:** Pre-existing stale `flow_key` parameter docstring; adjudicated in-scope.
- **Resolution:** Docstring corrected in `294168fa`.

### F-181-P2-001 (LOW) — RULING-137-002 Cross-Ref Missing
- **Location:** `src/analyzer/enip.rs` inline comment
- **Category:** code-quality (traceability)
- **Problem:** Inline comment cited the ruling but omitted the back-reference to the
  originating architectural decision.
- **Resolution:** Cross-reference added in `093ff519`.

### F-181-P2-002 (LOW) — `"line ~1033"` Reference Off by 6 Lines
- **Location:** `src/analyzer/enip.rs` inline comment
- **Category:** code-quality (precision)
- **Problem:** Line reference was 6 lines off after the refactor shifted line numbers.
- **Resolution:** Corrected in `093ff519`.

### O-181-P3-001 (theoretical, non-blocking)
- **Category:** theoretical-only
- **Description:** Panic-unwind flow-drop divergence in a `debug_assert`-only panic path
  compiled out in release. Explicitly non-blocking; no action required.

</details>

---

## Security Review

```mermaid
graph LR
    Critical["Critical: 0"]
    High["High: 0"]
    Medium["Medium: 0"]
    Low["Low: 0"]

    style Critical fill:#90EE90
    style High fill:#90EE90
    style Medium fill:#90EE90
    style Low fill:#90EE90
```

**SEC-001 CLOSED:** The primary security finding from PR #334 review (MEDIUM, carried forward
to wave-85 as D-493) is resolved by this PR. Zero `unsafe` blocks remain in `src/analyzer/enip.rs`.
Adversary-confirmed across all 3 passes.

<details>
<summary><strong>Security Scan Details</strong></summary>

### Unsafe Block Elimination

`grep -n "flow_ptr\|ptr_as_ptr\|\*mut EnipFlowState\|unsafe" src/analyzer/enip.rs` returns
**zero matches** at HEAD `0b5ba318`. The four SEC-001 symbols are absent from the file:
- `let flow_ptr: *mut EnipFlowState` — removed
- `unsafe { &mut *flow_ptr }` — removed
- `#[allow(clippy::ptr_as_ptr)]` — removed
- The `unsafe` keyword at the former dispatch site — removed

### Dependency Audit

No new crate dependencies introduced. `Cargo.toml` unchanged.

### Formal Verification

| Property | Method | Status |
|----------|--------|--------|
| Carry buffer accumulation preserved | BC-2.17.016 test suite (184 tests) | VERIFIED |
| Borrow disjointness (structural) | Rust compiler type-checker | VERIFIED at compile time |
| `process_pdu` self.flows isolation | Exhaustive grep (×3 adversarial passes) | VERIFIED |

</details>

---

## Risk Assessment & Deployment

### Blast Radius

- **Systems affected:** `src/analyzer/enip.rs` `on_data` dispatch loop only; no public API changes
- **User impact:** None — behavior-preserving refactor; CLI output and finding emission are identical
- **Data impact:** None — no storage, no schema changes
- **Risk Level:** LOW (behavior-preserving; compiler-enforced correctness improvement)

### Performance Impact

| Metric | Before | After | Delta | Status |
|--------|--------|-------|-------|--------|
| Latency | HashMap::remove + HashMap::insert per dispatch cycle | Same operations, same cost | neutral | OK |
| Memory | EnipFlowState stack-local during dispatch | Same; short-lived local | neutral | OK |
| Throughput | Identical PDU dispatch rate | Identical | 0 | OK |

The `remove` + `insert` operations on a `HashMap` are O(1) amortized — equivalent to the
prior `get_mut` + pointer deref. No observable performance difference is expected.

<details>
<summary><strong>Rollback Instructions</strong></summary>

**Immediate rollback (< 2 min):**
```bash
git revert 224311a1  # take-remove-reinsert implementation commit
git push origin develop
```

The revert restores the pre-refactor `*mut EnipFlowState` unsafe block. All tests pass in
either form — this is a behavior-preserving change. No feature flag; no migration required.

**Verification after rollback:**
- `cargo test --all-targets` returns 2667 passing / 0 failed
- `grep -n "flow_ptr" src/analyzer/enip.rs` shows the raw pointer restored

</details>

### Feature Flags

None. This is a direct code change with no feature flag. Rollback is via `git revert`.

---

## Traceability

| Requirement | Story AC | Test | Verification | Status |
|-------------|---------|------|-------------|--------|
| BC-2.17.016 carry postconditions preserved | AC-181-002 | `test_carry_buffer_partial_header` | ENIP suite 184/184 | PASS |
| BC-2.17.016 carry postconditions preserved | AC-181-002 | `test_carry_buffer_two_frames_one_segment` | ENIP suite 184/184 | PASS |
| BC-2.17.016 cross-direction isolation | AC-181-002 | `test_ec_x1_cross_direction_no_splice` | ENIP suite 184/184 | PASS |
| SEC-001 unsafe eliminated | AC-181-001 | grep zero-match | compiler type-checker | PASS |
| No public API change | AC-181-003 | git diff --stat | Cargo.toml absent from diff | PASS |
| ROUTE-W74 OBS-1 docstring | AC-181-004 | `python3 bin/test_validate_citations.py` | 27/27 pass | PASS |

<details>
<summary><strong>Full VSDD Contract Chain</strong></summary>

```
BC-2.17.016 → AC-181-001 → grep "unsafe" src/analyzer/enip.rs → zero matches → compiler-enforced
BC-2.17.016 → AC-181-002 → test_carry_buffer_partial_header → enip.rs on_data carry select → ENIP 184/184
BC-2.17.016 → AC-181-002 → test_carry_buffer_two_frames_one_segment → enip.rs on_data carry select → ENIP 184/184
BC-2.17.016 → AC-181-002 → test_ec_x1_cross_direction_no_splice → enip.rs on_data carry select → ENIP 184/184
BC-2.17.016 → AC-181-003 → git diff --stat → Cargo.toml absent → no API change
ROUTE-W74/OBS-1 → AC-181-004 → bin/validate-citations parse_line() → test_validate_citations.py → 27/27
```

</details>

---

## Demo Evidence

Demo evidence at `docs/demo-evidence/STORY-181/` (5 artifacts, scrub PASSED 2026-07-24):

| File | AC Coverage |
|------|-------------|
| `AC-181-001-unsafe-eliminated.md` | AC-181-001: grep zero-match + before/after code excerpt |
| `AC-181-002-behavior-identical.md` | AC-181-002: 184/184 ENIP tests + 3 carry-path witnesses + full suite |
| `AC-181-003-no-api-change.md` | AC-181-003: process_pdu signature grep + git diff stat |
| `AC-181-004-bin-docstring.md` | AC-181-004: docstring excerpt + 27/27 test_validate_citations.py |
| `evidence-report.md` | Index — coverage map + scrub gate PASSED |

---

## AI Pipeline Metadata

<details>
<summary><strong>Pipeline Details</strong></summary>

```yaml
ai-generated: true
pipeline-mode: maintenance
factory-version: "1.0.0-rc.23"
pipeline-stages:
  spec-crystallization: completed (wave-85 story decomposition 2026-07-23)
  story-decomposition: completed (STORY-181 v1.1, human approval D-505 2026-07-24)
  tdd-implementation: completed (224311a1 + 13491355 + e9572820; Red Gate N/A-BY-DESIGN)
  holdout-evaluation: "N/A — evaluated at wave gate (behavior-preserving refactor)"
  adversarial-review: completed (3 passes, CONVERGED BC-5.39.001)
  formal-verification: skipped (refactor; compiler type-check is structural verification)
  convergence: achieved (P1/P2/P3 clean streak)
convergence-metrics:
  adversarial-passes: 3
  last-classification: CLEAN
  clean-streak: "P1/P2/P3 = 3/3"
  code-tip-at-convergence: "093ff519"
  open-HIGH-CRIT: 0
models-used:
  builder: claude-sonnet-4-6
  adversary: claude-sonnet-4-6 (step-4.5 adversarial)
generated-at: "2026-07-24T22:00:00Z"
wave: 85
story-version: "1.1"
```

</details>

---

## Pre-Merge Checklist

- [ ] All CI status checks passing
- [x] Coverage delta: neutral (2667/0/5 baseline-identical — behavior-preserving)
- [x] No critical/high security findings unresolved (SEC-001 CLOSED; 0 HIGH/CRIT adversarial)
- [x] Rollback procedure: `git revert 224311a1`; all tests pass in both states
- [x] No feature flag required (direct code change)
- [ ] Human review completed (autonomy level requires human merge authorization — see DF-MERGE-AUTH-CLASSIFIER-001; no wave-85 wave-level grant exists)
- [x] Adversarial convergence: CONVERGED 3/3 (BC-5.39.001)
- [x] Demo evidence: 5 artifacts per-AC, scrub PASSED
- [x] AC-181-002 carry-path witnesses enumerated: test_carry_buffer_partial_header, test_carry_buffer_two_frames_one_segment, test_ec_x1_cross_direction_no_splice
- [x] PG-W74-PRDESC-ROW-VERIFY: row-verified 3 carry-path test entries + aggregate count cross-checked
- [x] CHANGELOG [Unreleased] entry present (AC-158-001)
