### PR TITLE
chore: release v0.13.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ Version numbers follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- **ENIP `on_data` PDU dispatch loop: unsafe `*mut EnipFlowState` split-borrow replaced
+  with safe take-remove-reinsert (STORY-181, SEC-001, wave-85).**
+
+  The PDU dispatch loop in `src/analyzer/enip.rs` `on_data` previously acquired a raw
+  `*mut EnipFlowState` pointer via `self.flows.get_mut(&flow_key)` and called
+  `self.process_pdu(unsafe { &mut *flow_ptr }, ...)`, relying on a multi-line SAFETY
+  comment to guarantee that `process_pdu` never accesses `self.flows`. This pattern was
+  sound but fragile — any future change to `process_pdu` touching `self.flows` would
+  silently break soundness.
+
+  The fix removes the raw pointer entirely. Before the dispatch loop,
+  `self.flows.remove(&flow_key)` produces an owned `EnipFlowState`; `process_pdu(&mut
+  self, &mut flow, ...)` is called with this local variable (structurally disjoint from
+  `self.flows`); after the loop, `self.flows.insert(flow_key, flow)` re-inserts the flow.
+  The compiler enforces disjointness — no convention required. No `unsafe` block, no
+  `#[allow(clippy::ptr_as_ptr)]`, no raw-pointer cast remains in `on_data`. Behavior is
+  identical; all 2667 tests pass unchanged.
+
+  Resolves SEC-001 from `.factory/tech-debt-register.md` (MEDIUM, carry-forward since
+  PR #334).
+
 ### Added
 
 - **IEC-104 timed control command detection: TypeIDs 58–64 emit T1692.001 and T0836

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ Version numbers follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- **IEC-104 timed control command detection: TypeIDs 58–64 emit T1692.001 and T0836
+  (STORY-180, BC-2.19.029 + BC-2.19.030, wave-85).**
+
+  The IEC-104 passive analyzer detects the CP56Time2a time-tagged variants of control
+  command TypeIDs, closing the evasion gap documented in IEC104-TIMED-CMD-GAP-001 where
+  TypeIDs 58–64 fell silently through the `_` catch-all arm.
+
+  Two new match arms in `detect_iec104_threats` (`src/analyzer/iec104.rs`):
+
+  - `58..=60` (C_SC_TA_1 / C_DC_TA_1 / C_RC_TA_1 — timed switching commands): emits one
+    T1692.001 "Unauthorized Message: Command Message" Possible / Medium / Impact finding
+    with CASDU and conditional first_ioa evidence. No T0836 (binary switching control, not
+    parameter writes). Parity with untimed arm 45..=47 (BC-2.19.019); summary wording
+    distinguishes timed from untimed with "time-tagged" qualifier and C_SC_TA/C_DC_TA/C_RC_TA
+    mnemonics (BC-2.19.029).
+
+  - `61..=64` (C_SE_TA_1 / C_SE_TB_1 / C_SE_TC_1 / C_BO_TA_1 — timed set-point and
+    bitstring write commands): emits T1692.001 Possible then T0836 "Modify Parameter" Possible,
+    both with CASDU and conditional first_ioa evidence. T0836 is co-emitted because set-point
+    and bitstring TypeIDs modify ICS control parameters. Parity with untimed arm 48..=51
+    (BC-2.19.019); summaries name C_SE_TA/C_SE_TB/C_SE_TC/C_BO_TA mnemonics (BC-2.19.030).
+
+  The catch-all arm comment at `detect_iec104_threats` is narrowed from "52–99" to
+  "{52–57, 65–99}", noting that TypeIDs 58–64 are now handled by BC-2.19.029 and
+  BC-2.19.030 (AC-180-007; BC-2.19.022 v1.1). The existing post-emission `[TEST]` loop
+  covers the new arms automatically — no extra wiring required (BC-2.19.017 invariant 1).
+
+  `cargo test --test iec104_analyzer_tests`: 248 passed (221 prior + 27 new story_180
+  tests; 21 flipped red→green at the Green step, 6 regression guards green throughout).
+
 ## [0.13.1] - 2026-07-21
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Version numbers follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.13.2] - 2026-07-25
+
 ### Changed
 
 - **ENIP `on_data` PDU dispatch loop: unsafe `*mut EnipFlowState` split-borrow replaced
