### PR TITLE
chore: back-merge v0.13.2 release into develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Version numbers follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.13.2] - 2026-07-25
+
 ### Changed
 
 - **ENIP `on_data` PDU dispatch loop: unsafe `*mut EnipFlowState` split-borrow replaced
@@ -59,8 +61,7 @@ Version numbers follow [Semantic Versioning](https://semver.org/).
   BC-2.19.030 (AC-180-007; BC-2.19.022 v1.1). The existing post-emission `[TEST]` loop
   covers the new arms automatically — no extra wiring required (BC-2.19.017 invariant 1).
 
-  `cargo test --test iec104_analyzer_tests`: 248 passed (221 prior + 27 new story_180
-  tests; 21 flipped red→green at the Green step, 6 regression guards green throughout).
+  `cargo test --test iec104_analyzer_tests`: 248 passed (221 prior + 27 new STORY-180 tests).
 
 ## [0.13.1] - 2026-07-21
 
@@ -1884,7 +1885,8 @@ Downstream consumers of wirerust JSON or CSV output must update for this release
 - Output sanitization in the terminal reporter guards against C1 control bytes
   in packet-derived strings.
 
-[Unreleased]: https://github.com/Zious11/wirerust/compare/v0.13.1...HEAD
+[Unreleased]: https://github.com/Zious11/wirerust/compare/v0.13.2...HEAD
+[0.13.2]: https://github.com/Zious11/wirerust/compare/v0.13.1...v0.13.2
 [0.13.1]: https://github.com/Zious11/wirerust/compare/v0.13.0...v0.13.1
 [0.13.0]: https://github.com/Zious11/wirerust/compare/v0.12.1...v0.13.0
 [0.12.1]: https://github.com/Zious11/wirerust/compare/v0.12.0...v0.12.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1524,7 +1524,7 @@ dependencies = [
 
 [[package]]
 name = "wirerust"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wirerust"
-version = "0.13.1"
+version = "0.13.2"
 edition = "2024"
 rust-version = "1.91"
 description = "Fast PCAP forensics and network triage CLI tool"


### PR DESCRIPTION
## Back-merge: v0.13.2 → develop

This PR merges the `v0.13.2` release branch (`main`) back into `develop` to keep the
two branches in sync after the release.

## CRITICAL — Must be merged as a TRUE MERGE COMMIT

**Do NOT use squash merge or rebase.** This PR must be merged with **Create a merge commit**
so that `main` becomes a proper ancestor of `develop`.

Merging as squash or rebase breaks the git ancestry chain (DRIFT-BACKMERGE-SQUASH-001),
preventing `git merge-base --is-ancestor` from confirming that release commits are
contained in develop.

**Merge method: "Create a merge commit" only.**

## Precedent

D-491 (v0.13.1) back-merge: PR #433 — same pattern, same constraint.

## Commits merged from main

- `9601d711` — Merge pull request #440 from Zious11/release/0.13.2
- `b33e45f9` — chore: release v0.13.2