@@ -59,8 +61,7 @@ Version numbers follow [Semantic Versioning](https://semver.org/).
   BC-2.19.030 (AC-180-007; BC-2.19.022 v1.1). The existing post-emission `[TEST]` loop
   covers the new arms automatically — no extra wiring required (BC-2.19.017 invariant 1).
 
-  `cargo test --test iec104_analyzer_tests`: 248 passed (221 prior + 27 new story_180
-  tests; 21 flipped red→green at the Green step, 6 regression guards green throughout).
+  `cargo test --test iec104_analyzer_tests`: 248 passed (221 prior + 27 new STORY-180 tests).
 
 ## [0.13.1] - 2026-07-21
 
@@ -1884,7 +1885,8 @@ Downstream consumers of wirerust JSON or CSV output must update for this release
 - Output sanitization in the terminal reporter guards against C1 control bytes
   in packet-derived strings.
 
-[Unreleased]: https://github.com/Zious11/wirerust/compare/v0.13.1...HEAD
+[Unreleased]: https://github.com/Zious11/wirerust/compare/v0.13.2...HEAD
+[0.13.2]: https://github.com/Zious11/wirerust/compare/v0.13.1...v0.13.2
 [0.13.1]: https://github.com/Zious11/wirerust/compare/v0.13.0...v0.13.1
 [0.13.0]: https://github.com/Zious11/wirerust/compare/v0.12.1...v0.13.0
 [0.12.1]: https://github.com/Zious11/wirerust/compare/v0.12.0...v0.12.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1524,7 +1524,7 @@ dependencies = [
 
 [[package]]
 name = "wirerust"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wirerust"
-version = "0.13.1"
+version = "0.13.2"
 edition = "2024"
 rust-version = "1.91"
 description = "Fast PCAP forensics and network triage CLI tool"

--- a/bin/validate-citations
+++ b/bin/validate-citations
@@ -117,10 +117,10 @@ def parse_line(raw: str) -> tuple[str, int, int | None, str | None] | None:
     """Parse one line from a citations table.
 
     Returns (path, start_line, end_line_or_None, anchor_or_None) for a valid
-    citation line, or None if the line should be skipped (blank, comment, or
-    a non-blank/non-comment line that fails the citation regex match --
-    callers distinguish this MALFORMED case from the skip case by re-checking
-    the stripped/comment status of the raw line, per F-S164P1-002).
+    citation line, or None if the line should be skipped (blank or comment),
+    or None if the line fails the citation regex (caller should treat as
+    MALFORMED). Callers distinguish the skip case from the MALFORMED case by
+    re-checking the stripped/comment status of the raw line, per F-S164P1-002.
     """
     stripped = raw.strip()
     if not stripped or stripped.startswith("#"):

--- a/docs/demo-evidence/STORY-180/AC-001-002-typeid-58-60-timed-switching.md
+++ b/docs/demo-evidence/STORY-180/AC-001-002-typeid-58-60-timed-switching.md
@@ -1,0 +1,89 @@
+# AC-180-001 / AC-180-002 — TypeIDs 58–60 (C_SC_TA/C_DC_TA/C_RC_TA): T1692.001 Only, No T0836
+
+**Story:** STORY-180: IEC-104 Timed Control Command Detection: TypeIDs 58–64  
+**ACs:** AC-180-001, AC-180-002  
+**Traces to:** BC-2.19.029 postconditions 1–3; invariant 2  
+**Wave:** 85
+
+---
+
+## Acceptance Criteria
+
+**AC-180-001:** TypeIDs 58–60 emit exactly one T1692.001 Possible finding with CASDU and
+first_ioa evidence — identical parity to untimed arm 45..=47.
+
+**AC-180-002:** TypeIDs 58–60 do NOT emit T0836 (switching commands are binary control,
+not parameter writes) — mirrors BC-2.19.019 Invariant 2.
+
+---
+
+## Test Suite Execution
+
+Command:
+```
+cargo test --test iec104_analyzer_tests "BC_2_19_029"
+```
+
+Output:
+```
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.08s
+     Running tests/iec104_analyzer_tests.rs (target/debug/deps/iec104_analyzer_tests-09617f6be29af6e9)
+
+running 10 tests
+test story_180::test_BC_2_19_029_type_id_58_count_zero_still_emits ... ok
+test story_180::test_BC_2_19_029_timed_summary_contains_time_tagged_qualifier ... ok
+test story_180::test_BC_2_19_029_type_id_58_emits_t1692_001_only ... ok
+test story_180::test_BC_2_19_029_timed_summary_differs_from_untimed_twin ... ok
+test story_180::test_BC_2_19_029_casdu_first_ioa_evidence ... ok
+test story_180::test_BC_2_19_029_type_id_58_verdict_confidence_category ... ok
+test story_180::test_BC_2_19_029_type_id_60_cot_test_suffix ... ok
+test story_180::test_BC_2_19_029_type_id_59_first_ioa_none_no_first_ioa_evidence ... ok
+test story_180::test_BC_2_19_029_type_id_59_emits_t1692_001_only ... ok
+test story_180::test_BC_2_19_029_type_id_60_emits_t1692_001_only ... ok
+
+test result: ok. 10 passed; 0 failed; 0 ignored; 0 measured; 238 filtered out; finished in 0.00s
+```
+
+Result: **10/10 PASS**
+
+---
+
+## Test Coverage
+
+### AC-180-001: Exactly One T1692.001 Possible Finding per TypeID (BC-2.19.029 PC1 + PC3)
+
+| Test Name | TypeID / Condition | Assertion | Result |
+|-----------|-------------------|-----------|--------|
+| `test_BC_2_19_029_type_id_58_emits_t1692_001_only` | TypeID=58 (C_SC_TA_1) | exactly 1 finding; T1692.001 present | PASS |
+| `test_BC_2_19_029_type_id_59_emits_t1692_001_only` | TypeID=59 (C_DC_TA_1) | exactly 1 finding; T1692.001 present | PASS |
+| `test_BC_2_19_029_type_id_60_emits_t1692_001_only` | TypeID=60 (C_RC_TA_1) | exactly 1 finding; T1692.001 present | PASS |
+| `test_BC_2_19_029_type_id_58_verdict_confidence_category` | TypeID=58 | Verdict::Possible, Confidence::Medium, ThreatCategory::Impact | PASS |
+| `test_BC_2_19_029_casdu_first_ioa_evidence` | TypeID=58, casdu=1, first_ioa=Some(100) | evidence contains "CASDU=1" and "first_ioa=100" | PASS |
+| `test_BC_2_19_029_type_id_59_first_ioa_none_no_first_ioa_evidence` | TypeID=59, first_ioa=None | evidence contains "CASDU=" but NOT "first_ioa=" (EC-008) | PASS |
+
+### AC-180-002: No T0836 for Switching Commands (BC-2.19.029 invariant 2)
+
+The `test_BC_2_19_029_type_id_58_emits_t1692_001_only`,
+`test_BC_2_19_029_type_id_59_emits_t1692_001_only`, and
+`test_BC_2_19_029_type_id_60_emits_t1692_001_only` tests each assert `findings.len() == 1`,
+which proves T0836 is never emitted (exactly one finding, not two).
+
+---
+
+## Dispatch Behavior Summary
+
+| TypeID | IEC-104 Name | Findings | MITRE Techniques | Verdict |
+|--------|-------------|----------|-----------------|---------|
+| 58 | C_SC_TA_1 (timed single-point switching) | 1 | T1692.001 | Possible |
+| 59 | C_DC_TA_1 (timed double-point switching) | 1 | T1692.001 | Possible |
+| 60 | C_RC_TA_1 (timed regulating step) | 1 | T1692.001 | Possible |
+
+---
+
+## Verdict
+
+AC-180-001: **PASS** — All three timed switching TypeIDs (58, 59, 60) emit exactly one
+T1692.001 Possible finding with CASDU and conditional first_ioa evidence.
+
+AC-180-002: **PASS** — T0836 is never emitted for TypeIDs 58–60; single-finding assertion
+in each test is the negative proof.

--- a/docs/demo-evidence/STORY-180/AC-003-typeid-61-64-timed-setpoint.md
+++ b/docs/demo-evidence/STORY-180/AC-003-typeid-61-64-timed-setpoint.md
@@ -1,0 +1,94 @@
+# AC-180-003 — TypeIDs 61–64 (C_SE_TA/C_SE_TB/C_SE_TC/C_BO_TA): T1692.001 + T0836 Both Possible
+
+**Story:** STORY-180: IEC-104 Timed Control Command Detection: TypeIDs 58–64  
+**AC:** AC-180-003  
+**Traces to:** BC-2.19.030 postconditions 1–3  
+**Wave:** 85
+
+---
+
+## Acceptance Criterion
+
+- Given an I-format ASDU with TypeID in {61, 62, 63, 64}
+- Then exactly two findings are emitted:
+  1. T1692.001 "Unauthorized Message: Command Message" with Verdict::Possible, Confidence::Medium, ThreatCategory::Impact
+  2. T0836 "Modify Parameter" with Verdict::Possible, Confidence::Medium, ThreatCategory::Impact
+- Both findings' evidence vectors include CASDU and, when present, first_ioa
+- T0836 is co-emitted because TypeIDs 61–64 are ICS parameter writes (set-point and bitstring output register writes)
+
+---
+
+## Test Suite Execution
+
+Command:
+```
+cargo test --test iec104_analyzer_tests "BC_2_19_030"
+```
+
+Output:
+```
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.07s
+     Running tests/iec104_analyzer_tests.rs (target/debug/deps/iec104_analyzer_tests-09617f6be29af6e9)
+
+running 11 tests
+test story_180::test_BC_2_19_030_type_id_61_count_zero_still_emits_two_findings ... ok
+test story_180::test_BC_2_19_030_timed_summaries_differ_from_untimed_twin ... ok
+test story_180::test_BC_2_19_030_timed_summaries_contain_time_tagged_and_mnemonics ... ok
+test story_180::test_BC_2_19_030_type_id_61_casdu_first_ioa_evidence_both_findings ... ok
+test story_180::test_BC_2_19_030_type_id_64_emits_two_findings ... ok
+test story_180::test_BC_2_19_030_type_id_62_emits_two_findings ... ok
+test story_180::test_BC_2_19_030_type_id_61_verdict_confidence_category_both_findings ... ok
+test story_180::test_BC_2_19_030_type_id_64_cot_test_both_findings_tagged ... ok
+test story_180::test_BC_2_19_030_type_id_61_emits_two_findings ... ok
+test story_180::test_BC_2_19_030_type_id_62_first_ioa_none_no_first_ioa_evidence ... ok
+test story_180::test_BC_2_19_030_type_id_63_emits_two_findings ... ok
+
+test result: ok. 11 passed; 0 failed; 0 ignored; 0 measured; 237 filtered out; finished in 0.00s
+```
+
+Result: **11/11 PASS**
+
+---
+
+## Test Coverage
+
+### Exactly Two Findings per TypeID — T1692.001 + T0836
+
+| Test Name | TypeID / Condition | Assertion | Result |
+|-----------|-------------------|-----------|--------|
+| `test_BC_2_19_030_type_id_61_emits_two_findings` | TypeID=61 (C_SE_TA_1) | exactly 2 findings; T1692.001 + T0836 present | PASS |
+| `test_BC_2_19_030_type_id_62_emits_two_findings` | TypeID=62 (C_SE_TB_1) | exactly 2 findings; T1692.001 + T0836 present | PASS |
+| `test_BC_2_19_030_type_id_63_emits_two_findings` | TypeID=63 (C_SE_TC_1) | exactly 2 findings; T1692.001 + T0836 present | PASS |
+| `test_BC_2_19_030_type_id_64_emits_two_findings` | TypeID=64 (C_BO_TA_1, bitstring) | exactly 2 findings; T1692.001 + T0836 present | PASS |
+
+### Verdict, Confidence, Category (BC-2.19.030 PC1 + PC2)
+
+| Test Name | Condition | Assertion | Result |
+|-----------|-----------|-----------|--------|
+| `test_BC_2_19_030_type_id_61_verdict_confidence_category_both_findings` | TypeID=61 | Both findings: Verdict::Possible, Confidence::Medium, ThreatCategory::Impact | PASS |
+
+### CASDU / first_ioa Evidence in Both Findings (BC-2.19.030 PC3)
+
+| Test Name | Input | Assertion | Result |
+|-----------|-------|-----------|--------|
+| `test_BC_2_19_030_type_id_61_casdu_first_ioa_evidence_both_findings` | TypeID=61, casdu=5, first_ioa=Some(200) | Both findings contain "CASDU=5" and "first_ioa=200" | PASS |
+| `test_BC_2_19_030_type_id_62_first_ioa_none_no_first_ioa_evidence` | TypeID=62, first_ioa=None | Both findings contain "CASDU=" but NOT "first_ioa=" | PASS |
+
+---
+
+## Dispatch Behavior Summary
+
+| TypeID | IEC-104 Name | Findings | MITRE Techniques | Verdict |
+|--------|-------------|----------|-----------------|---------|
+| 61 | C_SE_TA_1 (timed set-point normalized value) | 2 | T1692.001 + T0836 | Possible |
+| 62 | C_SE_TB_1 (timed set-point scaled value) | 2 | T1692.001 + T0836 | Possible |
+| 63 | C_SE_TC_1 (timed set-point short float) | 2 | T1692.001 + T0836 | Possible |
+| 64 | C_BO_TA_1 (timed bitstring of 32 bits) | 2 | T1692.001 + T0836 | Possible |
+
+---
+
+## Verdict
+
+AC-180-003: **PASS** — All four timed set-point/bitstring TypeIDs (61, 62, 63, 64) emit
+exactly two findings (T1692.001 Possible + T0836 Possible) with CASDU and conditional
+first_ioa evidence in both findings, matching BC-2.19.030 postconditions 1–3.

--- a/docs/demo-evidence/STORY-180/AC-004-timed-summary-wording.md
+++ b/docs/demo-evidence/STORY-180/AC-004-timed-summary-wording.md
@@ -1,0 +1,95 @@
+# AC-180-004 — Timed-Variant Summary Wording Distinguishes from Untimed Twin Summaries
+
+**Story:** STORY-180: IEC-104 Timed Control Command Detection: TypeIDs 58–64  
+**AC:** AC-180-004  
+**Traces to:** BC-2.19.029 postcondition 4; BC-2.19.030 postconditions 4 and 5  
+**Wave:** 85
+
+---
+
+## Acceptance Criterion
+
+- For TypeIDs 58–60: the T1692.001 finding `summary` field uses the "time-tagged" qualifier
+  and names the timed mnemonics (C_SC_TA/C_DC_TA/C_RC_TA)
+- For TypeIDs 61–64: both the T1692.001 and T0836 finding `summary` fields name the timed
+  mnemonics (C_SE_TA/C_SE_TB/C_SE_TC/C_BO_TA)
+- Neither timed summary string is identical to the corresponding untimed arm's summary —
+  analysts can distinguish timed from untimed findings in output
+
+---
+
+## Test Suite Execution
+
+Command:
+```
+cargo test --test iec104_analyzer_tests "timed_summary"
+```
+
+Output:
+```
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.07s
+     Running tests/iec104_analyzer_tests.rs (target/debug/deps/iec104_analyzer_tests-09617f6be29af6e9)
+
+running 4 tests
+test story_180::test_BC_2_19_029_timed_summary_contains_time_tagged_qualifier ... ok
+test story_180::test_BC_2_19_029_timed_summary_differs_from_untimed_twin ... ok
+test story_180::test_BC_2_19_030_timed_summaries_contain_time_tagged_and_mnemonics ... ok
+test story_180::test_BC_2_19_030_timed_summaries_differ_from_untimed_twin ... ok
+
+test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 244 filtered out; finished in 0.00s
+```
+
+Result: **4/4 PASS**
+
+---
+
+## Test Coverage
+
+| Test Name | Scope | Assertion | Result |
+|-----------|-------|-----------|--------|
+| `test_BC_2_19_029_timed_summary_contains_time_tagged_qualifier` | TypeID=58 T1692.001 summary | summary contains "time-tagged" and "C_SC_TA/C_DC_TA/C_RC_TA" | PASS |
+| `test_BC_2_19_029_timed_summary_differs_from_untimed_twin` | TypeID=58 vs TypeID=45 T1692.001 summary | timed summary != untimed arm-45 summary | PASS |
+| `test_BC_2_19_030_timed_summaries_contain_time_tagged_and_mnemonics` | TypeID=61 both findings | both summaries contain "time-tagged" and "C_SE_TA/C_SE_TB/C_SE_TC/C_BO_TA" | PASS |
+| `test_BC_2_19_030_timed_summaries_differ_from_untimed_twin` | TypeID=61 vs TypeID=48 summaries | timed T1692.001 summary != untimed arm-48 T1692.001 summary | PASS |
+
+---
+
+## Source-Level Verification
+
+Summary string for arm 58..=60 (src/analyzer/iec104.rs):
+```
+"IEC-104 time-tagged control command TypeID={type_id} \
+ (C_SC_TA/C_DC_TA/C_RC_TA): time-tagged switching control command \
+ observed on passive monitor \
+ (T1692.001 unauthorized command message; BC-2.19.029)"
+```
+
+Summary string for arm 61..=64 T1692.001 (src/analyzer/iec104.rs):
+```
+"IEC-104 time-tagged control command TypeID={type_id} \
+ (C_SE_TA/C_SE_TB/C_SE_TC/C_BO_TA): time-tagged set-point or bitstring \
+ write command observed on passive monitor \
+ (T1692.001 unauthorized command message; BC-2.19.030)"
+```
+
+Summary string for arm 61..=64 T0836 (src/analyzer/iec104.rs):
+```
+"IEC-104 time-tagged parameter modification TypeID={type_id} \
+ (C_SE_TA/C_SE_TB/C_SE_TC/C_BO_TA): time-tagged set-point or bitstring \
+ write modifying ICS control parameter on passive monitor \
+ (T0836 modify parameter; BC-2.19.030 postcondition 2)"
+```
+
+Confirmed by grep:
+```
+grep -n "C_SC_TA/C_DC_TA/C_RC_TA\|C_SE_TA/C_SE_TB" src/analyzer/iec104.rs
+```
+Returns lines 857–860 and 904–907, 920–923 — all contain "time-tagged".
+
+---
+
+## Verdict
+
+AC-180-004: **PASS** — All four summary-wording tests pass. Timed summaries include
+"time-tagged" qualifier and timed-arm mnemonics; diff tests confirm no string identity
+with the untimed twin arm summaries.

--- a/docs/demo-evidence/STORY-180/AC-005-cot-test-tagging.md
+++ b/docs/demo-evidence/STORY-180/AC-005-cot-test-tagging.md
@@ -1,0 +1,89 @@
+# AC-180-005 — cot_test=true Appends [TEST] Suffix to All Timed-Command Findings
+
+**Story:** STORY-180: IEC-104 Timed Control Command Detection: TypeIDs 58–64  
+**AC:** AC-180-005  
+**Traces to:** BC-2.19.029 postcondition 6; BC-2.19.030 postcondition 7; BC-2.19.017 invariant 1  
+**Wave:** 85
+
+---
+
+## Acceptance Criterion
+
+- Given an I-format ASDU with TypeID in {58..=64} and `asdu.cot_test == true`
+- Then the ` [TEST]` suffix is appended to all emitted findings' `summary` fields
+- The existing post-emission loop at `detect_iec104_threats` (lines 1027–1030) covers all
+  findings added during the call — no extra wiring needed in the new arms
+
+---
+
+## Test Suite Execution — TypeIDs 58–60 (cot_test=true, 1 finding tagged)
+
+Command:
+```
+cargo test --test iec104_analyzer_tests "BC_2_19_029_type_id_60_cot_test"
+```
+
+Output:
+```
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.07s
+     Running tests/iec104_analyzer_tests.rs (target/debug/deps/iec104_analyzer_tests-09617f6be29af6e9)
+
+running 1 test
+test story_180::test_BC_2_19_029_type_id_60_cot_test_suffix ... ok
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 247 filtered out; finished in 0.00s
+```
+
+---
+
+## Test Suite Execution — TypeID 64 (cot_test=true, 2 findings both tagged)
+
+Command:
+```
+cargo test --test iec104_analyzer_tests "BC_2_19_030_type_id_64_cot_test"
+```
+
+Output:
+```
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.07s
+     Running tests/iec104_analyzer_tests.rs (target/debug/deps/iec104_analyzer_tests-09617f6be29af6e9)
+
+running 1 test
+test story_180::test_BC_2_19_030_type_id_64_cot_test_both_findings_tagged ... ok
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 247 filtered out; finished in 0.00s
+```
+
+---
+
+## Test Coverage
+
+| Test Name | TypeID / cot_test | Assertion | Result |
+|-----------|-------------------|-----------|--------|
+| `test_BC_2_19_029_type_id_60_cot_test_suffix` | TypeID=60, cot_test=true | T1692.001 summary ends with " [TEST]" (EC-009) | PASS |
+| `test_BC_2_19_030_type_id_64_cot_test_both_findings_tagged` | TypeID=64, cot_test=true | BOTH T1692.001 and T0836 summaries end with " [TEST]" (EC-010) | PASS |
+
+---
+
+## Implementation Anchor
+
+The [TEST] loop at `src/analyzer/iec104.rs` lines 1027–1030:
+```rust
+if asdu.cot_test {
+    for f in &mut findings[start_idx..] {
+        f.summary.push_str(" [TEST]");
+    }
+}
+```
+This runs after both new arms (58..=60 and 61..=64) push their findings. The loop iterates
+over the entire `findings[start_idx..]` slice, so all findings added during the call are
+tagged regardless of how many arms fired. No wiring was added to the new arms.
+
+---
+
+## Verdict
+
+AC-180-005: **PASS** — Both cot_test tagging tests pass. The existing post-emission
+[TEST] loop automatically covers the new timed-command arms with no extra implementation.
+TypeID=60 with cot_test=true: 1 finding tagged. TypeID=64 with cot_test=true: both T1692.001
+and T0836 findings tagged.

--- a/docs/demo-evidence/STORY-180/AC-006-silence-regression-guard.md
+++ b/docs/demo-evidence/STORY-180/AC-006-silence-regression-guard.md
@@ -1,0 +1,91 @@
+# AC-180-006 — TypeIDs 52–57 and 65–99 Still Produce Zero Findings (BC-2.19.022 v1.1 Regression Guard)
+
+**Story:** STORY-180: IEC-104 Timed Control Command Detection: TypeIDs 58–64  
+**AC:** AC-180-006  
+**Traces to:** BC-2.19.022 v1.1 invariant 1; BC-2.19.029 invariant 6; BC-2.19.030 invariant 6  
+**Wave:** 85
+
+---
+
+## Acceptance Criterion
+
+- TypeIDs {52–57} (reserved, below new arms) and {65–99} (unhandled, above new arms)
+  remain in the silently-logged set — zero findings emitted
+- Regression guard: TypeIDs 52, 57, 65, 99 each explicitly tested
+- Untimed twins (45, 51) still produce correct findings (no regression)
+
+---
+
+## Test Suite Execution — BC-2.19.022 v1.1 Neighbor Silence
+
+Command:
+```
+cargo test --test iec104_analyzer_tests "BC_2_19_022_v1_1"
+```
+
+Output:
+```
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.07s
+     Running tests/iec104_analyzer_tests.rs (target/debug/deps/iec104_analyzer_tests-09617f6be29af6e9)
+
+running 4 tests
+test story_180::test_BC_2_19_022_v1_1_type_id_57_no_finding ... ok
+test story_180::test_BC_2_19_022_v1_1_type_id_65_no_finding ... ok
+test story_180::test_BC_2_19_022_v1_1_type_id_52_no_finding ... ok
+test story_180::test_BC_2_19_022_v1_1_type_id_99_no_finding ... ok
+
+test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 244 filtered out; finished in 0.00s
+```
+
+Result: **4/4 PASS** (silence regression guard green)
+
+---
+
+## Test Suite Execution — Untimed Twin Regression (BC-2.19.019 parity unchanged)
+
+Command:
+```
+cargo test --test iec104_analyzer_tests "BC_2_19_019_v1_1"
+```
+
+Output:
+```
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.07s
+     Running tests/iec104_analyzer_tests.rs (target/debug/deps/iec104_analyzer_tests-09617f6be29af6e9)
+
+running 2 tests
+test story_180::test_BC_2_19_019_v1_1_regression_type_id_45_still_one_finding ... ok
+test story_180::test_BC_2_19_019_v1_1_regression_type_id_51_still_two_findings ... ok
+
+test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 246 filtered out; finished in 0.00s
+```
+
+Result: **2/2 PASS** (untimed twins unaffected)
+
+---
+
+## Test Coverage
+
+### Silent-range neighbors (negative path — error path)
+
+| Test Name | TypeID | Boundary Role | Assertion | Result |
+|-----------|--------|---------------|-----------|--------|
+| `test_BC_2_19_022_v1_1_type_id_52_no_finding` | 52 (RESERVED) | lower bound of 52–57 block | 0 findings | PASS |
+| `test_BC_2_19_022_v1_1_type_id_57_no_finding` | 57 (RESERVED) | upper neighbor just below arm 58 | 0 findings | PASS |
+| `test_BC_2_19_022_v1_1_type_id_65_no_finding` | 65 (unhandled) | lower neighbor just above arm 64 | 0 findings | PASS |
+| `test_BC_2_19_022_v1_1_type_id_99_no_finding` | 99 (unhandled) | upper bound of 65–99 block | 0 findings | PASS |
+
+### Untimed twin regression guard
+
+| Test Name | TypeID | Assertion | Result |
+|-----------|--------|-----------|--------|
+| `test_BC_2_19_019_v1_1_regression_type_id_45_still_one_finding` | 45 (C_SC_NA_1) | 1 finding; T1692.001 present; arm 45..=47 unaffected | PASS |
+| `test_BC_2_19_019_v1_1_regression_type_id_51_still_two_findings` | 51 (C_BO_NA_1) | 2 findings; T1692.001 + T0836 present; arm 48..=51 unaffected | PASS |
+
+---
+
+## Verdict
+
+AC-180-006: **PASS** — TypeIDs 52, 57, 65, and 99 all produce zero findings.
+Boundary silence (TypeID=57 just below new arm, TypeID=65 just above new arm) confirmed.
+Untimed twin arms 45..=47 and 48..=51 remain unaffected by the new arms.

--- a/docs/demo-evidence/STORY-180/AC-007-silent-range-comment.md
+++ b/docs/demo-evidence/STORY-180/AC-007-silent-range-comment.md
@@ -1,0 +1,69 @@
+# AC-180-007 — Silent-Range Code Comment Narrowed to {52–57, 65–99}
+
+**Story:** STORY-180: IEC-104 Timed Control Command Detection: TypeIDs 58–64  
+**AC:** AC-180-007  
+**Traces to:** BC-2.19.022 v1.1 architecture anchor; BC-2.19.029 invariant 6 note; BC-2.19.030 invariant 6 note  
+**Wave:** 85
+
+---
+
+## Acceptance Criterion
+
+The code comment at `detect_iec104_threats` (previously lines 912–914, now lines 1013–1017
+after the new arms were inserted) MUST:
+- Name the silent range as `{52–57, 65–99}` (not `52–99`)
+- State that TypeIDs 58–64 were removed from the silently-logged set
+- Credit BC-2.19.029 (58–60) and BC-2.19.030 (61–64) as the handlers
+
+---
+
+## Source-Level Verification
+
+Command:
+```
+grep -n "52.*57\|65.*99\|were here prior\|BC-2.19.029\|BC-2.19.030" src/analyzer/iec104.rs | tail -10
+```
+
+Output:
+```
+709:/// | 58–60 (C_SC/DC/RC_TA)       | T1692.001               | Possible | BC-2.19.029 |
+710:/// | 61–64 (C_SE_TA/C_BO_TA)     | T1692.001 + T0836       | Possible | BC-2.19.030 |
+714:/// | {52–57, 65–99, …} (unhandled) | none (silently logged)  | —        | BC-2.19.022 |
+838:        // (BC-2.19.029 postconditions 1–2; invariants 1–2; AC-180-001/002).
+875:        // (BC-2.19.030 postconditions 1–2; invariants 1–2; AC-180-003).
+1014:        // TypeIDs 1–44 (monitoring direction), {52–57, 65–99}, 102 (C_RD_NA_1), 104, 106–127.
+1015:        // TypeIDs 58–64 were here prior to wave-85-spec-evolution; they are now handled by
+1016:        // BC-2.19.029 (58–60) and BC-2.19.030 (61–64).
+1017:        // No finding emitted — silently logged (BC-2.19.022 v1.1 invariant 1; AC-170-005).
+```
+
+---
+
+## Comment Text (src/analyzer/iec104.rs, lines 1013–1017)
+
+```rust
+// Defined-but-unhandled TypeIDs in [1, 127] not covered by the arms above:
+// TypeIDs 1–44 (monitoring direction), {52–57, 65–99}, 102 (C_RD_NA_1), 104, 106–127.
+// TypeIDs 58–64 were here prior to wave-85-spec-evolution; they are now handled by
+// BC-2.19.029 (58–60) and BC-2.19.030 (61–64).
+// No finding emitted — silently logged (BC-2.19.022 v1.1 invariant 1; AC-170-005).
+```
+
+---
+
+## Dispatch Table Docstring Update (src/analyzer/iec104.rs, line 714)
+
+The dispatch table docstring was also updated:
+```
+| {52–57, 65–99, …} (unhandled) | none (silently logged)  | —        | BC-2.19.022 |
+```
+Previously read `52–99`; now reflects `{52–57, 65–99}` after the removal of 58–64.
+
+---
+
+## Verdict
+
+AC-180-007: **PASS** — The silent-range comment at lines 1013–1017 names `{52–57, 65–99}`,
+states that TypeIDs 58–64 were removed from the catch-all, and credits BC-2.19.029 and
+BC-2.19.030 as the handlers. The dispatch-table docstring at line 714 also reflects
+the narrowed range. Both are confirmed by source grep above.

--- a/docs/demo-evidence/STORY-180/AC-008-count-independent-emission.md
+++ b/docs/demo-evidence/STORY-180/AC-008-count-independent-emission.md
@@ -1,0 +1,81 @@
+# AC-180-008 — Emission is Count-Independent: One Finding Set per ASDU Regardless of VSQ Object Count
+
+**Story:** STORY-180: IEC-104 Timed Control Command Detection: TypeIDs 58–64  
+**AC:** AC-180-008  
+**Traces to:** BC-2.19.029 postcondition 5 and invariant 3; BC-2.19.030 postcondition 6 and invariant 3  
+**Wave:** 85
+
+---
+
+## Acceptance Criterion
+
+- Given an I-format ASDU with TypeID in {58..=64} and `asdu.count == 0`
+- When `detect_iec104_threats` processes the parsed `Asdu`
+- Then the same finding(s) are still emitted as for `count > 0` — emission is per-ASDU,
+  not per-object
+
+---
+
+## Test Suite Execution — TypeID 58, count=0
+
+Command:
+```
+cargo test --test iec104_analyzer_tests "BC_2_19_029_type_id_58_count_zero"
+```
+
+Output:
+```
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.07s
+     Running tests/iec104_analyzer_tests.rs (target/debug/deps/iec104_analyzer_tests-09617f6be29af6e9)
+
+running 1 test
+test story_180::test_BC_2_19_029_type_id_58_count_zero_still_emits ... ok
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 247 filtered out; finished in 0.00s
+```
+
+---
+
+## Test Suite Execution — TypeID 61, count=0
+
+Command:
+```
+cargo test --test iec104_analyzer_tests "BC_2_19_030_type_id_61_count_zero"
+```
+
+Output:
+```
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.07s
+     Running tests/iec104_analyzer_tests.rs (target/debug/deps/iec104_analyzer_tests-09617f6be29af6e9)
+
+running 1 test
+test story_180::test_BC_2_19_030_type_id_61_count_zero_still_emits_two_findings ... ok
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 247 filtered out; finished in 0.00s
+```
+
+---
+
+## Test Coverage
+
+| Test Name | TypeID | asdu.count | Assertion | Result |
+|-----------|--------|------------|-----------|--------|
+| `test_BC_2_19_029_type_id_58_count_zero_still_emits` | 58 (C_SC_TA_1) | 0 | 1 finding emitted (EC-011: count-independent) | PASS |
+| `test_BC_2_19_030_type_id_61_count_zero_still_emits_two_findings` | 61 (C_SE_TA_1) | 0 | 2 findings emitted (T1692.001 + T0836); count-independent | PASS |
+
+---
+
+## Implementation Anchor
+
+The new detection arms operate on `asdu.type_id` and `asdu.casdu`/`asdu.first_ioa` only.
+The `asdu.count` field (VSQ object count) is not consulted by the detection arms — findings
+are emitted per-ASDU, not per-object. This is the same design as the untimed arms (45..=47
+and 48..=51), which also do not gate on count.
+
+---
+
+## Verdict
+
+AC-180-008: **PASS** — Both count=0 tests pass. TypeID=58 with count=0 still emits one
+T1692.001 finding. TypeID=61 with count=0 still emits two findings (T1692.001 + T0836).
+Emission is confirmed per-ASDU, count-independent.

--- a/docs/demo-evidence/STORY-180/evidence-report.md
+++ b/docs/demo-evidence/STORY-180/evidence-report.md
@@ -184,6 +184,4 @@ grep -rE '<host-path-pattern>' docs/demo-evidence/STORY-180/
 
 Result: **zero matches** — no absolute host paths present in any evidence file.
 
-Result: **zero matches** — no absolute host paths present in any evidence file.
-
 Gate status: **PASSED** (2026-07-24).

--- a/docs/demo-evidence/STORY-180/evidence-report.md
+++ b/docs/demo-evidence/STORY-180/evidence-report.md
@@ -1,0 +1,189 @@
+# Evidence Report — STORY-180
+
+**Story:** STORY-180: IEC-104 Timed Control Command Detection: TypeIDs 58–64 (BC-2.19.029 + BC-2.19.030 + BC-2.19.022 v1.1 Regression Guard)  
+**Wave:** 85  
+**Date:** 2026-07-24  
+**Branch:** feature/STORY-180-iec104-timed-cmd-detection  
+**Product type:** Library (effectful detection function — no CLI/web surface; dispatch wiring in iec104 analyzer)
+
+---
+
+## Full Test Suite: 248/248 PASS
+
+Command:
+```
+cargo test --test iec104_analyzer_tests
+```
+
+Output (tail):
+```
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.06s
+     Running tests/iec104_analyzer_tests.rs (target/debug/deps/iec104_analyzer_tests-09617f6be29af6e9)
+
+test result: ok. 248 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.06s
+```
+
+**STORY-180 contribution:** 27 tests (story_180 module)  
+**Predecessor contributions:** 221 tests (story_167..story_174 modules)  
+**Total:** 248/248 PASS
+
+---
+
+## STORY-180 Test Run (27 tests)
+
+Command:
+```
+cargo test --test iec104_analyzer_tests story_180
+```
+
+Output:
+```
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.12s
+     Running tests/iec104_analyzer_tests.rs (target/debug/deps/iec104_analyzer_tests-09617f6be29af6e9)
+
+running 27 tests
+test story_180::test_BC_2_19_022_v1_1_type_id_57_no_finding ... ok
+test story_180::test_BC_2_19_022_v1_1_type_id_65_no_finding ... ok
+test story_180::test_BC_2_19_022_v1_1_type_id_52_no_finding ... ok
+test story_180::test_BC_2_19_019_v1_1_regression_type_id_45_still_one_finding ... ok
+test story_180::test_BC_2_19_022_v1_1_type_id_99_no_finding ... ok
+test story_180::test_BC_2_19_029_casdu_first_ioa_evidence ... ok
+test story_180::test_BC_2_19_019_v1_1_regression_type_id_51_still_two_findings ... ok
+test story_180::test_BC_2_19_029_timed_summary_differs_from_untimed_twin ... ok
+test story_180::test_BC_2_19_029_timed_summary_contains_time_tagged_qualifier ... ok
+test story_180::test_BC_2_19_029_type_id_58_emits_t1692_001_only ... ok
+test story_180::test_BC_2_19_029_type_id_58_count_zero_still_emits ... ok
+test story_180::test_BC_2_19_029_type_id_58_verdict_confidence_category ... ok
+test story_180::test_BC_2_19_029_type_id_59_emits_t1692_001_only ... ok
+test story_180::test_BC_2_19_029_type_id_60_cot_test_suffix ... ok
+test story_180::test_BC_2_19_029_type_id_59_first_ioa_none_no_first_ioa_evidence ... ok
+test story_180::test_BC_2_19_029_type_id_60_emits_t1692_001_only ... ok
+test story_180::test_BC_2_19_030_timed_summaries_contain_time_tagged_and_mnemonics ... ok
+test story_180::test_BC_2_19_030_timed_summaries_differ_from_untimed_twin ... ok
+test story_180::test_BC_2_19_030_type_id_61_casdu_first_ioa_evidence_both_findings ... ok
+test story_180::test_BC_2_19_030_type_id_61_count_zero_still_emits_two_findings ... ok
+test story_180::test_BC_2_19_030_type_id_61_emits_two_findings ... ok
+test story_180::test_BC_2_19_030_type_id_61_verdict_confidence_category_both_findings ... ok
+test story_180::test_BC_2_19_030_type_id_62_emits_two_findings ... ok
+test story_180::test_BC_2_19_030_type_id_62_first_ioa_none_no_first_ioa_evidence ... ok
+test story_180::test_BC_2_19_030_type_id_63_emits_two_findings ... ok
+test story_180::test_BC_2_19_030_type_id_64_cot_test_both_findings_tagged ... ok
+test story_180::test_BC_2_19_030_type_id_64_emits_two_findings ... ok
+
+test result: ok. 27 passed; 0 failed; 0 ignored; 0 measured; 221 filtered out; finished in 0.00s
+```
+
+---
+
+## Coverage Map
+
+| AC | Description | BC | Tests | Evidence File | Verdict |
+|----|-------------|-----|-------|---------------|---------|
+| AC-180-001 | TypeIDs 58–60 emit exactly one T1692.001 Possible finding with CASDU and first_ioa evidence | BC-2.19.029 PC1 + PC3 | 6 | `AC-001-002-typeid-58-60-timed-switching.md` | PASS |
+| AC-180-002 | TypeIDs 58–60 do NOT emit T0836 (switching commands, not parameter writes) | BC-2.19.029 invariant 2 | included in AC-001 tests (single-finding assertion) | `AC-001-002-typeid-58-60-timed-switching.md` | PASS |
+| AC-180-003 | TypeIDs 61–64 emit exactly one T1692.001 Possible AND one T0836 Possible finding | BC-2.19.030 PC1-PC3 | 7 | `AC-003-typeid-61-64-timed-setpoint.md` | PASS |
+| AC-180-004 | Timed-variant summary wording distinguishes from untimed twin summaries | BC-2.19.029 PC4; BC-2.19.030 PC4-PC5 | 4 | `AC-004-timed-summary-wording.md` | PASS |
+| AC-180-005 | cot_test=true appends [TEST] suffix to all emitted timed-command findings | BC-2.19.017 inv1; BC-2.19.029 PC6; BC-2.19.030 PC7 | 2 | `AC-005-cot-test-tagging.md` | PASS |
+| AC-180-006 | TypeIDs 52–57 and 65–99 still produce zero findings (BC-2.19.022 v1.1 regression guard) | BC-2.19.022 v1.1 inv1 | 4 + 2 regression | `AC-006-silence-regression-guard.md` | PASS |
+| AC-180-007 | Silent-range code comment narrowed to {52–57, 65–99} with BC-2.19.029/030 note | BC-2.19.022 v1.1 arch anchor | source-level verification (grep output) | `AC-007-silent-range-comment.md` | PASS |
+| AC-180-008 | Emission is count-independent — one finding set per ASDU regardless of VSQ count | BC-2.19.029 inv3; BC-2.19.030 inv3 | 2 | `AC-008-count-independent-emission.md` | PASS |
+
+**Total STORY-180 test-based coverage: 27/27 (all AC-180-001..008)**
+
+---
+
+## Per-AC Test Distribution
+
+| AC | BC | Test Count | Key Test Names |
+|----|-----|-----------|----------------|
+| AC-180-001/002 | BC-2.19.029 PC1-PC3; inv2 | 6 | type_id_58/59/60_emits_t1692_001_only; verdict_confidence_category; casdu_first_ioa_evidence; first_ioa_none_no_first_ioa_evidence |
+| AC-180-003 | BC-2.19.030 PC1-PC3 | 7 | type_id_61/62/63/64_emits_two_findings; verdict_confidence_category_both; casdu_first_ioa_evidence_both; first_ioa_none_no_first_ioa_evidence |
+| AC-180-004 | BC-2.19.029 PC4; BC-2.19.030 PC4-PC5 | 4 | timed_summary_contains_time_tagged_qualifier; timed_summary_differs_from_untimed_twin (both arms) |
+| AC-180-005 | BC-2.19.017 inv1 | 2 | type_id_60_cot_test_suffix; type_id_64_cot_test_both_findings_tagged |
+| AC-180-006 | BC-2.19.022 v1.1 inv1 | 6 | type_id_52/57/65/99_no_finding; regression_type_id_45_still_one_finding; regression_type_id_51_still_two_findings |
+| AC-180-007 | BC-2.19.022 v1.1 arch anchor | — (source-level) | grep confirms {52–57, 65–99} in catch-all comment and "58–64 were here prior" note |
+| AC-180-008 | BC-2.19.029 inv3; BC-2.19.030 inv3 | 2 | type_id_58_count_zero_still_emits; type_id_61_count_zero_still_emits_two_findings |
+
+---
+
+## Updated Dispatch Table (after STORY-180)
+
+| TypeID Range | Finding(s) Emitted | MITRE Techniques | Verdict | BC |
+|-------------|-------------------|-----------------|---------|-----|
+| 0 | T0814 "Denial of Service" | T0814 | Possible | BC-2.19.022 |
+| 1–44 | None (monitoring direction) | — | — | BC-2.19.022 |
+| 45–47 | T1692.001 "Command Message" | T1692.001 | Possible | BC-2.19.019 |
+| 48–51 | T1692.001 "Command Message" + T0836 "Modify Parameter" | T1692.001, T0836 | Possible | BC-2.19.019 |
+| 52–57 | None (reserved — silently logged) | — | — | BC-2.19.022 v1.1 |
+| **58–60** | **T1692.001 "Command Message"** | **T1692.001** | **Possible** | **BC-2.19.029 (NEW)** |
+| **61–64** | **T1692.001 "Command Message" + T0836 "Modify Parameter"** | **T1692.001, T0836** | **Possible** | **BC-2.19.030 (NEW)** |
+| 65–99 | None (unhandled — silently logged) | — | — | BC-2.19.022 v1.1 |
+| 100, 101, 103 | None (interrogation/clock-sync benign) | — | — | BC-2.19.021 |
+| 102, 104, 106–127 | None (defined-but-unhandled) | — | — | BC-2.19.022 |
+| 105 | T0827 "Loss of Control" | T0827 | **Likely** | BC-2.19.020 |
+| 128–255 | T0814 "Denial of Service" | T0814 | Possible | BC-2.19.022 |
+
+---
+
+## Edge Case Coverage Summary
+
+| Edge Case | BC | Test Covering | Verdict |
+|-----------|-----|--------------|---------|
+| EC-001: TypeID=58 (C_SC_TA_1) | BC-2.19.029 | `type_id_58_emits_t1692_001_only` | PASS |
+| EC-002: TypeID=59 (C_DC_TA_1) | BC-2.19.029 | `type_id_59_emits_t1692_001_only` | PASS |
+| EC-003: TypeID=60 (C_RC_TA_1) | BC-2.19.029 | `type_id_60_emits_t1692_001_only` | PASS |
+| EC-004: TypeID=61 (C_SE_TA_1) | BC-2.19.030 | `type_id_61_emits_two_findings` | PASS |
+| EC-005: TypeID=64 (C_BO_TA_1) | BC-2.19.030 | `type_id_64_emits_two_findings` | PASS |
+| EC-006: TypeID=57 (RESERVED, upper neighbor below 58) | BC-2.19.022 v1.1 | `type_id_57_no_finding` | PASS |
+| EC-007: TypeID=65 (lower neighbor above 64) | BC-2.19.022 v1.1 | `type_id_65_no_finding` | PASS |
+| EC-008: TypeID=58, first_ioa=None | BC-2.19.029 | `type_id_59_first_ioa_none_no_first_ioa_evidence` | PASS |
+| EC-009: TypeID=60, cot_test=true | BC-2.19.029 | `type_id_60_cot_test_suffix` | PASS |
+| EC-010: TypeID=64, cot_test=true (both findings) | BC-2.19.030 | `type_id_64_cot_test_both_findings_tagged` | PASS |
+| EC-011: TypeID=58, asdu.count=0 | BC-2.19.029 | `type_id_58_count_zero_still_emits` | PASS |
+| EC-012: TypeID=45 (untimed twin regression) | BC-2.19.019 | `regression_type_id_45_still_one_finding` | PASS |
+| EC-013: TypeID=51 (untimed twin regression) | BC-2.19.019 | `regression_type_id_51_still_two_findings` | PASS |
+
+---
+
+## Recording Method
+
+This is an effectful library story (no CLI binary, no web UI). Evidence is captured as:
+- Annotated CLI transcript markdown files showing `cargo test` output grouped by AC
+- Inline dispatch table and edge-case coverage tables
+- Source-level verification via grep for AC-180-007 (comment-only AC)
+
+VHS/Playwright recordings are not applicable at this story scope. The timed-command
+detection function (`detect_iec104_threats`) is an internal effectful function with no
+interactive CLI surface in STORY-180.
+
+---
+
+## Artifact List
+
+| File | AC Coverage |
+|------|-------------|
+| `AC-001-002-typeid-58-60-timed-switching.md` | AC-180-001 (BC-2.19.029 PC1+PC3), AC-180-002 (BC-2.19.029 inv2) |
+| `AC-003-typeid-61-64-timed-setpoint.md` | AC-180-003 (BC-2.19.030 PC1-PC3) |
+| `AC-004-timed-summary-wording.md` | AC-180-004 (BC-2.19.029 PC4; BC-2.19.030 PC4-PC5) |
+| `AC-005-cot-test-tagging.md` | AC-180-005 (BC-2.19.017 inv1; BC-2.19.029 PC6; BC-2.19.030 PC7) |
+| `AC-006-silence-regression-guard.md` | AC-180-006 (BC-2.19.022 v1.1 inv1) |
+| `AC-007-silent-range-comment.md` | AC-180-007 (BC-2.19.022 v1.1 arch anchor; source-level) |
+| `AC-008-count-independent-emission.md` | AC-180-008 (BC-2.19.029 inv3; BC-2.19.030 inv3) |
+| `evidence-report.md` | Index (this file) |
+
+---
+
+## Demo-Evidence Path-Scrub Gate (PG-W70-DEMO-SCRUB)
+
+Gate defined in: `.factory/maintenance/demo-evidence-scrub-gate.md`
+
+Command run before commit (PG-W70-DEMO-SCRUB canonical pattern):
+```
+grep -rE '<host-path-pattern>' docs/demo-evidence/STORY-180/
+```
+
+Result: **zero matches** — no absolute host paths present in any evidence file.
+
+Result: **zero matches** — no absolute host paths present in any evidence file.
+
+Gate status: **PASSED** (2026-07-24).

--- a/docs/demo-evidence/STORY-181/AC-181-001-unsafe-eliminated.md
+++ b/docs/demo-evidence/STORY-181/AC-181-001-unsafe-eliminated.md
@@ -1,0 +1,109 @@
+# AC-181-001: Unsafe *mut EnipFlowState Split-Borrow Eliminated
+
+**AC:** AC-181-001  
+**Story:** STORY-181 (SEC-001 ENIP unsafe split-borrow refactor)  
+**Date:** 2026-07-24  
+**Branch:** feature/STORY-181-enip-sec001-split-borrow
+
+---
+
+## Verdict: PASS
+
+---
+
+## grep Confirms Zero Unsafe Symbols at Former Site
+
+Command:
+```
+grep -n "flow_ptr\|ptr_as_ptr\|\*mut EnipFlowState\|unsafe" src/analyzer/enip.rs
+```
+
+Output:
+```
+(no output — zero matches)
+```
+
+All four patterns that defined the SEC-001 unsafe block (`flow_ptr`, `ptr_as_ptr`,
+`*mut EnipFlowState`, `unsafe`) are absent from `src/analyzer/enip.rs` after the refactor.
+
+---
+
+## Before: Old Unsafe Block (git show 421bf572:src/analyzer/enip.rs, lines 985–1000)
+
+```rust
+        for pdu in pdu_queue {
+            // SAFETY (split-borrow): flow_ptr aliases self.flows[flow_key]. process_pdu
+            // only touches self.all_findings, self.error_count, self.write_count,
+            // self.dropped_findings, self.enip_write_burst_threshold,
+            // self.enip_error_burst_threshold — none of which overlap with self.flows.
+            // The aliased field is therefore not accessed by process_pdu, making the
+            // exclusive-reference invariant sound.
+            let flow_ptr: *mut EnipFlowState = self
+                .flows
+                .get_mut(&flow_key)
+                .expect("flow exists: inserted above and not removed");
+            // SAFETY: flow_ptr is a valid &mut obtained from self.flows. process_pdu does
+            // not call self.flows or alias flow_ptr through any other path.
+            #[allow(clippy::ptr_as_ptr)]
+            self.process_pdu(unsafe { &mut *flow_ptr }, &pdu, timestamp, src_ip);
+        }
+```
+
+The old pattern:
+- Created `*mut EnipFlowState` via `self.flows.get_mut(&flow_key)` (live aliasing `self.flows`)
+- Called `self.process_pdu(unsafe { &mut *flow_ptr }, ...)` (simultaneously `&mut self` + `&mut *flow_ptr`)
+- Required a multi-line SAFETY comment to document a convention the compiler could not enforce
+- Carried `#[allow(clippy::ptr_as_ptr)]` to silence the lint on the raw pointer cast
+
+---
+
+## After: Take-Remove-Reinsert Pattern (current HEAD, src/analyzer/enip.rs, lines 978–1001)
+
+```rust
+        // Dispatch each collected valid PDU using take-remove-reinsert (SEC-001 fix).
+        // The flow is removed from self.flows before the loop; the resulting owned local
+        // EnipFlowState is structurally disjoint from self.flows. process_pdu(&mut self,
+        // &mut flow, ...) is therefore safe: &mut self (for process_pdu's access to
+        // self.all_findings, self.error_count, self.write_count, self.dropped_findings,
+        // and threshold fields) and &mut flow (the local variable) do not alias — the
+        // compiler enforces this disjointness, not a convention. After all PDUs are
+        // dispatched, the flow is re-inserted.
+        // is_non_enip safety: if the flag was already true on on_data entry, the early
+        // return at ~801 fired before any PDUs were collected, so pdu_queue is empty here.
+        // If the flag was latched during this call's carry-cap check (~955-974), pdu_queue
+        // may still contain items (per RULING-137-002 this latch branch is currently
+        // structurally unreachable; retained as defensive documentation for the anticipated
+        // carry-cap redesign); process_pdu gates on flow.is_non_enip (process_pdu's
+        // is_non_enip early-return gate) and skips all detection for those PDUs.
+        let mut flow = self
+            .flows
+            .remove(&flow_key)
+            .expect("flow exists: inserted above and not removed");
+        for pdu in pdu_queue {
+            self.process_pdu(&mut flow, &pdu, timestamp, src_ip);
+        }
+        self.flows.insert(flow_key, flow);
+```
+
+The new pattern:
+- `self.flows.remove(&flow_key)` produces an owned local `EnipFlowState`
+- `&mut flow` (the local) and `&mut self` (for `process_pdu`) are structurally disjoint
+- The compiler enforces disjointness — no convention required
+- No `unsafe` block, no `*mut` cast, no `#[allow(clippy::ptr_as_ptr)]`
+
+---
+
+## process_pdu Signature: Unchanged
+
+The method signature at `src/analyzer/enip.rs` line 1032 is:
+```rust
+    pub fn process_pdu(
+        &mut self,
+        flow: &mut EnipFlowState,
+        pdu: &[u8],
+        timestamp: u32,
+        src_ip: IpAddr,
+    ) {
+```
+
+Identical to the pre-refactor signature. The fix is local to the `on_data` call site.

--- a/docs/demo-evidence/STORY-181/AC-181-002-behavior-identical.md
+++ b/docs/demo-evidence/STORY-181/AC-181-002-behavior-identical.md
@@ -1,0 +1,86 @@
+# AC-181-002: All Existing ENIP Tests Pass Unchanged
+
+**AC:** AC-181-002  
+**Story:** STORY-181 (SEC-001 ENIP unsafe split-borrow refactor)  
+**Date:** 2026-07-24  
+**Branch:** feature/STORY-181-enip-sec001-split-borrow
+
+---
+
+## Verdict: PASS — 184/184 ENIP tests, zero failures
+
+---
+
+## ENIP Integration Test Suite
+
+Command:
+```
+cargo test --test enip_analyzer_tests
+```
+
+Output (tail):
+```
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.07s
+     Running tests/enip_analyzer_tests.rs (target/debug/deps/enip_analyzer_tests-831d4c1100defc5d)
+
+test result: ok. 184 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.07s
+```
+
+184 tests pass, 0 failures.
+
+---
+
+## Carry-Path Regression Witnesses (BC-2.17.016)
+
+The three tests named in the story AC are confirmed passing:
+
+### test_carry_buffer_partial_header
+```
+cargo test --test enip_analyzer_tests "test_carry_buffer_partial_header"
+
+running 1 test
+test frame_walk::test_carry_buffer_partial_header ... ok
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 183 filtered out; finished in 0.00s
+```
+
+### test_carry_buffer_two_frames_one_segment
+```
+cargo test --test enip_analyzer_tests "test_carry_buffer_two_frames_one_segment"
+
+running 1 test
+test frame_walk::test_carry_buffer_two_frames_one_segment ... ok
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 183 filtered out; finished in 0.00s
+```
+
+### test_ec_x1_cross_direction_no_splice
+```
+cargo test --test enip_analyzer_tests "test_ec_x1_cross_direction_no_splice"
+
+running 1 test
+test direction_and_clock::test_ec_x1_cross_direction_no_splice ... ok
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 183 filtered out; finished in 0.01s
+```
+
+All three carry-path tests pass. BC-2.17.016 regression guard is satisfied.
+
+---
+
+## Full Suite Summary (cargo test --all-targets)
+
+Command:
+```
+cargo test --all-targets
+```
+
+Selected result lines (all targets, zero failures):
+```
+test result: ok. 184 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.06s  (enip)
+test result: ok. 248 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.06s  (iec104)
+test result: ok. 229 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.38s  (dnp3)
+test result: ok. 160 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 15.94s (tls)
+```
+
+Every test-result line in the full suite reads `0 failed`. No test assertion was modified.

--- a/docs/demo-evidence/STORY-181/AC-181-003-no-api-change.md
+++ b/docs/demo-evidence/STORY-181/AC-181-003-no-api-change.md
@@ -1,0 +1,63 @@
+# AC-181-003: No Public API Surface Change
+
+**AC:** AC-181-003  
+**Story:** STORY-181 (SEC-001 ENIP unsafe split-borrow refactor)  
+**Date:** 2026-07-24  
+**Branch:** feature/STORY-181-enip-sec001-split-borrow
+
+---
+
+## Verdict: PASS
+
+---
+
+## process_pdu Signature Unchanged
+
+Command:
+```
+grep -n "fn process_pdu" src/analyzer/enip.rs
+```
+
+Output:
+```
+1032:    pub fn process_pdu(
+```
+
+Current signature at `src/analyzer/enip.rs` lines 1032–1037:
+```rust
+    pub fn process_pdu(
+        &mut self,
+        flow: &mut EnipFlowState,
+        pdu: &[u8],
+        timestamp: u32,
+        src_ip: IpAddr,
+    ) {
+```
+
+This is identical to the pre-refactor signature. The fix is internal to the `on_data`
+function body; no `pub` or `pub(crate)` signatures were changed.
+
+---
+
+## git diff Stat: Only enip.rs, bin/, CHANGELOG Touched
+
+Command:
+```
+git diff 421bf572..HEAD --stat
+```
+
+Output:
+```
+ CHANGELOG.md           | 23 +++++++++++++++++++++++
+ bin/validate-citations |  8 ++++----
+ src/analyzer/enip.rs   | 45 ++++++++++++++++++++++++---------------------
+ 3 files changed, 51 insertions(+), 25 deletions(-)
+```
+
+Exactly three files:
+- `src/analyzer/enip.rs` — the refactored implementation (SEC-001 fix)
+- `bin/validate-citations` — the AC-181-004 docstring update (advisory)
+- `CHANGELOG.md` — required [Unreleased] entry (PG-W71-CHANGELOG)
+
+`Cargo.toml` is **not** in the diff. No new crate dependencies. No Cargo.toml changes.
+The refactor scope is implementation-internal to `on_data` only.

--- a/docs/demo-evidence/STORY-181/AC-181-004-bin-docstring.md
+++ b/docs/demo-evidence/STORY-181/AC-181-004-bin-docstring.md
@@ -1,0 +1,140 @@
+# AC-181-004: parse_line() Docstring Clarified for Regex-Mismatch None Return
+
+**AC:** AC-181-004  
+**Story:** STORY-181 (ROUTE-W74 OBS-1 residual, bin/ housekeeping)  
+**Date:** 2026-07-24  
+**Branch:** feature/STORY-181-enip-sec001-split-borrow
+
+---
+
+## Verdict: PASS
+
+---
+
+## parse_line() Docstring (bin/validate-citations, lines 116–131)
+
+The third return case (regex-mismatch None) is now documented:
+
+```python
+def parse_line(raw: str) -> tuple[str, int, int | None, str | None] | None:
+    """Parse one line from a citations table.
+
+    Returns (path, start_line, end_line_or_None, anchor_or_None) for a valid
+    citation line, or None if the line should be skipped (blank or comment),
+    or None if the line fails the citation regex (caller should treat as
+    MALFORMED). Callers distinguish the skip case from the MALFORMED case by
+    re-checking the stripped/comment status of the raw line, per F-S164P1-002.
+    """
+    stripped = raw.strip()
+    if not stripped or stripped.startswith("#"):
+        return None
+    m = _CITATION_RE.match(raw)
+    if not m:
+        return None
+    ...
+```
+
+OBS-1 (wave-74 gate-summary carry-forward) is resolved: the docstring now enumerates
+all three `None` return cases:
+1. Valid citation line → returns `(path, start_line, end_line_or_None, anchor_or_None)`
+2. Blank or comment line → returns `None` (skip)
+3. Regex mismatch → returns `None` (caller treats as MALFORMED)
+
+---
+
+## bin/test_validate_citations.py: 27/27 PASS
+
+Command:
+```
+python3 bin/test_validate_citations.py
+```
+
+Output:
+```
+test_T01_valid_line_citation_passes:
+  [PASS] T01 valid single-line citation: exit=0, out='PASS: 1 citations verified'
+
+test_T02_valid_range_citation_passes:
+  [PASS] T02 valid range citation: exit=0, out='PASS: 1 citations verified'
+
+test_T03_nonexistent_file_rejected:
+  [PASS] T03 nonexistent file rejected: exit=1
+
+test_T04_out_of_range_single_line_rejected:
+  [PASS] T04 out-of-range single line rejected: exit=1
+
+test_T05_out_of_range_range_endpoint_rejected:
+  [PASS] T05 out-of-range range endpoint rejected: exit=1
+
+test_T06_comments_and_blanks_ignored:
+  [PASS] T06 comments and blank lines ignored: exit=0, out='PASS: 1 citations verified'
+
+test_T07_empty_input_passes:
+  [PASS] T07 empty input: exit=0, out='PASS: 0 citations verified'
+
+test_T08_invalid_range_start_gt_end:
+  [PASS] T08 invalid range (start > end) rejected: exit=1
+
+test_T09_bad_argument_exits_2:
+  [PASS] T09 nonexistent citations file → exit 2: exit=2
+
+test_T10_multiple_valid_citations_count:
+  [PASS] T10 multiple valid citations: exit=0, out='PASS: 3 citations verified'
+
+test_T11_mixed_valid_and_invalid:
+  [PASS] T11 mixed valid+invalid → FAIL with count: exit=1
+
+test_T12_malformed_line_reported:
+  [PASS] T12 malformed citation reported: exit=1
+
+test_T13_zero_line_number_rejected:
+  [PASS] T13 zero line number rejected: exit=1
+
+test_T14_zero_range_start_rejected:
+  [PASS] T14 zero range start rejected: exit=1
+
+test_T15_malformed_counts_in_fail_denominator:
+  [PASS] T15 malformed counted in FAIL denominator: exit=1
+
+test_T16_absolute_path_rejected:
+  [PASS] T16 absolute path rejected as OUTSIDE REPO: exit=1
+
+test_T17_parent_escape_rejected:
+  [PASS] T17 parent-escape path rejected as OUTSIDE REPO: exit=1
+
+test_T18_non_utf8_citations_file_exits_2:
+  [PASS] T18 non-UTF-8 citations file → exit 2: exit=2
+
+test_T19_unreadable_citations_file_exits_2:
+  [PASS] T19 unreadable file → exit 2: exit=2
+
+test_T20_non_utf8_stdin_exits_2:
+  [PASS] T20 non-UTF-8 stdin → exit 2: exit=2
+
+test_T21_directory_target_not_a_file:
+  [PASS] T21 directory target → NOT A FILE, exit 1: exit=1
+
+test_T22_unreadable_target_file:
+  [PASS] T22 unreadable target → UNREADABLE, exit 1: exit=1
+
+test_T23_anchor_present_passes:
+  [PASS] T23 anchor present (+ EC-002 regex-special anchor): exit=0, out='PASS: 2 citations verified'
+
+test_T24_anchor_absent_symbol_not_at_line:
+  [PASS] T24 anchor absent -> SYMBOL NOT AT LINE, exit 1: exit=1
+
+test_T25_bare_citation_still_passes:
+  [PASS] T25 bare citation backward-compat control: exit=0, out='PASS: 1 citations verified'
+
+test_T26_range_citation_anchor_asserts_start_line_only:
+  [PASS] T26 range anchor asserts start-line-only: a_exit=0, b_exit=1
+
+test_T27_symbol_failure_message_truncates_long_line:
+  [PASS] T27 long-line SYMBOL NOT AT LINE message truncated to <=80 chars: exit=1, found_len=80
+
+============================================================
+Results: 27 passed, 0 failed
+All tests passed.
+```
+
+All 27 tests pass. The docstring addition is behavior-neutral.

--- a/docs/demo-evidence/STORY-181/evidence-report.md
+++ b/docs/demo-evidence/STORY-181/evidence-report.md
@@ -1,0 +1,129 @@
+# Evidence Report — STORY-181
+
+**Story:** STORY-181: Fix SEC-001 ENIP Unsafe Split-Borrow in on_data: Eliminate *mut EnipFlowState Raw Pointer in PDU Dispatch Loop (Behavior-Preserving Refactor)  
+**Wave:** 85  
+**Date:** 2026-07-24  
+**Branch:** feature/STORY-181-enip-sec001-split-borrow  
+**Product type:** Library (behavior-preserving refactor — no CLI/web surface; internal-only change to `on_data` PDU dispatch loop)
+
+---
+
+## ENIP Test Suite: 184/184 PASS
+
+Command:
+```
+cargo test --test enip_analyzer_tests
+```
+
+Output (tail):
+```
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.07s
+     Running tests/enip_analyzer_tests.rs (target/debug/deps/enip_analyzer_tests-831d4c1100defc5d)
+
+test result: ok. 184 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.07s
+```
+
+---
+
+## Coverage Map
+
+| AC | Description | Evidence File | Verdict |
+|----|-------------|---------------|---------|
+| AC-181-001 | Unsafe `*mut EnipFlowState` split-borrow eliminated; take-remove-reinsert in place | `AC-181-001-unsafe-eliminated.md` | PASS |
+| AC-181-002 | All 184 ENIP tests pass; 3 carry-path regression witnesses confirmed | `AC-181-002-behavior-identical.md` | PASS |
+| AC-181-003 | `process_pdu` signature unchanged; `git diff --stat` shows only enip.rs/bin/CHANGELOG; no Cargo.toml | `AC-181-003-no-api-change.md` | PASS |
+| AC-181-004 | `parse_line()` docstring updated; 27/27 `test_validate_citations.py` pass | `AC-181-004-bin-docstring.md` | PASS |
+
+---
+
+## AC-181-001 Summary
+
+`grep -n "flow_ptr\|ptr_as_ptr\|\*mut EnipFlowState\|unsafe" src/analyzer/enip.rs` returns
+**zero matches**. The four SEC-001 symbols are absent from the file.
+
+Before (commit 421bf572, lines 985–1000): `let flow_ptr: *mut EnipFlowState = self.flows.get_mut(...)` 
+with `self.process_pdu(unsafe { &mut *flow_ptr }, &pdu, ...)` and `#[allow(clippy::ptr_as_ptr)]`.
+
+After (HEAD, lines 978–1001): `self.flows.remove(&flow_key)` → local owned `flow` →
+`self.process_pdu(&mut flow, &pdu, ...)` → `self.flows.insert(flow_key, flow)`.
+Compiler-enforced disjointness. No unsafe, no raw pointer, no clippy allow.
+
+---
+
+## AC-181-002 Summary
+
+184 ENIP tests pass (0 failures). Three BC-2.17.016 carry-path regression witnesses confirmed:
+- `frame_walk::test_carry_buffer_partial_header` — ok
+- `frame_walk::test_carry_buffer_two_frames_one_segment` — ok
+- `direction_and_clock::test_ec_x1_cross_direction_no_splice` — ok
+
+Full suite (`cargo test --all-targets`): all test-result lines read `0 failed`.
+
+---
+
+## AC-181-003 Summary
+
+`git diff 421bf572..HEAD --stat` output:
+```
+ CHANGELOG.md           | 23 +++++++++++++++++++++++
+ bin/validate-citations |  8 ++++----
+ src/analyzer/enip.rs   | 45 ++++++++++++++++++++++++---------------------
+ 3 files changed, 51 insertions(+), 25 deletions(-)
+```
+
+`Cargo.toml` absent. No new dependencies. No public API change.
+
+---
+
+## AC-181-004 Summary
+
+`parse_line()` at `bin/validate-citations` line 116 now documents all three return cases
+including `None` when the line fails the citation regex (caller treats as MALFORMED).
+`python3 bin/test_validate_citations.py`: 27 passed, 0 failed.
+
+---
+
+## End-to-End CLI Run (Optional)
+
+No ENIP-specific pcap fixture exists in `tests/fixtures/`. No CLI demo was built for
+this refactor story per the task specification ("only if a fixture already exists").
+
+---
+
+## Recording Method
+
+This is a behavior-preserving refactor story (no new behavioral surface). Evidence is
+captured as annotated CLI transcript markdown files showing real command output for each AC:
+- Source-level grep verification (AC-181-001 unsafe elimination)
+- `cargo test` run output (AC-181-002 behavior identity)
+- `git diff --stat` + signature grep (AC-181-003 no API change)
+- Docstring excerpt + `test_validate_citations.py` output (AC-181-004 bin housekeeping)
+
+VHS/Playwright recordings are not applicable at this story scope.
+
+---
+
+## Artifact List
+
+| File | AC Coverage |
+|------|-------------|
+| `AC-181-001-unsafe-eliminated.md` | AC-181-001: grep zero-match + before/after code excerpt |
+| `AC-181-002-behavior-identical.md` | AC-181-002: 184/184 enip tests + 3 carry-path witnesses + full suite summary |
+| `AC-181-003-no-api-change.md` | AC-181-003: process_pdu signature grep + git diff stat |
+| `AC-181-004-bin-docstring.md` | AC-181-004: docstring excerpt + 27/27 test_validate_citations.py |
+| `evidence-report.md` | Index (this file) |
+
+---
+
+## Demo-Evidence Path-Scrub Gate (PG-W70-DEMO-SCRUB)
+
+Gate defined in: `.factory/maintenance/demo-evidence-scrub-gate.md`
+
+Command run before commit (PG-W70-DEMO-SCRUB canonical pattern):
+```
+grep -rE '<host-path-pattern>' docs/demo-evidence/STORY-181/
+```
+
+Result: **zero matches** — no absolute host paths present in any evidence file.
+
+Gate status: **PASSED** (2026-07-24).

--- a/src/analyzer/enip.rs
+++ b/src/analyzer/enip.rs
@@ -975,29 +975,29 @@ impl EnipAnalyzer {
         } // flow borrow released here
 
         // ── PDU dispatch phase ────────────────────────────────────────────────────────
-        // Dispatch each collected valid PDU. Re-acquire flow per call.
-        // Safety: process_pdu does NOT access self.flows (verified by inspection); the
-        // flow we pass is from self.flows[flow_key], and process_pdu only mutates
+        // Dispatch each collected valid PDU using take-remove-reinsert (SEC-001 fix).
+        // The flow is removed from self.flows before the loop; the resulting owned local
+        // EnipFlowState is structurally disjoint from self.flows. process_pdu(&mut self,
+        // &mut flow, ...) is therefore safe: &mut self (for process_pdu's access to
         // self.all_findings, self.error_count, self.write_count, self.dropped_findings,
-        // and threshold fields.
-        // We re-borrow self.flows[flow_key] each iteration; pdu_queue is empty if
-        // is_non_enip was set above (carry overflow clears it before block exit).
+        // and threshold fields) and &mut flow (the local variable) do not alias — the
+        // compiler enforces this disjointness, not a convention. After all PDUs are
+        // dispatched, the flow is re-inserted.
+        // is_non_enip safety: if the flag was already true on on_data entry, the early
+        // return at ~801 fired before any PDUs were collected, so pdu_queue is empty here.
+        // If the flag was latched during this call's carry-cap check (~955-974), pdu_queue
+        // may still contain items (per RULING-137-002 this latch branch is currently
+        // structurally unreachable; retained as defensive documentation for the anticipated
+        // carry-cap redesign); process_pdu gates on flow.is_non_enip (process_pdu's
+        // is_non_enip early-return gate) and skips all detection for those PDUs.
+        let mut flow = self
+            .flows
+            .remove(&flow_key)
+            .expect("flow exists: inserted above and not removed");
         for pdu in pdu_queue {
-            // SAFETY (split-borrow): flow_ptr aliases self.flows[flow_key]. process_pdu
-            // only touches self.all_findings, self.error_count, self.write_count,
-            // self.dropped_findings, self.enip_write_burst_threshold,
-            // self.enip_error_burst_threshold — none of which overlap with self.flows.
-            // The aliased field is therefore not accessed by process_pdu, making the
-            // exclusive-reference invariant sound.
-            let flow_ptr: *mut EnipFlowState = self
-                .flows
-                .get_mut(&flow_key)
-                .expect("flow exists: inserted above and not removed");
-            // SAFETY: flow_ptr is a valid &mut obtained from self.flows. process_pdu does
-            // not call self.flows or alias flow_ptr through any other path.
-            #[allow(clippy::ptr_as_ptr)]
-            self.process_pdu(unsafe { &mut *flow_ptr }, &pdu, timestamp, src_ip);
+            self.process_pdu(&mut flow, &pdu, timestamp, src_ip);
         }
+        self.flows.insert(flow_key, flow);
     }
 
     /// Main per-PDU detection dispatch for a single validated ENIP frame.
@@ -1019,7 +1019,10 @@ impl EnipAnalyzer {
     /// the frame-walk loop in `on_data` (BC-2.17.016 PC-0, STORY-137).
     ///
     /// # Parameters
-    /// - `flow_key` — identifies the TCP flow; used to look up `EnipFlowState`.
+    /// - `flow`     — owned-out `EnipFlowState` passed by the `on_data` dispatch loop;
+    ///   caller removes the state from `self.flows` before the loop and reinserts it
+    ///   after (SEC-001 pattern). Caller guarantees this is the state for the flow
+    ///   being dispatched.
     /// - `pdu`      — complete ENIP frame bytes (header + payload, 24 + header.length bytes).
     /// - `timestamp` — pcap-relative capture timestamp (seconds, u32).
     /// - `src_ip`   — source IP address of the sending endpoint.

--- a/src/analyzer/iec104.rs
+++ b/src/analyzer/iec104.rs
@@ -702,14 +702,16 @@ pub fn parse_asdu(asdu_body: &[u8]) -> Option<Asdu> {
 ///
 /// ## TypeID dispatch (AC-170-006 — exhaustive, no fallthrough)
 ///
-/// | Range / value      | Technique(s)            | Verdict  | BC ref      |
-/// |--------------------|-------------------------|----------|-------------|
-/// | 45–47 (C_SC/DC/RC) | T1692.001               | Possible | BC-2.19.019 |
-/// | 48–51 (C_SE/C_BO)  | T1692.001 + T0836       | Possible | BC-2.19.019 |
-/// | 105 (C_RP_NA_1)    | T0827 Loss of Control   | Likely   | BC-2.19.020 |
-/// | 100, 101, 103      | none (trace-logged)     | —        | BC-2.19.021 |
-/// | 0 or 128–255       | T0814 DoS anomaly       | Possible | BC-2.19.022 |
-/// | 1–127 (unhandled)  | none (silently logged)  | —        | BC-2.19.022 |
+/// | Range / value               | Technique(s)            | Verdict  | BC ref      |
+/// |-----------------------------|-------------------------|----------|-------------|
+/// | 45–47 (C_SC/DC/RC)          | T1692.001               | Possible | BC-2.19.019 |
+/// | 48–51 (C_SE/C_BO)           | T1692.001 + T0836       | Possible | BC-2.19.019 |
+/// | 58–60 (C_SC/DC/RC_TA)       | T1692.001               | Possible | BC-2.19.029 |
+/// | 61–64 (C_SE_TA/C_BO_TA)     | T1692.001 + T0836       | Possible | BC-2.19.030 |
+/// | 105 (C_RP_NA_1)             | T0827 Loss of Control   | Likely   | BC-2.19.020 |
+/// | 100, 101, 103               | none (trace-logged)     | —        | BC-2.19.021 |
+/// | 0 or 128–255                | T0814 DoS anomaly       | Possible | BC-2.19.022 |
+/// | {52–57, 65–99, …} (unhandled) | none (silently logged)  | —        | BC-2.19.022 |
 ///
 /// When `asdu.cot_test == true`, ` [TEST]` is appended to every emitted finding's
 /// `summary` field (BC-2.19.017 invariant 1; AC-170-007).
@@ -829,6 +831,105 @@ pub fn detect_iec104_threats(
             });
         }
 
+        // TypeIDs 58–60 (C_SC_TA_1, C_DC_TA_1, C_RC_TA_1): time-tagged switching commands.
+        // Emit T1692.001 "Unauthorized Message: Command Message" — Possible.
+        // No T0836 emitted: timed switching commands are binary control, not parameter writes.
+        // Parity with untimed arm 45..=47; only the summary wording differs to name timed mnemonics.
+        // (BC-2.19.029 postconditions 1–2; invariants 1–2; AC-180-001/002).
+        58..=60 => {
+            // BC-2.19.029 postcondition 3: include CASDU and first_ioa as target-address
+            // context; parity with untimed arm 45..=47 (BC-2.19.019 PC3).
+            let mut evidence = vec![
+                format!(
+                    "TypeID={type_id} is a time-tagged switching control command \
+                     (C_SC_TA/C_DC_TA/C_RC_TA)"
+                ),
+                format!("CASDU={}", asdu.casdu),
+            ];
+            if let Some(ioa) = asdu.first_ioa {
+                evidence.push(format!("first_ioa={ioa}"));
+            }
+            findings.push(Finding {
+                category: ThreatCategory::Impact,
+                verdict: Verdict::Possible,
+                confidence: Confidence::Medium,
+                summary: format!(
+                    "IEC-104 time-tagged control command TypeID={type_id} \
+                     (C_SC_TA/C_DC_TA/C_RC_TA): time-tagged switching control command \
+                     observed on passive monitor \
+                     (T1692.001 unauthorized command message; BC-2.19.029)"
+                ),
+                evidence,
+                mitre_techniques: vec!["T1692.001".to_string()],
+                source_ip,
+                timestamp,
+                direction: Some(direction),
+            });
+        }
+
+        // TypeIDs 61–64 (C_SE_TA_1, C_SE_TB_1, C_SE_TC_1, C_BO_TA_1):
+        // time-tagged set-point and bitstring write commands.
+        // Emit T1692.001 Possible (command-message indicator for all control TypeIDs)
+        // AND T0836 Possible (parameter/value write — set-point/bitstring are ICS parameter writes).
+        // Parity with untimed arm 48..=51; only summary wording differs to name timed mnemonics.
+        // (BC-2.19.030 postconditions 1–2; invariants 1–2; AC-180-003).
+        61..=64 => {
+            // BC-2.19.030 postcondition 3: CASDU/first_ioa target-address context for both
+            // co-emitted findings (T1692.001 + T0836); parity with untimed arm 48..=51 (BC-2.19.019 PC3).
+            let mut ev1 = vec![
+                format!(
+                    "TypeID={type_id} is a time-tagged set-point/bitstring write command \
+                     (C_SE_TA/C_SE_TB/C_SE_TC/C_BO_TA)"
+                ),
+                format!("CASDU={}", asdu.casdu),
+            ];
+            if let Some(ioa) = asdu.first_ioa {
+                ev1.push(format!("first_ioa={ioa}"));
+            }
+            let mut ev2 = vec![
+                format!(
+                    "TypeID={type_id} is a time-tagged set-point/bitstring write; \
+                     parameter modification (C_SE_TA/C_SE_TB/C_SE_TC/C_BO_TA)"
+                ),
+                format!("CASDU={}", asdu.casdu),
+            ];
+            if let Some(ioa) = asdu.first_ioa {
+                ev2.push(format!("first_ioa={ioa}"));
+            }
+            findings.push(Finding {
+                category: ThreatCategory::Impact,
+                verdict: Verdict::Possible,
+                confidence: Confidence::Medium,
+                summary: format!(
+                    "IEC-104 time-tagged control command TypeID={type_id} \
+                     (C_SE_TA/C_SE_TB/C_SE_TC/C_BO_TA): time-tagged set-point or bitstring \
+                     write command observed on passive monitor \
+                     (T1692.001 unauthorized command message; BC-2.19.030)"
+                ),
+                evidence: ev1,
+                mitre_techniques: vec!["T1692.001".to_string()],
+                source_ip,
+                timestamp,
+                direction: Some(direction),
+            });
+            findings.push(Finding {
+                category: ThreatCategory::Impact,
+                verdict: Verdict::Possible,
+                confidence: Confidence::Medium,
+                summary: format!(
+                    "IEC-104 time-tagged parameter modification TypeID={type_id} \
+                     (C_SE_TA/C_SE_TB/C_SE_TC/C_BO_TA): time-tagged set-point or bitstring \
+                     write modifies ICS control parameters \
+                     (T0836 modify parameter; BC-2.19.030 postcondition 2)"
+                ),
+                evidence: ev2,
+                mitre_techniques: vec!["T0836".to_string()],
+                source_ip,
+                timestamp,
+                direction: Some(direction),
+            });
+        }
+
         // TypeID 105 (C_RP_NA_1 — Reset Process Command).
         // Emit T0827 "Loss of Control" — Likely (NOT Possible; BC-2.19.020 v1.1 correction).
         // Only T0827 is emitted — not T1692.001 (reset is session management, not parameter change).
@@ -910,8 +1011,10 @@ pub fn detect_iec104_threats(
         }
 
         // Defined-but-unhandled TypeIDs in [1, 127] not covered by the arms above:
-        // TypeIDs 1–44 (monitoring direction), 52–99, 102 (C_RD_NA_1), 104, 106–127.
-        // No finding emitted — silently logged (BC-2.19.022 invariant 1; AC-170-005).
+        // TypeIDs 1–44 (monitoring direction), {52–57, 65–99}, 102 (C_RD_NA_1), 104, 106–127.
+        // TypeIDs 58–64 were here prior to wave-85-spec-evolution; they are now handled by
+        // BC-2.19.029 (58–60) and BC-2.19.030 (61–64).
+        // No finding emitted — silently logged (BC-2.19.022 v1.1 invariant 1; AC-170-005).
         _ => {
             // Silently logged: defined TypeID not in any detection set.
             // No finding emitted (BC-2.19.022 invariant 1).

--- a/tests/fixtures/E2E-PCAPS.md
+++ b/tests/fixtures/E2E-PCAPS.md
@@ -355,7 +355,7 @@ Two sources used:
 |------|------|--------|--------|---------|----------------|
 | `iec104.pcap` | 10 KB | `a78aa971adc51e54413a865937f1799ef57118d397cef57ccd93a358ed5b85d6` | Wireshark SampleCaptures | local-use-only | Canonical IEC-104 reference: U-frames (STARTDT/STOPDT/TESTFR) + I-frame ASDUs + C_IC general interrogation (TypeID 100, COT 6 act/7 con/20 inrogen/10 actterm). 105 reader packets. Produces 66 findings: T1692.001 ×42 (control commands) + T0836 ×24 (parameter modification). |
 | `iec104-sq.pcapng` | 584 B | `f855a11326f7aa4f719b1fbb65e5f8dfe3d9d194185a8f5faf5b5dc3cb831227` | Wireshark SampleCaptures | local-use-only | **Native pcapng** (SHB magic `0x0A0D0D0A`); SQ-bit set in ASDU variable-structure qualifier (sequence-of-information-objects encoding). Only native IEC-104 pcapng found on an authoritative source. 1 reader packet; 0 findings (small link-layer exercise). |
-| `iec104-iti-diverse.pcap` | 14 KB | `07b9a0879dc83e420c4cf83b37fb5830d1d8fb5f6ac6edc435896f70b0fc6bc7` | ITI/ICS-Security-Tools | CC-BY-4.0 | IEC-104 diverse-ASDU capture from the same ITI ICS corpus as the ENIP fixtures. 173 reader packets. Produces 31 findings: T1692.001 ×21 + T0836 ×10. |
+| `iec104-iti-diverse.pcap` | 14 KB | `07b9a0879dc83e420c4cf83b37fb5830d1d8fb5f6ac6edc435896f70b0fc6bc7` | ITI/ICS-Security-Tools | CC-BY-4.0 | IEC-104 diverse-ASDU capture from the same ITI ICS corpus as the ENIP fixtures. 173 reader packets. Produces 66 findings: T1692.001 ×46 + T0836 ×20. (Wave-85/STORY-180: was 31 before timed TypeIDs 58–64 were detected.) |
 | `iec104-iti-dissect.pcap` | 11 KB | `292c18a8765db3b1bcaa9bd0b8455e4e61b8366cc5910a7363b7381eb11441b8` | ITI/ICS-Security-Tools | CC-BY-4.0 | Wireshark-dissector test capture: deliberately broad Type ID / COT coverage including control commands (C_SC/C_DC/C_SE). 147 reader packets. Produces 11 findings: T1692.001 ×9 + T0814 ×2. |
 
 ### Analyzer-level outcomes (IEC-104 --iec104 flag)
@@ -364,7 +364,7 @@ Two sources used:
 |------|----------|-----------------|--------------|
 | `iec104.pcap` | 66 | T0836 ×24, T1692.001 ×42 | 0 |
 | `iec104-sq.pcapng` | 0 | — (benign link-management traffic only) | 0 |
-| `iec104-iti-diverse.pcap` | 31 | T0836 ×10, T1692.001 ×21 | 0 |
+| `iec104-iti-diverse.pcap` | 66 | T0836 ×20, T1692.001 ×46 | 0 |
 | `iec104-iti-dissect.pcap` | 11 | T0814 ×2, T1692.001 ×9 | 0 |
 
 All four captures parse without panics; zero parse_errors across all.

--- a/tests/iec104_analyzer_tests.rs
+++ b/tests/iec104_analyzer_tests.rs
@@ -3198,16 +3198,22 @@ mod story_170 {
         );
     }
 
-    /// BC-2.19.022 invariant: a representative sample of defined-but-unhandled TypeIDs emit no finding.
+    /// BC-2.19.022 v1.1 invariant: a representative sample of defined-but-unhandled TypeIDs emit no finding.
     ///
-    /// Tests {1, 30, 44, 52, 99, 102, 104, 127} — all silently logged with no findings.
+    /// Tests {1, 30, 44, 52, 99, 102, 104, 106, 127} — all silently logged with no findings.
     /// Ensures the silent-log path is exhaustive for a cross-section of the [1,127] range.
     ///
-    /// Traces: BC-2.19.022 invariant 1; AC-170-005; AC-170-006.
+    /// BC-2.19.022 v1.1 (wave-85-spec-evolution): the silently-logged range is now {52–57} and
+    /// {65–99}. TypeIDs 58–64 were removed from the silently-logged set and are handled by
+    /// BC-2.19.029 (58–60) and BC-2.19.030 (61–64). The sample below (52 and 99) is unchanged
+    /// because it does not include any value in 58–64, so no assertion removal is needed.
+    ///
+    /// Traces: BC-2.19.022 v1.1 invariant 1; AC-170-005; AC-170-006; AC-180-006.
     #[test]
     fn test_BC_2_19_022_invariant_silent_range_sample_emits_no_findings() {
         // Defined-but-unhandled TypeIDs that must produce no finding:
-        // 1–44: monitoring direction; 52–99: above control range;
+        // 1–44: monitoring direction; 52–57 and 65–99: silently logged per BC-2.19.022 v1.1
+        // (TypeIDs 58–64 are now handled by BC-2.19.029/030 — NOT in this list);
         // 102: C_RD (read, not detection set); 104: between C_RP and C_IC; 106–127: future
         let silent_type_ids: &[u8] = &[1, 30, 44, 52, 99, 102, 104, 106, 127];
         for &type_id in silent_type_ids {
@@ -6931,6 +6937,999 @@ mod fix_f5_001 {
         assert!(
             f.timestamp.is_some(),
             "non-canonical U-frame T0814 must carry a non-None timestamp (FIX-F5-001)"
+        );
+    }
+}
+
+// =============================================================================
+// STORY-180: IEC-104 Timed Control Command Detection (TypeIDs 58–64)
+// BC-2.19.029 + BC-2.19.030 + BC-2.19.022 v1.1 Regression Guard
+// =============================================================================
+// Red Gate classification:
+//   RED  (expected FAIL before implementation): all tests asserting findings for
+//        TypeIDs 58–64 — currently these fall through the `_` catch-all silently.
+//   GREEN (expected PASS before implementation): BC-2.19.022 v1.1 silence guards
+//        (52, 57, 65, 99) and untimed twin regression guards (45, 51) — their
+//        detection arms are unchanged by STORY-180.
+// =============================================================================
+mod story_180 {
+    use wirerust::analyzer::iec104::{Asdu, detect_iec104_threats};
+    use wirerust::findings::{Confidence, ThreatCategory, Verdict};
+    use wirerust::reassembly::handler::Direction;
+
+    // -------------------------------------------------------------------------
+    // Test helpers
+    // -------------------------------------------------------------------------
+
+    /// Construct a minimal Asdu with a given TypeID and cot_test flag.
+    ///
+    /// Mirrors story_170::make_asdu; sq=false, count=1, cot_cause=6, cot_pn=false,
+    /// cot_originator=0, casdu=1, first_ioa=None.
+    fn make_asdu(type_id: u8, cot_test: bool) -> Asdu {
+        Asdu {
+            type_id,
+            sq: false,
+            count: 1,
+            cot_cause: 6,
+            cot_pn: false,
+            cot_test,
+            cot_originator: 0,
+            casdu: 1,
+            first_ioa: None,
+        }
+    }
+
+    /// Construct an Asdu with explicit casdu, first_ioa, and count for evidence/count tests.
+    fn make_asdu_full(
+        type_id: u8,
+        cot_test: bool,
+        casdu: u16,
+        first_ioa: Option<u32>,
+        count: u8,
+    ) -> Asdu {
+        Asdu {
+            type_id,
+            sq: false,
+            count,
+            cot_cause: 6,
+            cot_pn: false,
+            cot_test,
+            cot_originator: 0,
+            casdu,
+            first_ioa,
+        }
+    }
+
+    // =========================================================================
+    // BC-2.19.029: Time-Tagged Switching Control Commands (TypeIDs 58–60)
+    // Emit exactly one T1692.001 Possible finding; no T0836.
+    // AC-180-001, AC-180-002
+    // =========================================================================
+
+    /// BC-2.19.029 canonical vector row 1: TypeID=58 (C_SC_TA_1, timed single command) →
+    /// exactly 1 finding (T1692.001 only; no T0836).
+    ///
+    /// At the RED gate, TypeID=58 fell through the `_` catch-all (0 findings); now handled by the 58..=60 arm.
+    ///
+    /// Traces: BC-2.19.029 postconditions 1–2; invariants 1–2; AC-180-001; AC-180-002;
+    ///         EC-001 (BC-2.19.029).
+    #[test]
+    fn test_BC_2_19_029_type_id_58_emits_t1692_001_only() {
+        let asdu = make_asdu(58, false);
+        let mut findings = Vec::new();
+        detect_iec104_threats(&asdu, &mut findings, Direction::ClientToServer, None, None);
+        assert_eq!(
+            findings.len(),
+            1,
+            "TypeID=58 (C_SC_TA_1, timed single command) must emit exactly 1 finding — \
+             T1692.001 only; no T0836 \
+             (BC-2.19.029 postconditions 1–2; invariant 2; AC-180-001/002)"
+        );
+        assert!(
+            findings[0]
+                .mitre_techniques
+                .iter()
+                .any(|t| t == "T1692.001"),
+            "TypeID=58 sole finding must be T1692.001 \
+             (BC-2.19.029 postcondition 1; AC-180-001)"
+        );
+        assert!(
+            !findings
+                .iter()
+                .any(|f| f.mitre_techniques.iter().any(|t| t == "T0836")),
+            "TypeID=58 must NOT emit T0836 — timed switching commands are binary control, \
+             not parameter writes (BC-2.19.029 postcondition 2; invariant 2; AC-180-002)"
+        );
+    }
+
+    /// BC-2.19.029 canonical vector row 2: TypeID=59 (C_DC_TA_1, timed double command) →
+    /// exactly 1 finding (T1692.001 only; no T0836).
+    ///
+    /// At the RED gate, TypeID=59 fell through the `_` catch-all (0 findings); now handled by the 58..=60 arm.
+    ///
+    /// Traces: BC-2.19.029 postconditions 1–2; invariant 2; AC-180-001; EC-002 (BC-2.19.029).
+    #[test]
+    fn test_BC_2_19_029_type_id_59_emits_t1692_001_only() {
+        let asdu = make_asdu(59, false);
+        let mut findings = Vec::new();
+        detect_iec104_threats(&asdu, &mut findings, Direction::ClientToServer, None, None);
+        assert_eq!(
+            findings.len(),
+            1,
+            "TypeID=59 (C_DC_TA_1, timed double command) must emit exactly 1 finding — \
+             T1692.001 only (BC-2.19.029 postconditions 1–2; AC-180-001)"
+        );
+        assert!(
+            findings[0]
+                .mitre_techniques
+                .iter()
+                .any(|t| t == "T1692.001"),
+            "TypeID=59 finding must be T1692.001 (BC-2.19.029 postcondition 1)"
+        );
+        assert!(
+            !findings
+                .iter()
+                .any(|f| f.mitre_techniques.iter().any(|t| t == "T0836")),
+            "TypeID=59 must NOT emit T0836 (BC-2.19.029 invariant 2; AC-180-002)"
+        );
+    }
+
+    /// BC-2.19.029: TypeID=60 (C_RC_TA_1, timed regulating step command) → exactly 1 finding
+    /// (T1692.001 only; no T0836).
+    ///
+    /// At the RED gate, TypeID=60 fell through the `_` catch-all (0 findings); now handled by the 58..=60 arm.
+    ///
+    /// Traces: BC-2.19.029 postconditions 1–2; invariant 2; AC-180-001; EC-003 (BC-2.19.029).
+    #[test]
+    fn test_BC_2_19_029_type_id_60_emits_t1692_001_only() {
+        let asdu = make_asdu(60, false);
+        let mut findings = Vec::new();
+        detect_iec104_threats(&asdu, &mut findings, Direction::ClientToServer, None, None);
+        assert_eq!(
+            findings.len(),
+            1,
+            "TypeID=60 (C_RC_TA_1, timed regulating step) must emit exactly 1 finding — \
+             T1692.001 only (BC-2.19.029 postconditions 1–2; AC-180-001)"
+        );
+        assert!(
+            findings[0]
+                .mitre_techniques
+                .iter()
+                .any(|t| t == "T1692.001"),
+            "TypeID=60 finding must be T1692.001 (BC-2.19.029 postcondition 1)"
+        );
+        assert!(
+            !findings
+                .iter()
+                .any(|f| f.mitre_techniques.iter().any(|t| t == "T0836")),
+            "TypeID=60 must NOT emit T0836 (BC-2.19.029 invariant 2; AC-180-002)"
+        );
+    }
+
+    /// BC-2.19.029 postcondition 1 sub-check: TypeID=58 finding has Verdict::Possible,
+    /// Confidence::Medium, ThreatCategory::Impact — parity with untimed arm 45–47.
+    ///
+    /// At the RED gate, TypeID=58 fell through the `_` catch-all (0 findings); now handled by the 58..=60 arm.
+    ///
+    /// Traces: BC-2.19.029 postcondition 1; invariant 5 (parity with untimed arm); AC-180-001.
+    #[test]
+    fn test_BC_2_19_029_type_id_58_verdict_confidence_category() {
+        let asdu = make_asdu(58, false);
+        let mut findings = Vec::new();
+        detect_iec104_threats(&asdu, &mut findings, Direction::ClientToServer, None, None);
+        let f = findings
+            .first()
+            .expect("TypeID=58 must emit at least one finding (BC-2.19.029 postcondition 1)");
+        assert_eq!(
+            f.verdict,
+            Verdict::Possible,
+            "TypeID=58 T1692.001 finding must have Verdict::Possible \
+             (BC-2.19.029 postcondition 1)"
+        );
+        assert_eq!(
+            f.confidence,
+            Confidence::Medium,
+            "TypeID=58 T1692.001 finding must have Confidence::Medium \
+             (BC-2.19.029 postcondition 1)"
+        );
+        assert_eq!(
+            f.category,
+            ThreatCategory::Impact,
+            "TypeID=58 T1692.001 finding must have ThreatCategory::Impact \
+             (BC-2.19.029 postcondition 1; ICS command message)"
+        );
+    }
+
+    /// BC-2.19.029 canonical vector row 1: TypeID=58, CASDU=1, first_ioa=Some(100) →
+    /// evidence includes the descriptive element
+    /// "time-tagged switching control command (C_SC_TA/C_DC_TA/C_RC_TA)", "CASDU=1",
+    /// and "first_ioa=100".
+    ///
+    /// F-180-P3-001: strengthened to assert the BC-canonical descriptive evidence element so
+    /// that a regression mangling that element would be caught.
+    ///
+    /// At the RED gate, TypeID=58 fell through the `_` catch-all (0 findings); now handled by the 58..=60 arm.
+    ///
+    /// Traces: BC-2.19.029 postcondition 3; AC-180-001; canonical vector row 1; F-180-P3-001.
+    #[test]
+    fn test_BC_2_19_029_casdu_first_ioa_evidence() {
+        let asdu = make_asdu_full(58, false, 1, Some(100), 1);
+        let mut findings = Vec::new();
+        detect_iec104_threats(&asdu, &mut findings, Direction::ClientToServer, None, None);
+        assert!(
+            !findings.is_empty(),
+            "TypeID=58 must emit a finding (BC-2.19.029 postcondition 1; \
+             precondition for evidence check)"
+        );
+        let f = &findings[0];
+        assert!(
+            f.evidence
+                .iter()
+                .any(|e| e
+                    .contains("time-tagged switching control command (C_SC_TA/C_DC_TA/C_RC_TA)")),
+            "TypeID=58: finding evidence must contain the descriptive element \
+             \"time-tagged switching control command (C_SC_TA/C_DC_TA/C_RC_TA)\" \
+             (BC-2.19.029 canonical vector row 1; F-180-P3-001)"
+        );
+        assert!(
+            f.evidence.iter().any(|e| e.contains("CASDU=1")),
+            "TypeID=58, CASDU=1: finding evidence must contain \"CASDU=1\" \
+             (BC-2.19.029 postcondition 3; canonical vector row 1)"
+        );
+        assert!(
+            f.evidence.iter().any(|e| e.contains("first_ioa=100")),
+            "TypeID=58, first_ioa=Some(100): finding evidence must contain \"first_ioa=100\" \
+             (BC-2.19.029 postcondition 3; canonical vector row 1)"
+        );
+    }
+
+    /// BC-2.19.029 canonical vector row 2: TypeID=59, CASDU=200, first_ioa=None →
+    /// evidence includes "CASDU=200" but no "first_ioa=" entry.
+    ///
+    /// first_ioa is conditionally included (only when Some). None → omitted entirely.
+    /// At the RED gate, TypeID=59 fell through the `_` catch-all (0 findings); now handled by the 58..=60 arm.
+    ///
+    /// Traces: BC-2.19.029 postcondition 3; AC-180-001; canonical vector row 2;
+    ///         EC-008 analog (STORY-180 EC-008 specifies TypeID=58; the conditional
+    ///         first_ioa-omission property is TypeID-independent within the 58..=60 arm —
+    ///         TypeID=59 exercised here).
+    #[test]
+    fn test_BC_2_19_029_type_id_59_first_ioa_none_no_first_ioa_evidence() {
+        let asdu = make_asdu_full(59, false, 200, None, 1);
+        let mut findings = Vec::new();
+        detect_iec104_threats(&asdu, &mut findings, Direction::ClientToServer, None, None);
+        assert!(
+            !findings.is_empty(),
+            "TypeID=59 must emit a finding (BC-2.19.029 postcondition 1)"
+        );
+        let f = &findings[0];
+        assert!(
+            f.evidence.iter().any(|e| e.contains("CASDU=200")),
+            "TypeID=59, CASDU=200: evidence must contain \"CASDU=200\" \
+             (BC-2.19.029 postcondition 3; canonical vector row 2)"
+        );
+        assert!(
+            !f.evidence.iter().any(|e| e.contains("first_ioa=")),
+            "TypeID=59, first_ioa=None: evidence must NOT contain a \"first_ioa=\" entry — \
+             conditional inclusion only when first_ioa is Some \
+             (BC-2.19.029 postcondition 3; EC-008 STORY-180)"
+        );
+    }
+
+    // =========================================================================
+    // BC-2.19.029 postcondition 4: Timed summary wording (AC-180-004)
+    // =========================================================================
+
+    /// BC-2.19.029 postcondition 4: TypeID=58 finding summary contains "time-tagged"
+    /// qualifier and names C_SC_TA/C_DC_TA/C_RC_TA mnemonics.
+    ///
+    /// At the RED gate, TypeID=58 fell through the `_` catch-all (0 findings); now handled by the 58..=60 arm.
+    ///
+    /// Traces: BC-2.19.029 postcondition 4; AC-180-004.
+    #[test]
+    fn test_BC_2_19_029_timed_summary_contains_time_tagged_qualifier() {
+        let asdu = make_asdu(58, false);
+        let mut findings = Vec::new();
+        detect_iec104_threats(&asdu, &mut findings, Direction::ClientToServer, None, None);
+        assert!(
+            !findings.is_empty(),
+            "TypeID=58 must emit a finding (BC-2.19.029 postcondition 1; \
+             precondition for summary wording check)"
+        );
+        let summary = &findings[0].summary;
+        assert!(
+            summary.contains("time-tagged"),
+            "TypeID=58 T1692.001 summary must contain \"time-tagged\" qualifier \
+             (BC-2.19.029 postcondition 4; AC-180-004). Actual: {summary:?}"
+        );
+        assert!(
+            summary.contains("C_SC_TA")
+                || summary.contains("C_DC_TA")
+                || summary.contains("C_RC_TA"),
+            "TypeID=58 T1692.001 summary must name timed mnemonics \
+             C_SC_TA/C_DC_TA/C_RC_TA (BC-2.19.029 postcondition 4; AC-180-004). \
+             Actual: {summary:?}"
+        );
+    }
+
+    /// BC-2.19.029 postcondition 4: TypeID=58 (timed) summary differs from TypeID=45
+    /// (untimed twin) summary — analysts must distinguish timed from untimed in output.
+    ///
+    /// At the RED gate, the TypeID=58 assertion was RED (catch-all fallthrough, 0 findings); TypeID=45 assertion was GREEN throughout.
+    ///
+    /// Traces: BC-2.19.029 postcondition 4; AC-180-004.
+    #[test]
+    fn test_BC_2_19_029_timed_summary_differs_from_untimed_twin() {
+        let asdu_untimed = make_asdu(45, false);
+        let mut findings_untimed = Vec::new();
+        detect_iec104_threats(
+            &asdu_untimed,
+            &mut findings_untimed,
+            Direction::ClientToServer,
+            None,
+            None,
+        );
+        assert!(
+            !findings_untimed.is_empty(),
+            "TypeID=45 (untimed twin) must emit a finding (BC-2.19.019 — regression guard)"
+        );
+
+        let asdu_timed = make_asdu(58, false);
+        let mut findings_timed = Vec::new();
+        detect_iec104_threats(
+            &asdu_timed,
+            &mut findings_timed,
+            Direction::ClientToServer,
+            None,
+            None,
+        );
+        assert!(
+            !findings_timed.is_empty(),
+            "TypeID=58 (timed) must emit a finding (BC-2.19.029 postcondition 1; AC-180-001)"
+        );
+
+        assert_ne!(
+            findings_timed[0].summary, findings_untimed[0].summary,
+            "TypeID=58 (timed) summary must NOT be identical to TypeID=45 (untimed) summary — \
+             analysts must distinguish timed from untimed findings \
+             (BC-2.19.029 postcondition 4; AC-180-004)"
+        );
+    }
+
+    // =========================================================================
+    // BC-2.19.029 postcondition 6: cot_test=true appends [TEST] suffix (AC-180-005)
+    // =========================================================================
+
+    /// BC-2.19.029 canonical vector row 3: TypeID=60, cot_test=true → summary ends with
+    /// " [TEST]". Applied by the post-emission loop; no arm-specific wiring needed.
+    ///
+    /// At the RED gate, TypeID=60 fell through the `_` catch-all (0 findings); now handled by the 58..=60 arm.
+    ///
+    /// Traces: BC-2.19.029 postcondition 6; BC-2.19.017 invariant 1; AC-180-005;
+    ///         EC-007 (BC-2.19.029); EC-009 (STORY-180).
+    #[test]
+    fn test_BC_2_19_029_type_id_60_cot_test_suffix() {
+        let asdu = make_asdu(60, true);
+        let mut findings = Vec::new();
+        detect_iec104_threats(&asdu, &mut findings, Direction::ClientToServer, None, None);
+        assert!(
+            !findings.is_empty(),
+            "TypeID=60 must emit a finding (BC-2.19.029 postcondition 1; \
+             precondition for [TEST] suffix check)"
+        );
+        for f in &findings {
+            assert!(
+                f.summary.ends_with(" [TEST]"),
+                "TypeID=60 with cot_test=true: finding summary must end with \" [TEST]\" \
+                 (BC-2.19.029 postcondition 6; BC-2.19.017 invariant 1; AC-180-005). \
+                 Actual: {:?}",
+                f.summary
+            );
+        }
+    }
+
+    // =========================================================================
+    // BC-2.19.029 postcondition 5 / invariant 3: count-independent emission (AC-180-008)
+    // =========================================================================
+
+    /// BC-2.19.029 invariant 3: TypeID=58, count=0 → finding still emitted.
+    ///
+    /// Emission is per-ASDU frame; the VSQ object count is not consulted.
+    /// At the RED gate, TypeID=58 fell through the `_` catch-all (0 findings); now handled by the 58..=60 arm.
+    ///
+    /// Traces: BC-2.19.029 postcondition 5; invariant 3; AC-180-008;
+    ///         EC-006 (BC-2.19.029); EC-011 (STORY-180).
+    #[test]
+    fn test_BC_2_19_029_type_id_58_count_zero_still_emits() {
+        let asdu = make_asdu_full(58, false, 1, None, 0);
+        let mut findings = Vec::new();
+        detect_iec104_threats(&asdu, &mut findings, Direction::ClientToServer, None, None);
+        assert_eq!(
+            findings.len(),
+            1,
+            "TypeID=58 with count=0 must still emit 1 finding — emission is count-independent \
+             per ASDU frame (BC-2.19.029 postcondition 5; invariant 3; AC-180-008; EC-011)"
+        );
+    }
+
+    // =========================================================================
+    // BC-2.19.030: Time-Tagged Set-Point + Bitstring Commands (TypeIDs 61–64)
+    // Emit exactly 2 findings: T1692.001 Possible + T0836 Possible.
+    // AC-180-003
+    // =========================================================================
+
+    /// BC-2.19.030 canonical vector row 1: TypeID=61 (C_SE_TA_1, timed set-point normalized)
+    /// → exactly 2 findings: T1692.001 Possible + T0836 Possible.
+    ///
+    /// At the RED gate, TypeID=61 fell through the `_` catch-all (0 findings); now handled by the 61..=64 arm.
+    ///
+    /// Traces: BC-2.19.030 postconditions 1–2; invariant 1; AC-180-003; EC-001 (BC-2.19.030).
+    #[test]
+    fn test_BC_2_19_030_type_id_61_emits_two_findings() {
+        let asdu = make_asdu(61, false);
+        let mut findings = Vec::new();
+        detect_iec104_threats(&asdu, &mut findings, Direction::ClientToServer, None, None);
+        assert_eq!(
+            findings.len(),
+            2,
+            "TypeID=61 (C_SE_TA_1) must emit exactly 2 findings: T1692.001 + T0836 \
+             (BC-2.19.030 postconditions 1–2; invariant 1; AC-180-003)"
+        );
+        assert!(
+            findings
+                .iter()
+                .any(|f| f.mitre_techniques.iter().any(|t| t == "T1692.001")),
+            "TypeID=61 must emit T1692.001 (BC-2.19.030 postcondition 1; AC-180-003)"
+        );
+        assert!(
+            findings
+                .iter()
+                .any(|f| f.mitre_techniques.iter().any(|t| t == "T0836")),
+            "TypeID=61 must emit T0836 (BC-2.19.030 postcondition 2; AC-180-003)"
+        );
+    }
+
+    /// BC-2.19.030: TypeID=62 (C_SE_TB_1, timed set-point scaled) → exactly 2 findings.
+    ///
+    /// At the RED gate, TypeID=62 fell through the `_` catch-all (0 findings); now handled by the 61..=64 arm.
+    ///
+    /// Traces: BC-2.19.030 postconditions 1–2; invariant 1; AC-180-003; EC-002 (BC-2.19.030).
+    #[test]
+    fn test_BC_2_19_030_type_id_62_emits_two_findings() {
+        let asdu = make_asdu(62, false);
+        let mut findings = Vec::new();
+        detect_iec104_threats(&asdu, &mut findings, Direction::ClientToServer, None, None);
+        assert_eq!(
+            findings.len(),
+            2,
+            "TypeID=62 (C_SE_TB_1, timed set-point scaled) must emit exactly 2 findings: \
+             T1692.001 + T0836 (BC-2.19.030 postconditions 1–2; AC-180-003)"
+        );
+        assert!(
+            findings
+                .iter()
+                .any(|f| f.mitre_techniques.iter().any(|t| t == "T1692.001")),
+            "TypeID=62 must emit T1692.001 (BC-2.19.030 postcondition 1)"
+        );
+        assert!(
+            findings
+                .iter()
+                .any(|f| f.mitre_techniques.iter().any(|t| t == "T0836")),
+            "TypeID=62 must emit T0836 (BC-2.19.030 postcondition 2)"
+        );
+    }
+
+    /// BC-2.19.030: TypeID=63 (C_SE_TC_1, timed set-point short float) → exactly 2 findings.
+    ///
+    /// At the RED gate, TypeID=63 fell through the `_` catch-all (0 findings); now handled by the 61..=64 arm.
+    ///
+    /// Traces: BC-2.19.030 postconditions 1–2; invariant 1; AC-180-003; EC-003 (BC-2.19.030).
+    #[test]
+    fn test_BC_2_19_030_type_id_63_emits_two_findings() {
+        let asdu = make_asdu(63, false);
+        let mut findings = Vec::new();
+        detect_iec104_threats(&asdu, &mut findings, Direction::ClientToServer, None, None);
+        assert_eq!(
+            findings.len(),
+            2,
+            "TypeID=63 (C_SE_TC_1, timed set-point short float) must emit exactly 2 findings: \
+             T1692.001 + T0836 (BC-2.19.030 postconditions 1–2; AC-180-003)"
+        );
+        assert!(
+            findings
+                .iter()
+                .any(|f| f.mitre_techniques.iter().any(|t| t == "T1692.001")),
+            "TypeID=63 must emit T1692.001 (BC-2.19.030 postcondition 1)"
+        );
+        assert!(
+            findings
+                .iter()
+                .any(|f| f.mitre_techniques.iter().any(|t| t == "T0836")),
+            "TypeID=63 must emit T0836 (BC-2.19.030 postcondition 2)"
+        );
+    }
+
+    /// BC-2.19.030: TypeID=64 (C_BO_TA_1, timed bitstring of 32 bits) → exactly 2 findings.
+    ///
+    /// At the RED gate, TypeID=64 fell through the `_` catch-all (0 findings); now handled by the 61..=64 arm.
+    ///
+    /// Traces: BC-2.19.030 postconditions 1–2; invariants 1–2; AC-180-003;
+    ///         EC-004 (BC-2.19.030); EC-005 (STORY-180).
+    #[test]
+    fn test_BC_2_19_030_type_id_64_emits_two_findings() {
+        let asdu = make_asdu(64, false);
+        let mut findings = Vec::new();
+        detect_iec104_threats(&asdu, &mut findings, Direction::ClientToServer, None, None);
+        assert_eq!(
+            findings.len(),
+            2,
+            "TypeID=64 (C_BO_TA_1, timed bitstring) must emit exactly 2 findings: \
+             T1692.001 + T0836 (BC-2.19.030 postconditions 1–2; invariant 2; AC-180-003)"
+        );
+        assert!(
+            findings
+                .iter()
+                .any(|f| f.mitre_techniques.iter().any(|t| t == "T1692.001")),
+            "TypeID=64 must emit T1692.001 (BC-2.19.030 postcondition 1)"
+        );
+        assert!(
+            findings
+                .iter()
+                .any(|f| f.mitre_techniques.iter().any(|t| t == "T0836")),
+            "TypeID=64 must emit T0836 (BC-2.19.030 postcondition 2)"
+        );
+    }
+
+    /// BC-2.19.030 postconditions 1–2 sub-check: TypeID=61 — both findings have
+    /// Verdict::Possible, Confidence::Medium, ThreatCategory::Impact.
+    ///
+    /// At the RED gate, TypeID=61 fell through the `_` catch-all (0 findings); now handled by the 61..=64 arm.
+    ///
+    /// Traces: BC-2.19.030 postconditions 1–2; invariant 5 (parity with untimed arm); AC-180-003.
+    #[test]
+    fn test_BC_2_19_030_type_id_61_verdict_confidence_category_both_findings() {
+        let asdu = make_asdu(61, false);
+        let mut findings = Vec::new();
+        detect_iec104_threats(&asdu, &mut findings, Direction::ClientToServer, None, None);
+        assert_eq!(
+            findings.len(),
+            2,
+            "TypeID=61 must emit 2 findings (precondition for verdict/category check)"
+        );
+        for f in &findings {
+            assert_eq!(
+                f.verdict,
+                Verdict::Possible,
+                "TypeID=61 finding (technique={:?}) must have Verdict::Possible \
+                 (BC-2.19.030 postconditions 1–2)",
+                f.mitre_techniques
+            );
+            assert_eq!(
+                f.confidence,
+                Confidence::Medium,
+                "TypeID=61 finding (technique={:?}) must have Confidence::Medium \
+                 (BC-2.19.030 postconditions 1–2)",
+                f.mitre_techniques
+            );
+            assert_eq!(
+                f.category,
+                ThreatCategory::Impact,
+                "TypeID=61 finding (technique={:?}) must have ThreatCategory::Impact \
+                 (BC-2.19.030 postconditions 1–2)",
+                f.mitre_techniques
+            );
+        }
+    }
+
+    /// BC-2.19.030 postcondition 3 / canonical vector row 1: TypeID=61, CASDU=1,
+    /// first_ioa=Some(200) → BOTH findings' evidence include "CASDU=1" and "first_ioa=200".
+    /// Additionally asserts the BC-canonical descriptive elements per finding:
+    ///   ev1 (T1692.001): "time-tagged set-point/bitstring write command (C_SE_TA/...)"
+    ///   ev2 (T0836):     "parameter modification (C_SE_TA/C_SE_TB/C_SE_TC/C_BO_TA)"
+    ///
+    /// F-180-P3-001: strengthened to assert per-finding descriptive evidence elements so that
+    /// a regression mangling either element would be caught.
+    ///
+    /// At the RED gate, TypeID=61 fell through the `_` catch-all (0 findings); now handled by the 61..=64 arm.
+    ///
+    /// Traces: BC-2.19.030 postconditions 1–3; AC-180-003; canonical vector row 1; F-180-P3-001.
+    #[test]
+    fn test_BC_2_19_030_type_id_61_casdu_first_ioa_evidence_both_findings() {
+        let asdu = make_asdu_full(61, false, 1, Some(200), 1);
+        let mut findings = Vec::new();
+        detect_iec104_threats(&asdu, &mut findings, Direction::ClientToServer, None, None);
+        assert_eq!(
+            findings.len(),
+            2,
+            "TypeID=61 must emit 2 findings (BC-2.19.030 postconditions 1–2)"
+        );
+        for f in &findings {
+            assert!(
+                f.evidence.iter().any(|e| e.contains("CASDU=1")),
+                "TypeID=61 finding (technique={:?}) evidence must include \"CASDU=1\" \
+                 (BC-2.19.030 postcondition 3; canonical vector row 1)",
+                f.mitre_techniques
+            );
+            assert!(
+                f.evidence.iter().any(|e| e.contains("first_ioa=200")),
+                "TypeID=61, first_ioa=Some(200): finding (technique={:?}) evidence must include \
+                 \"first_ioa=200\" (BC-2.19.030 postcondition 3; canonical vector row 1)",
+                f.mitre_techniques
+            );
+        }
+        // F-180-P3-001: assert the BC-canonical descriptive element for ev1 (T1692.001) and
+        // ev2 (T0836) individually — a loop over both findings cannot distinguish them because
+        // their descriptive strings differ.
+        let ev1 = findings
+            .iter()
+            .find(|f| f.mitre_techniques.iter().any(|t| t == "T1692.001"))
+            .expect("T1692.001 finding must be present (BC-2.19.030 postcondition 1)");
+        assert!(
+            ev1.evidence.iter().any(|e| e.contains(
+                "time-tagged set-point/bitstring write command \
+                                      (C_SE_TA/C_SE_TB/C_SE_TC/C_BO_TA)"
+            )),
+            "T1692.001 finding evidence must contain the descriptive element \
+             \"time-tagged set-point/bitstring write command \
+             (C_SE_TA/C_SE_TB/C_SE_TC/C_BO_TA)\" \
+             (BC-2.19.030 postcondition 1; F-180-P3-001)"
+        );
+        let ev2 = findings
+            .iter()
+            .find(|f| f.mitre_techniques.iter().any(|t| t == "T0836"))
+            .expect("T0836 finding must be present (BC-2.19.030 postcondition 2)");
+        assert!(
+            ev2.evidence
+                .iter()
+                .any(|e| e.contains("parameter modification (C_SE_TA/C_SE_TB/C_SE_TC/C_BO_TA)")),
+            "T0836 finding evidence must contain the descriptive element \
+             \"parameter modification (C_SE_TA/C_SE_TB/C_SE_TC/C_BO_TA)\" \
+             (BC-2.19.030 postcondition 2; F-180-P3-001)"
+        );
+    }
+
+    /// BC-2.19.030 postcondition 3 / canonical vector row 2: TypeID=62, CASDU=100,
+    /// first_ioa=None → both findings include "CASDU=100"; neither has "first_ioa=".
+    ///
+    /// At the RED gate, TypeID=62 fell through the `_` catch-all (0 findings); now handled by the 61..=64 arm.
+    ///
+    /// Traces: BC-2.19.030 postcondition 3; AC-180-003; canonical vector row 2.
+    #[test]
+    fn test_BC_2_19_030_type_id_62_first_ioa_none_no_first_ioa_evidence() {
+        let asdu = make_asdu_full(62, false, 100, None, 1);
+        let mut findings = Vec::new();
+        detect_iec104_threats(&asdu, &mut findings, Direction::ClientToServer, None, None);
+        assert_eq!(
+            findings.len(),
+            2,
+            "TypeID=62 must emit 2 findings (BC-2.19.030 postconditions 1–2)"
+        );
+        for f in &findings {
+            assert!(
+                f.evidence.iter().any(|e| e.contains("CASDU=100")),
+                "TypeID=62 finding (technique={:?}) evidence must include \"CASDU=100\" \
+                 (BC-2.19.030 postcondition 3; canonical vector row 2)",
+                f.mitre_techniques
+            );
+            assert!(
+                !f.evidence.iter().any(|e| e.contains("first_ioa=")),
+                "TypeID=62, first_ioa=None: finding (technique={:?}) evidence must NOT include \
+                 a \"first_ioa=\" entry — conditional inclusion only when Some \
+                 (BC-2.19.030 postcondition 3)",
+                f.mitre_techniques
+            );
+        }
+    }
+
+    // =========================================================================
+    // BC-2.19.030 postconditions 4–5: Timed summary wording (AC-180-004)
+    // =========================================================================
+
+    /// BC-2.19.030 postconditions 4–5: TypeID=61 — BOTH findings' summaries contain
+    /// "time-tagged" qualifier and C_SE_TA/C_SE_TB/C_SE_TC/C_BO_TA mnemonics.
+    ///
+    /// At the RED gate, TypeID=61 fell through the `_` catch-all (0 findings); now handled by the 61..=64 arm.
+    ///
+    /// Traces: BC-2.19.030 postconditions 4–5; AC-180-004.
+    #[test]
+    fn test_BC_2_19_030_timed_summaries_contain_time_tagged_and_mnemonics() {
+        let asdu = make_asdu(61, false);
+        let mut findings = Vec::new();
+        detect_iec104_threats(&asdu, &mut findings, Direction::ClientToServer, None, None);
+        assert_eq!(
+            findings.len(),
+            2,
+            "TypeID=61 must emit 2 findings (precondition for summary wording check)"
+        );
+        for f in &findings {
+            assert!(
+                f.summary.contains("time-tagged"),
+                "TypeID=61 finding (technique={:?}) summary must contain \"time-tagged\" \
+                 (BC-2.19.030 postconditions 4–5; AC-180-004). Actual: {:?}",
+                f.mitre_techniques,
+                f.summary
+            );
+            assert!(
+                f.summary.contains("C_SE_TA")
+                    || f.summary.contains("C_SE_TB")
+                    || f.summary.contains("C_SE_TC")
+                    || f.summary.contains("C_BO_TA"),
+                "TypeID=61 finding (technique={:?}) summary must name timed mnemonics \
+                 C_SE_TA/C_SE_TB/C_SE_TC/C_BO_TA (BC-2.19.030 postconditions 4–5; AC-180-004). \
+                 Actual: {:?}",
+                f.mitre_techniques,
+                f.summary
+            );
+        }
+    }
+
+    /// BC-2.19.030: Timed summaries (TypeID=61) differ from untimed twin summaries (TypeID=48).
+    ///
+    /// At the RED gate, the TypeID=61 assertions were RED (catch-all fallthrough, 0 findings); TypeID=48 regression check was GREEN throughout.
+    ///
+    /// Traces: BC-2.19.030 postconditions 4–5; AC-180-004.
+    #[test]
+    fn test_BC_2_19_030_timed_summaries_differ_from_untimed_twin() {
+        let asdu_untimed = make_asdu(48, false);
+        let mut findings_untimed = Vec::new();
+        detect_iec104_threats(
+            &asdu_untimed,
+            &mut findings_untimed,
+            Direction::ClientToServer,
+            None,
+            None,
+        );
+        assert_eq!(
+            findings_untimed.len(),
+            2,
+            "TypeID=48 (untimed twin) must still emit 2 findings (BC-2.19.019 — regression guard)"
+        );
+
+        let asdu_timed = make_asdu(61, false);
+        let mut findings_timed = Vec::new();
+        detect_iec104_threats(
+            &asdu_timed,
+            &mut findings_timed,
+            Direction::ClientToServer,
+            None,
+            None,
+        );
+        assert_eq!(
+            findings_timed.len(),
+            2,
+            "TypeID=61 (timed) must emit 2 findings (BC-2.19.030 postconditions 1–2; AC-180-003)"
+        );
+
+        let t1692_untimed = findings_untimed
+            .iter()
+            .find(|f| f.mitre_techniques.iter().any(|t| t == "T1692.001"))
+            .expect("TypeID=48 must have a T1692.001 finding (BC-2.19.019)");
+        let t1692_timed = findings_timed
+            .iter()
+            .find(|f| f.mitre_techniques.iter().any(|t| t == "T1692.001"))
+            .expect("TypeID=61 must have a T1692.001 finding (BC-2.19.030)");
+        assert_ne!(
+            t1692_timed.summary, t1692_untimed.summary,
+            "TypeID=61 T1692.001 summary must differ from TypeID=48 T1692.001 summary — \
+             analysts must distinguish timed from untimed \
+             (BC-2.19.030 postcondition 4; AC-180-004)"
+        );
+
+        let t0836_untimed = findings_untimed
+            .iter()
+            .find(|f| f.mitre_techniques.iter().any(|t| t == "T0836"))
+            .expect("TypeID=48 must have a T0836 finding (BC-2.19.019)");
+        let t0836_timed = findings_timed
+            .iter()
+            .find(|f| f.mitre_techniques.iter().any(|t| t == "T0836"))
+            .expect("TypeID=61 must have a T0836 finding (BC-2.19.030)");
+        assert_ne!(
+            t0836_timed.summary, t0836_untimed.summary,
+            "TypeID=61 T0836 summary must differ from TypeID=48 T0836 summary — \
+             analysts must distinguish timed from untimed \
+             (BC-2.19.030 postcondition 5; AC-180-004)"
+        );
+    }
+
+    // =========================================================================
+    // BC-2.19.030 postcondition 7: cot_test=true tags BOTH findings (AC-180-005)
+    // =========================================================================
+
+    /// BC-2.19.030 canonical vector row 3: TypeID=64, cot_test=true, first_ioa=Some(1) →
+    /// BOTH findings' summaries end with " [TEST]".
+    ///
+    /// At the RED gate, TypeID=64 fell through the `_` catch-all (0 findings); now handled by the 61..=64 arm.
+    ///
+    /// Traces: BC-2.19.030 postcondition 7; BC-2.19.017 invariant 1; AC-180-005;
+    ///         EC-008 (BC-2.19.030); EC-010 (STORY-180).
+    #[test]
+    fn test_BC_2_19_030_type_id_64_cot_test_both_findings_tagged() {
+        let asdu = make_asdu_full(64, true, 1, Some(1), 1);
+        let mut findings = Vec::new();
+        detect_iec104_threats(&asdu, &mut findings, Direction::ClientToServer, None, None);
+        assert_eq!(
+            findings.len(),
+            2,
+            "TypeID=64 with cot_test=true must emit exactly 2 findings — \
+             precondition for [TEST] tagging check \
+             (BC-2.19.030 postconditions 1–2)"
+        );
+        for f in &findings {
+            assert!(
+                f.summary.ends_with(" [TEST]"),
+                "TypeID=64 with cot_test=true: finding (technique={:?}) summary must end with \
+                 \" [TEST]\" (BC-2.19.030 postcondition 7; BC-2.19.017 invariant 1; AC-180-005). \
+                 Actual: {:?}",
+                f.mitre_techniques,
+                f.summary
+            );
+        }
+    }
+
+    // =========================================================================
+    // BC-2.19.030 postcondition 6 / invariant 3: count-independent emission (AC-180-008)
+    // =========================================================================
+
+    /// BC-2.19.030 invariant 3: TypeID=61, count=0 → both findings still emitted.
+    ///
+    /// Emission is per-ASDU frame; the VSQ object count is not consulted.
+    /// At the RED gate, TypeID=61 fell through the `_` catch-all (0 findings); now handled by the 61..=64 arm.
+    ///
+    /// Traces: BC-2.19.030 postcondition 6; invariant 3; AC-180-008; EC-007 (BC-2.19.030).
+    #[test]
+    fn test_BC_2_19_030_type_id_61_count_zero_still_emits_two_findings() {
+        let asdu = make_asdu_full(61, false, 1, None, 0);
+        let mut findings = Vec::new();
+        detect_iec104_threats(&asdu, &mut findings, Direction::ClientToServer, None, None);
+        assert_eq!(
+            findings.len(),
+            2,
+            "TypeID=61 with count=0 must still emit 2 findings — emission is count-independent \
+             per ASDU frame (BC-2.19.030 postcondition 6; invariant 3; AC-180-008)"
+        );
+    }
+
+    // =========================================================================
+    // BC-2.19.022 v1.1 Regression Guard — TypeIDs 52–57 and 65–99 stay silent
+    // AC-180-006
+    // =========================================================================
+
+    /// BC-2.19.022 v1.1 invariant 1: TypeID=52 (RESERVED, in {52–57} silent range) →
+    /// no finding. Expected GREEN.
+    ///
+    /// TypeID=52 was silently logged under the old 52–99 range and remains silently logged
+    /// under BC-2.19.022 v1.1's narrowed {52–57, 65–99} range.
+    ///
+    /// Traces: BC-2.19.022 v1.1 invariant 1; BC-2.19.029 invariant 6; AC-180-006;
+    ///         EC-006 (STORY-180).
+    #[test]
+    fn test_BC_2_19_022_v1_1_type_id_52_no_finding() {
+        let asdu = make_asdu(52, false);
+        let mut findings = Vec::new();
+        detect_iec104_threats(&asdu, &mut findings, Direction::ClientToServer, None, None);
+        assert!(
+            findings.is_empty(),
+            "TypeID=52 (RESERVED, {{52-57}} silent range per BC-2.19.022 v1.1) must produce \
+             no finding (BC-2.19.022 v1.1 invariant 1; AC-180-006)"
+        );
+    }
+
+    /// BC-2.19.022 v1.1 invariant 1: TypeID=57 (RESERVED, upper neighbor below 58..=60 arm) →
+    /// no finding. Expected GREEN.
+    ///
+    /// TypeID=57 is the immediate predecessor of the new timed switching arm (58..=60).
+    /// It must remain silently logged per BC-2.19.029 invariant 6.
+    ///
+    /// Traces: BC-2.19.022 v1.1 invariant 1; BC-2.19.029 invariant 6; AC-180-006;
+    ///         EC-004 (BC-2.19.029); EC-006 (STORY-180).
+    #[test]
+    fn test_BC_2_19_022_v1_1_type_id_57_no_finding() {
+        let asdu = make_asdu(57, false);
+        let mut findings = Vec::new();
+        detect_iec104_threats(&asdu, &mut findings, Direction::ClientToServer, None, None);
+        assert!(
+            findings.is_empty(),
+            "TypeID=57 (RESERVED, upper neighbor below timed switching arm 58..=60) must produce \
+             no finding (BC-2.19.022 v1.1 invariant 1; BC-2.19.029 invariant 6; AC-180-006)"
+        );
+    }
+
+    /// BC-2.19.022 v1.1 invariant 1: TypeID=65 (unhandled, lower neighbor above 61..=64 arm) →
+    /// no finding. Expected GREEN.
+    ///
+    /// TypeID=65 is the immediate successor of the new timed set-point arm (61..=64).
+    /// It must remain silently logged per BC-2.19.030 invariant 6.
+    ///
+    /// Traces: BC-2.19.022 v1.1 invariant 1; BC-2.19.030 invariant 6; AC-180-006;
+    ///         EC-006 (BC-2.19.030); EC-007 (STORY-180).
+    #[test]
+    fn test_BC_2_19_022_v1_1_type_id_65_no_finding() {
+        let asdu = make_asdu(65, false);
+        let mut findings = Vec::new();
+        detect_iec104_threats(&asdu, &mut findings, Direction::ClientToServer, None, None);
+        assert!(
+            findings.is_empty(),
+            "TypeID=65 (unhandled, lower neighbor above timed set-point arm 61..=64) must produce \
+             no finding (BC-2.19.022 v1.1 invariant 1; BC-2.19.030 invariant 6; AC-180-006)"
+        );
+    }
+
+    /// BC-2.19.022 v1.1 invariant 1: TypeID=99 (unhandled, in {65–99} silent range) →
+    /// no finding. Expected GREEN.
+    ///
+    /// Traces: BC-2.19.022 v1.1 invariant 1; BC-2.19.030 invariant 6; AC-180-006;
+    ///         EC-008 (BC-2.19.022).
+    #[test]
+    fn test_BC_2_19_022_v1_1_type_id_99_no_finding() {
+        let asdu = make_asdu(99, false);
+        let mut findings = Vec::new();
+        detect_iec104_threats(&asdu, &mut findings, Direction::ClientToServer, None, None);
+        assert!(
+            findings.is_empty(),
+            "TypeID=99 (unhandled, in {{65-99}} silent range per BC-2.19.022 v1.1) must produce \
+             no finding (BC-2.19.022 v1.1 invariant 1; AC-180-006)"
+        );
+    }
+
+    // =========================================================================
+    // BC-2.19.019 untimed twin regression guards (EC-012/013 from STORY-180)
+    // Expected GREEN: existing arms are unchanged by STORY-180.
+    // =========================================================================
+
+    /// EC-012 (STORY-180): TypeID=45 (C_SC_NA_1, untimed twin of 58-60) still emits
+    /// exactly 1 finding (T1692.001 only) after STORY-180 arms are added.
+    /// Expected GREEN.
+    ///
+    /// Traces: BC-2.19.019 postcondition 1; EC-012 (STORY-180); AC-180-006 regression guard.
+    #[test]
+    fn test_BC_2_19_019_v1_1_regression_type_id_45_still_one_finding() {
+        let asdu = make_asdu(45, false);
+        let mut findings = Vec::new();
+        detect_iec104_threats(&asdu, &mut findings, Direction::ClientToServer, None, None);
+        assert_eq!(
+            findings.len(),
+            1,
+            "TypeID=45 (untimed twin C_SC_NA_1) must still emit exactly 1 finding after \
+             STORY-180 arms are added — regression guard \
+             (BC-2.19.019 postcondition 1; EC-012 STORY-180)"
+        );
+        assert!(
+            findings[0]
+                .mitre_techniques
+                .iter()
+                .any(|t| t == "T1692.001"),
+            "TypeID=45 regression guard: sole finding must be T1692.001 (BC-2.19.019)"
+        );
+    }
+
+    /// EC-013 (STORY-180): TypeID=51 (C_BO_NA_1, untimed twin of 61-64) still emits
+    /// exactly 2 findings (T1692.001 + T0836) after STORY-180 arms are added.
+    /// Expected GREEN.
+    ///
+    /// Traces: BC-2.19.019 postconditions 1–2; EC-013 (STORY-180); AC-180-006 regression guard.
+    #[test]
+    fn test_BC_2_19_019_v1_1_regression_type_id_51_still_two_findings() {
+        let asdu = make_asdu(51, false);
+        let mut findings = Vec::new();
+        detect_iec104_threats(&asdu, &mut findings, Direction::ClientToServer, None, None);
+        assert_eq!(
+            findings.len(),
+            2,
+            "TypeID=51 (untimed twin C_BO_NA_1) must still emit exactly 2 findings after \
+             STORY-180 arms are added — regression guard \
+             (BC-2.19.019 postconditions 1–2; EC-013 STORY-180)"
+        );
+        assert!(
+            findings
+                .iter()
+                .any(|f| f.mitre_techniques.iter().any(|t| t == "T1692.001")),
+            "TypeID=51 regression guard: must emit T1692.001 (BC-2.19.019)"
+        );
+        assert!(
+            findings
+                .iter()
+                .any(|f| f.mitre_techniques.iter().any(|t| t == "T0836")),
+            "TypeID=51 regression guard: must emit T0836 (BC-2.19.019)"
         );
     }
 }

--- a/tests/iec104_e2e_real_pcaps_tests.rs
+++ b/tests/iec104_e2e_real_pcaps_tests.rs
@@ -24,7 +24,7 @@
 //! |------|------|-----------------|
 //! | `test_e2e_BC_2_19_iec104_pcap_T0836_T1692_001_interrogation` | `iec104.pcap` (Wireshark Foundation) | T0836 ×24 + T1692.001 ×42 = 66 total; flows_analyzed=1; dropped_findings=0 |
 //! | `test_e2e_BC_2_19_iec104_sq_pcapng_zero_findings_benign_uframes` | `iec104-sq.pcapng` (Wireshark Foundation) | 0 findings (benign STARTDT/TESTFR-only SQ-bit fixture); flows_analyzed=1; dropped_findings=0 |
-//! | `test_e2e_BC_2_19_iec104_iti_diverse_T0836_T1692_001_mixed_asdu` | `iec104-iti-diverse.pcap` (ITI CC-BY-4.0) | T0836 ×10 + T1692.001 ×21 = 31 total; flows_analyzed=1; dropped_findings=0 |
+//! | `test_e2e_BC_2_19_iec104_iti_diverse_T0836_T1692_001_mixed_asdu` | `iec104-iti-diverse.pcap` (ITI CC-BY-4.0) | T0836 ×20 + T1692.001 ×46 = 66 total; flows_analyzed=1; dropped_findings=0 |
 //! | `test_e2e_BC_2_19_iec104_iti_dissect_T0814_T1692_001_control_coverage` | `iec104-iti-dissect.pcap` (ITI CC-BY-4.0) | T0814 ×2 + T1692.001 ×9 = 11 total; flows_analyzed=6; dropped_findings=0 |
 //!
 //! ## Traces
@@ -337,8 +337,17 @@ mod iec104_e2e_real_pcaps {
     //
     // Pcap: IEC-104 traffic with a diverse mix of ASDU Type IDs from the ITI ICS corpus.
     //       173 reader packets; 1 TCP flow on port 2404.
-    // Expected: 31 findings = T0836 ×10 + T1692.001 ×21. All Impact/Possible/Medium.
-    //           flows_analyzed=1, total_findings=31, dropped_findings=0.
+    // Expected: 66 findings = T0836 ×20 + T1692.001 ×46. All Impact/Possible/Medium.
+    //           flows_analyzed=1, total_findings=66, dropped_findings=0.
+    //
+    // Wave-85 change (STORY-180, BC-2.19.029/030): TypeIDs 58–64 (time-tagged control
+    // commands) present in this capture were silently ignored before wave-85. They are now
+    // detected, raising the total from 31 to 66 (+35 findings). The untimed contribution
+    // (31) is unchanged: TypeID=45→5×T1692.001, TypeID=46→6×T1692.001,
+    // TypeID=50→10×T0836+10×T1692.001.
+    // Timed contribution (+35): x=15 timed-switching ASDUs (TypeID=58→5, TypeID=59→10,
+    // each 1 finding → +15×T1692.001); y=10 timed-setpoint ASDUs (TypeID=61→5,
+    // TypeID=63→5, each 2 findings → +10×T1692.001 + +10×T0836); x+2y=35. ✓
     //
     // Traces: BC-2.19 (IEC-104 analyzer pipeline).
     // License: ITI/ICS-Security-Tools CC-BY-4.0. Attribution: ICS Security Tools,
@@ -349,15 +358,23 @@ mod iec104_e2e_real_pcaps {
     ///
     /// iec104-iti-diverse.pcap is from the same ITI ICS Security Tools corpus as the ENIP
     /// fixtures. It contains a diverse ASDU Type ID mix representing realistic IEC-104
-    /// traffic from a SCADA deployment.
+    /// traffic from a SCADA deployment, including time-tagged control commands.
     ///
-    /// Postconditions asserted (ground-truth from analyzer-level validation run):
-    /// - `iec104.all_findings.len()` == 31.
-    /// - T0836 count == 10.
-    /// - T1692.001 count == 21.
+    /// Wave-85 (STORY-180, BC-2.19.029/030): TypeIDs 58–64 (time-tagged control commands)
+    /// present in this capture were silently ignored before wave-85; they are now detected,
+    /// raising the expectation from 31 to 66. The +35 timed findings decompose as:
+    ///   x=15 from timed-switching TypeIDs 58–59 (1 finding each, T1692.001 only)
+    ///   2y=20 from timed-setpoint TypeIDs 61+63 (2 findings each: T1692.001 + T0836)
+    ///   T0836 delta=y=10; T1692.001 delta=x+y=25
+    ///
+    /// Postconditions asserted (ground-truth from wave-85 validation run):
+    /// - `iec104.all_findings.len()` == 66.
+    /// - T0836 count == 20.
+    /// - T1692.001 count == 46.
+    /// - Count of findings whose summary contains "time-tagged" == 35 (= x + 2y).
     /// - Every finding is Impact / Possible / Medium.
     /// - `iec104_summary.flows_analyzed` == 1.
-    /// - `iec104_summary.total_findings` == 31.
+    /// - `iec104_summary.total_findings` == 66.
     /// - `iec104_summary.dropped_findings` == 0.
     ///
     /// Traces: BC-2.19 (IEC-104 analyzer pipeline).
@@ -372,9 +389,10 @@ mod iec104_e2e_real_pcaps {
         // ── Total findings count ──────────────────────────────────────────────
         assert_eq!(
             iec104.all_findings.len(),
-            31,
-            "iec104-iti-diverse.pcap: expected exactly 31 findings \
-             (T0836 ×10 + T1692.001 ×21); got {} findings: {:?}",
+            66,
+            "iec104-iti-diverse.pcap: expected exactly 66 findings \
+             (T0836 ×20 + T1692.001 ×46, incl. 35 time-tagged from wave-85); \
+             got {} findings: {:?}",
             iec104.all_findings.len(),
             iec104
                 .all_findings
@@ -396,12 +414,30 @@ mod iec104_e2e_real_pcaps {
             .count();
 
         assert_eq!(
-            t0836_count, 10,
-            "iec104-iti-diverse.pcap: expected 10 T0836 findings; got {t0836_count}"
+            t0836_count, 20,
+            "iec104-iti-diverse.pcap: expected 20 T0836 findings \
+             (10 untimed from TypeID=50 + 10 timed from TypeIDs 61+63); got {t0836_count}"
         );
         assert_eq!(
-            t1692_001_count, 21,
-            "iec104-iti-diverse.pcap: expected 21 T1692.001 findings; got {t1692_001_count}"
+            t1692_001_count, 46,
+            "iec104-iti-diverse.pcap: expected 46 T1692.001 findings \
+             (21 untimed + 25 timed: x=15 from TypeIDs 58-59, y=10 from TypeIDs 61+63); \
+             got {t1692_001_count}"
+        );
+
+        // ── Time-tagged timed-arm marker (wave-85 STORY-180 guard) ───────────
+        // x=15 timed-switching findings (TypeIDs 58-59) + 2y=20 timed-setpoint findings
+        // (TypeIDs 61+63) = 35 findings whose summary contains "time-tagged".
+        let time_tagged_count = iec104
+            .all_findings
+            .iter()
+            .filter(|f| f.summary.contains("time-tagged"))
+            .count();
+        assert_eq!(
+            time_tagged_count, 35,
+            "iec104-iti-diverse.pcap: expected 35 time-tagged findings (x+2y = 15+20, \
+             TypeIDs 58–59 + 61+63; BC-2.19.029/030 timed-command detection from wave-85); \
+             got {time_tagged_count}"
         );
 
         // ── Category / verdict / confidence — all Impact/Possible/Medium ──────
@@ -438,8 +474,8 @@ mod iec104_e2e_real_pcaps {
         );
         assert_eq!(
             detail["total_findings"],
-            serde_json::json!(31u64),
-            "iec104-iti-diverse.pcap: total_findings must be 31; got {:?}",
+            serde_json::json!(66u64),
+            "iec104-iti-diverse.pcap: total_findings must be 66; got {:?}",
             detail["total_findings"]
         );
         assert_eq!(


### PR DESCRIPTION
## Summary

- **STORY-180 (PR #437):** IEC-104 timed control command detection — TypeIDs 58–64 now emit T1692.001 and T0836 findings, closing the evasion gap (IEC104-TIMED-CMD-GAP-001) where CP56Time2a time-tagged variants of control commands fell silently through the catch-all arm. Two new match arms cover `58..=60` (C_SC_TA_1/C_DC_TA_1/C_RC_TA_1, T1692.001 only) and `61..=64` (C_SE_TA_1/C_SE_TB_1/C_SE_TC_1/C_BO_TA_1, T1692.001 + T0836); catch-all comment narrowed from "52–99" to "{52–57, 65–99}".

- **STORY-181 (PR #438) + gate-fix PR #439:** ENIP `on_data` unsafe split-borrow eliminated (SEC-001, MEDIUM tech-debt carry-forward since PR #334) — raw `*mut EnipFlowState` pointer replaced with safe take-remove-reinsert pattern; compiler enforces disjointness with no convention required. No behavior change; all 2667 tests pass unchanged. PR #439 updated ITI diverse e2e expectations for timed-command detection.

## Wave gate

Wave-85 gate status: **CONVERGED / CLOSED** (D-511). All CI checks green on develop tip (`0ab6f52ee3be21687437d29923fadc903ca70387`).

## CI

Pre-release checks run on `release/0.13.2` (`b33e45f9`):

- `cargo test --all-targets`: **0 failed** across all suites
- `cargo clippy --all-targets -- -D warnings`: **clean**
- `cargo fmt --check`: **clean**
- `cargo build`: compiles at `wirerust v0.13.2`

## Notes

Do NOT merge via the GitHub UI "Squash and merge" button — use a **true merge commit** (`--no-ff`) per the D-491 precedent to preserve branch history on `main`. After merge: tag `v0.13.2` on `main`, create the GitHub Release with 4 binary artifacts (release.yml triggers on tag push), then back-merge `main` into `develop` as a true-merge commit.